### PR TITLE
Feature: Add least squares as a JointProbability

### DIFF
--- a/src/FitSamples/include/JointProbability.h
+++ b/src/FitSamples/include/JointProbability.h
@@ -57,6 +57,21 @@ namespace JointProbability {
     double eval(const FitSample& sample_, int bin_) override;
   };
 
+  /// Evaluate the Least Squares difference between the expected and observed.
+  /// This is NOT a real LLH function, but is good for debugging since it has
+  /// minimal numeric problems (doesn't use any functions like Log or Sqrt).
+  class LeastSquaresLLH : public JointProbability{
+  protected:
+    void readConfigImpl() override;
+
+  public:
+    double eval(const FitSample& sample_, int bin_) override;
+
+    /// If true the use Poissonian approximation with the variance equal to
+    /// the observed value (i.e. the data).
+    bool lsqPoissonianApproximation{false};
+  };
+
   class BarlowLLH : public JointProbability{
     double eval(const FitSample& sample_, int bin_) override;
   private:

--- a/src/FitSamples/src/FitSampleSet.cpp
+++ b/src/FitSamples/src/FitSampleSet.cpp
@@ -48,6 +48,7 @@ void FitSampleSet::readConfigImpl(){
   else if( llhMethod == "Plugin" ) {                 _jointProbabilityPtr_ = std::make_shared<JointProbability::JointProbabilityPlugin>(); }
   else if( llhMethod == "BarlowLLH_BANFF_OA2020" ) { _jointProbabilityPtr_ = std::make_shared<JointProbability::BarlowLLH_BANFF_OA2020>(); }
   else if( llhMethod == "BarlowLLH_BANFF_OA2021" ) { _jointProbabilityPtr_ = std::make_shared<JointProbability::BarlowLLH_BANFF_OA2021>(); }
+  else if( llhMethod == "LeastSquares" ) { _jointProbabilityPtr_ = std::make_shared<JointProbability::LeastSquaresLLH>(); }
   else{ LogThrow("Unknown LLH Method: " << llhMethod); }
 
   _jointProbabilityPtr_->readConfig(configJointProbability);
@@ -159,5 +160,3 @@ void FitSampleSet::updateSampleHistograms() const {
   GlobalVariables::getParallelWorker().runJob("FitSampleSet::updateSampleHistograms");
   if( _showTimeStats_ ) LogDebug << __METHOD_NAME__ << " took: " << GenericToolbox::getElapsedTimeSinceLastCallStr(__METHOD_NAME__) << std::endl;
 }
-
-

--- a/src/FitSamples/src/JointProbability.cpp
+++ b/src/FitSamples/src/JointProbability.cpp
@@ -257,6 +257,21 @@ namespace JointProbability{
     return 2.0 * (predVal - dataVal + dataVal * TMath::Log(dataVal / predVal));
   }
 
+  // LeastSquaresLLH
+  void LeastSquaresLLH::readConfigImpl(){
+    LogWarning << "Using LeastSquaresLLH: NOT A REAL LIKELIHOOD" << std::endl;
+    lsqPoissonianApproximation = JsonUtils::fetchValue(_config_, "lsqPoissonianApproximation", lsqPoissonianApproximation);
+    LogWarning << "Using Least Squares Poissonian Approximation" << std::endl;
+  }
+  double LeastSquaresLLH::eval(const FitSample& sample_, int bin_){
+    double predVal = sample_.getMcContainer().histogram->GetBinContent(bin_);
+    double dataVal = sample_.getDataContainer().histogram->GetBinContent(bin_);
+    double v = dataVal - predVal;
+    v = v*v;
+    if (lsqPoissonianApproximation && dataVal > 1.0) v /= 0.5*dataVal;
+    return v;
+  }
+
   // BarlowLLH
   double BarlowLLH::eval(const FitSample& sample_, int bin_){
     rel_var = sample_.getMcContainer().histogram->GetBinError(bin_) / TMath::Sq(sample_.getMcContainer().histogram->GetBinContent(bin_));

--- a/tests/fast-tests/100NormalizationTree.C
+++ b/tests/fast-tests/100NormalizationTree.C
@@ -83,14 +83,24 @@ void writeMCTree() {
     double varC;
     tree->Branch("C",&varC);
 
-    for (int i=0; i<10000; ++i) {
+    for (int i=0; i<5000; ++i) {
         varA = MakeA();
         varB = MakeB();
-        varC = MakeB();
-        if (varC > 0.0) varA += 1.0;
-        else varA -= 1.0;
+        varC = MakeC();
+        if (varC <= 0.0) varC = - varC + 1E-10;
+        varA += 1.0;
         tree->Fill();
     }
+
+    for (int i=0; i<5000; ++i) {
+        varA = MakeA();
+        varB = MakeB();
+        varC = MakeC();
+        if (varC > 0.0) varC = - varC - 1E-10;
+        varA -= 1.0;
+        tree->Fill();
+    }
+
 }
 
 void writeDataTree() {

--- a/tests/fast-tests/200NormalizationAsimov-config.yaml
+++ b/tests/fast-tests/200NormalizationAsimov-config.yaml
@@ -33,12 +33,13 @@ fitterEngineConfig:
             - "${DATA_DIR}/100NormalizationTree.root"
 
     fitSampleSetConfig:
-      # PoissonLLH is used for tests because it is mathematically simple
-      llhStatFunction: PoissonLLH
+      # LeastSquares is used for tests because it is mathematically simple
+      # and numerically stable.
+      llhStatFunction: LeastSquares
       dataEventType: Asimov
 
       llhConfig:
-        usePoissonLikelihood: true
+        lsqPoissonianApproximation: true
 
       fitSampleList:
         - name: AB

--- a/tests/fast-tests/900NormalizationAsimovCheck.C
+++ b/tests/fast-tests/900NormalizationAsimovCheck.C
@@ -103,15 +103,15 @@ int main() {
     TOLERANCE("Check nominal value for #0_Positive_C",
               postFitErrors->GetBinContent(1), 1.0, tolerance);
     TOLERANCE("Check variance for #0_Positive_C",
-              (*covariance)(0,0), 2.90029056e-04, tolerance);
+              (*covariance)(0,0), 1.40652139e-04, tolerance);
 
     TOLERANCE("Check nominal value for #1_Negative_C",
               postFitErrors->GetBinContent(2), 1.0, tolerance);
     TOLERANCE("Check variance for #1_Negative_C",
-              (*covariance)(1,1), 2.88813415e-04, tolerance);
+              (*covariance)(1,1), 1.43712809e-04, tolerance);
 
     TOLERANCE("Check covariance",
-              (*covariance)(0,1), -8.93441147e-05, tolerance);
+              (*covariance)(0,1), -4.21397580e-05, tolerance);
 
     file->Close();
 


### PR DESCRIPTION
The _real_ log likelihoods all use library functions like "log" which introduce numeric instabilities for testing.  A new `LeastSquaresLLH` has been introduced that is either `(dataVal-predVal)^2` or the traditional Gaussian approximation of `((dataVal-predVal)^2)/dataVal` so it's very stable with the Asimov fit.  This is good for testing, but should not be used for real fits, so a warning is printed when it is found.

The gundam-tests are updated to use LeastSquares with the Poissonian approximation.