### PR TITLE
Fix/Check Name List Validity in FitParameterSet

### DIFF
--- a/src/FitParameters/src/FitParameterSet.cpp
+++ b/src/FitParameters/src/FitParameterSet.cpp
@@ -655,7 +655,10 @@ void FitParameterSet::defineParameters(){
         auto parName = JsonUtils::fetchValue<std::string>(parConfig, "parameterName");
         if (not parName.empty()) par.setName(parName);
         par.setParameterDefinitionConfig(parConfig);
-
+        LogWarning << "Parameter #" << par.getParameterIndex()
+                   << " (name \"" << par.getName() << "\")"
+                   << " not defined by covariance matrix file"
+                   << std::endl;
       }
     }
     else if( not _dialSetDefinitions_.empty() ){


### PR DESCRIPTION
The FitParameterSet field _parameterNamesList_ which holds a shared pointer to a TObjArray of strings was being used without checking that it was valid.  This adds validity checks.

The usual use case is that fit parameters will be constrained by a covariance matrix, and the covariance matrix file will also contain a TObjArray defining the parameter names associated with the matrix.  The unusual use case is now checked and handled.

This change is limited to FitParameterSet, and does not change the behavior in the usual use case.