### PR TITLE
Feature/likelihood separation

### DIFF
--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCFILES
         src/FitterEngine.cpp
         src/MinimizerInterface.cpp
+        src/LikelihoodInterface.cpp
   )
 
 if( USE_STATIC_LINKS )
@@ -22,4 +23,3 @@ target_link_libraries( GundamFitter PUBLIC
 install(TARGETS GundamFitter DESTINATION lib)
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
-

--- a/src/Fitter/include/FitterEngine.h
+++ b/src/Fitter/include/FitterEngine.h
@@ -7,6 +7,7 @@
 
 
 #include "Propagator.h"
+#include "LikelihoodInterface.h"
 #include "MinimizerInterface.h"
 #include "JsonBaseClass.h"
 
@@ -44,6 +45,8 @@ public:
   const Propagator& getPropagator() const;
   Propagator& getPropagator();
   MinimizerInterface& getMinimizer(){ return _minimizer_; }
+  LikelihoodInterface& getLikelihood(){ return _likelihood_; }
+
   TDirectory* getSaveDir(){ return _saveDir_; }
 
   // Core
@@ -80,7 +83,7 @@ private:
   TDirectory* _saveDir_{nullptr};
   Propagator _propagator_{};
   MinimizerInterface _minimizer_{this};
-
+  LikelihoodInterface _likelihood_{this};
 };
 
 

--- a/src/Fitter/include/LikelihoodInterface.h
+++ b/src/Fitter/include/LikelihoodInterface.h
@@ -1,0 +1,180 @@
+//
+// Created by Clark McGrew 10/01/23
+//
+
+#ifndef GUNDAM_LikelihoodInterface_h
+#define GUNDAM_LikelihoodInterface_h
+
+#include "FitParameterSet.h"
+
+#include "GenericToolbox.VariablesMonitor.h"
+#include "GenericToolbox.CycleTimer.h"
+
+#include "Math/Functor.h"
+
+class FitterEngine;
+
+/// Wrap the calculation of the likelihood using the propagator into a single
+/// place.  This provides an abstract interface that can is provided to the
+/// FitterEngine and can be accessed by any MinimizerInterface.  The main
+/// access is through the evalFit method which takes an array of floating
+/// point values and returns the likelihood.  The meaning of the parameters is
+/// defined by the vector of pointers to FitParameter returned by
+/// getMinimizerFitParameterPtr.
+class LikelihoodInterface {
+public:
+  LikelihoodInterface(FitterEngine* owner_);
+  virtual ~LikelihoodInterface();
+  void setOwner(FitterEngine* owner_) {_owner_ = owner_;}
+
+  /// Initialize the likelihood interface.  Must be called after all of the
+  /// paramters are set, but before the first function evaluation.
+  void initialize();
+
+  /// Calculate the likelihood based on an array of parameters.  Used
+  /// to create a functor that can be used by MINIUT or TSimpleMCMC.
+  double evalFit(const double* parArray_);
+
+  /// A pointer to a ROOT functor that calls the evalFit method.  The object
+  /// referenced by the functor can be handed directly to Minuit.
+  ROOT::Math::Functor* evalFitFunctor() {return _functor_.get();}
+
+  /// A vector of the parameters being used in the fit.  This provides
+  /// the correspondence between an array of doubles (param[]) and the
+  /// pointers to the parameters.
+  std::vector<FitParameter *> &getMinimizerFitParameterPtr()
+    { return _minimizerFitParameterPtr_; }
+
+  /// Set whether a normalized fit space should be used.  This controls how
+  /// the fit parameter array is copied into the propagator parameter
+  /// structures.
+  void setUseNormalizedFitSpace(bool v) {_useNormalizedFitSpace_ = v;}
+  bool getUseNormalizedFitSpace() const {return _useNormalizedFitSpace_;}
+
+  /// Set the minimizer type and algorithm.
+  void setMinimizerInfo(const std::string& type, const std::string& algo) {
+    _minimizerType_ = type;
+    _minimizerAlgo_ = algo;
+  }
+
+  /// Set the target EDM for this fitter.  This is only informational in the
+  /// LikelihoodInterface, but it appears in the running summaries.  It needs
+  /// to be set by the minimizer.
+  void setTargetEDM(double v) { _targetEDM_=v; }
+
+  /// Get the total number of parameters expected by the evalFit method.
+  int getNbFitParameters() const {return _nbFitParameters_;}
+
+  /// Get the number of parameters that are free in the likelihood
+  int getNbFreePars() const {return _nbFreePars_; }
+
+  /// Get the number of times the evalFit function was called.
+  int getNbFitCalls() const {return _nbFitCalls_; }
+
+  /// Return the number of sample bins being used in the fit.  This really
+  /// belongs to the propagator!
+  int getNbFitBins() const {return _nbFitBins_; }
+
+  /// Get the convergence monitor.
+  GenericToolbox::VariablesMonitor& getConvergenceMonitor()
+    {return _convergenceMonitor_;}
+
+  /// Enable and disable the monitor output.
+  void enableFitMonitor(){ _enableFitMonitor_ = true; }
+  void disableFitMonitor(){ _enableFitMonitor_ = false; }
+
+  /// Set whether fit parameters should be shown in the monitor output.
+  void setShowParametersOnFitMonitor(bool v)
+    {_showParametersOnFitMonitor_=v;}
+
+  /// Set the maximum number of parameters to show on a line when parameters
+  /// are being show by the monitor.
+  void setMaxNbParametersPerLineOnMonitor(int v)
+    {_maxNbParametersPerLineOnMonitor_=v;}
+
+  /// Save the chi2 history to the current output file.
+  void saveChi2History();
+
+private:
+  /// True as soon as this has been initialized.
+  bool _isInitialized_{false};
+
+    /// The fitter engion that owns this likelihood.
+  FitterEngine* _owner_{nullptr};
+
+  /// A functor that can be called by Minuit or anybody else.  This wraps evalFit.
+  std::unique_ptr<ROOT::Math::Functor> _functor_;
+
+  /// A vector of pointers to fit parameters that defined the elements in the
+  /// array of parameters passed to evalFit.
+  std::vector<FitParameter*> _minimizerFitParameterPtr_{};
+
+  /// The number of calls to the fitter function.
+  int _nbFitCalls_{0};
+
+  /// The total number of parameters in the likelihood.
+  int _nbFitParameters_{0};
+
+  /// The number of parameters in the likelihood.
+  int _nbFreePars_{0};
+
+  /// The number of sample bins being fitted.
+  int _nbFitBins_{0};
+
+  /// Flag for if a normalized fit space is being used.
+  bool _useNormalizedFitSpace_{true};
+
+  /// The type of minimizer being used (usually minuit2)
+  std::string _minimizerType_{"not-set"};
+
+  /// The algorithm being used (usually Migrad).
+  std::string _minimizerAlgo_{"not-set"};
+
+  /// The target EDM for the best fit point.  This will have different
+  /// meanings for different "minimizers"
+  double _targetEDM_{1E-6};
+
+  /// A tree that save the history of the minimization.
+  std::unique_ptr<TTree> _chi2HistoryTree_{nullptr};
+
+  // Output monitors!
+  GenericToolbox::VariablesMonitor _convergenceMonitor_;
+  GenericToolbox::CycleTimer _evalFitAvgTimer_;
+  GenericToolbox::CycleTimer _outEvalFitAvgTimer_;
+  GenericToolbox::CycleTimer _itSpeed_;
+
+  /// Parameters to control how the monitor behaves.
+  bool _enableFitMonitor_{false};
+  bool _showParametersOnFitMonitor_{false};
+  int _maxNbParametersPerLineOnMonitor_{15};
+};
+
+#endif //  GUNDAM_LikelihoodInterface_h
+
+// An MIT Style License
+
+// Copyright (c) 2022 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/Fitter/include/MinimizerInterface.h
+++ b/src/Fitter/include/MinimizerInterface.h
@@ -35,8 +35,6 @@ public:
   [[nodiscard]] bool isFitHasConverged() const;
   [[nodiscard]] bool isEnablePostFitErrorEval() const;
   [[nodiscard]] const std::unique_ptr<ROOT::Math::Minimizer> &getMinimizer() const;
-  GenericToolbox::VariablesMonitor &getConvergenceMonitor();
-  std::vector<FitParameter *> &getMinimizerFitParameterPtr();
 
   void minimize();
   void calcErrors();
@@ -45,15 +43,19 @@ protected:
   void readConfigImpl() override;
   void initializeImpl() override;
 
-  double evalFit(const double* parArray_);
   void writePostFitData(TDirectory* saveDir_);
 
   void updateCacheToBestfitPoint();
 
-  void enableFitMonitor(){ _enableFitMonitor_ = true; }
-  void disableFitMonitor(){ _enableFitMonitor_ = false; }
-
 private:
+  // A local convenience function to get the convergence monitor.  The monitor
+  // actually lives in the likelihood).
+  GenericToolbox::VariablesMonitor &getConvergenceMonitor();
+
+  // A local convenience function to get the vector of fit parameter pointers.
+  // The actual vector lives in the likelihood.
+  std::vector<FitParameter *> &getMinimizerFitParameterPtr();
+
   // Parameters
   bool _useNormalizedFitSpace_{true};
   bool _enableSimplexBeforeMinimize_{false};
@@ -80,22 +82,9 @@ private:
   // internals
   bool _fitHasConverged_{false};
   bool _isBadCovMat_{false};
-  bool _enableFitMonitor_{false};
-  int _nbFitParameters_{-1};
-  int _nbFitBins_{0};
-  int _nbFreePars_{0};
-  int _nbFitCalls_{0};
+
   FitterEngine* _owner_{nullptr};
   std::unique_ptr<ROOT::Math::Minimizer> _minimizer_{nullptr};
-  std::unique_ptr<ROOT::Math::Functor> _functor_{nullptr};
-  std::vector<FitParameter*> _minimizerFitParameterPtr_{};
-  std::unique_ptr<TTree> _chi2HistoryTree_{nullptr};
-
-  // monitors
-  GenericToolbox::VariablesMonitor _convergenceMonitor_;
-  GenericToolbox::CycleTimer _evalFitAvgTimer_;
-  GenericToolbox::CycleTimer _outEvalFitAvgTimer_;
-  GenericToolbox::CycleTimer _itSpeed_;
 
   // dict
   const std::map<int, std::string> minuitStatusCodeStr{
@@ -133,6 +122,4 @@ private:
   };
 
 };
-
-
 #endif //GUNDAM_MINIMIZERINTERFACE_H

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -65,7 +65,7 @@ void FitterEngine::readConfigImpl(){
     _minimizer_.setMonitorRefreshRateInMs(JsonUtils::fetchValue<int>(_config_, "monitorRefreshRateInMs"));
   });
 
-  LogInfo << "Convergence monitor will be refreshed every " << _minimizer_.getConvergenceMonitor().getMaxRefreshRateInMs() << "ms." << std::endl;
+  LogInfo << "Convergence monitor will be refreshed every " << _likelihood_.getConvergenceMonitor().getMaxRefreshRateInMs() << "ms." << std::endl;
 }
 void FitterEngine::initializeImpl(){
   LogThrowIf(_config_.empty(), "Config is not set.");
@@ -441,7 +441,7 @@ void FitterEngine::scanMinimizerParameters(TDirectory* saveDir_){
                  << " is fixed. Skipping..." << std::endl;
       continue;
     }
-    _propagator_.getParScanner().scanFitParameter(*_minimizer_.getMinimizerFitParameterPtr()[iPar], saveDir_);
+    _propagator_.getParScanner().scanFitParameter(*_likelihood_.getMinimizerFitParameterPtr()[iPar], saveDir_);
   } // iPar
 }
 void FitterEngine::checkNumericalAccuracy(){

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -1,0 +1,210 @@
+//
+// Created by Clark McGrew 24/1/23
+//
+
+#include "LikelihoodInterface.h"
+#include "FitterEngine.h"
+#include "GlobalVariables.h"
+
+#include "GenericToolbox.h"
+#include "GenericToolbox.Root.h"
+#include "Logger.h"
+
+
+LoggerInit([]{
+  Logger::setUserHeaderStr("[Likelihood]");
+});
+
+LikelihoodInterface::LikelihoodInterface(FitterEngine* owner_)
+    : _owner_(owner_) {}
+
+LikelihoodInterface::~LikelihoodInterface() {}
+
+void LikelihoodInterface::initialize() {
+  _chi2HistoryTree_ = std::make_unique<TTree>("chi2History", "chi2History");
+  _chi2HistoryTree_->SetDirectory(nullptr);
+  _chi2HistoryTree_->Branch("nbFitCalls", &_nbFitCalls_);
+  _chi2HistoryTree_->Branch("chi2Total", _owner_->getPropagator().getLlhBufferPtr());
+  _chi2HistoryTree_->Branch("chi2Stat", _owner_->getPropagator().getLlhStatBufferPtr());
+  _chi2HistoryTree_->Branch("chi2Pulls", _owner_->getPropagator().getLlhPenaltyBufferPtr());
+
+  LogWarning << "Fetching the effective number of fit parameters..." << std::endl;
+  _minimizerFitParameterPtr_.clear();
+  _nbFreePars_ = 0;
+  for( auto& parSet : _owner_->getPropagator().getParameterSetsList() ){
+    for( auto& par : parSet.getEffectiveParameterList() ){
+      if( par.isEnabled() and not par.isFixed() ) {
+        _minimizerFitParameterPtr_.emplace_back(&par);
+        if( par.isFree() ) _nbFreePars_++;
+      }
+    }
+  }
+  _nbFitParameters_ = int(_minimizerFitParameterPtr_.size());
+
+  LogInfo << "Building functor with " << _nbFitParameters_ << " parameters ..." << std::endl;
+  _functor_ = std::make_unique<ROOT::Math::Functor>(this, &LikelihoodInterface::evalFit, _nbFitParameters_);
+
+  _nbFitBins_ = 0;
+  for( auto& sample : _owner_->getPropagator().getFitSampleSet().getFitSampleList() ){
+    _nbFitBins_ += int(sample.getBinning().getBinsList().size());
+  }
+
+  _convergenceMonitor_.addDisplayedQuantity("VarName");
+  _convergenceMonitor_.addDisplayedQuantity("LastAddedValue");
+  _convergenceMonitor_.addDisplayedQuantity("SlopePerCall");
+
+  _convergenceMonitor_.getQuantity("VarName").title = "Likelihood";
+  _convergenceMonitor_.getQuantity("LastAddedValue").title = "Current Value";
+  _convergenceMonitor_.getQuantity("SlopePerCall").title = "Avg. Slope /call";
+
+  _convergenceMonitor_.addVariable("Total");
+  _convergenceMonitor_.addVariable("Stat");
+  _convergenceMonitor_.addVariable("Syst");
+
+  _isInitialized_ = true;
+}
+
+void LikelihoodInterface::saveChi2History() {
+  GenericToolbox::writeInTFile(GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "fit"), _chi2HistoryTree_.get());
+}
+
+double LikelihoodInterface::evalFit(const double* parArray_){
+  LogThrowIf(not _isInitialized_, "not initialized");
+  GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds(__METHOD_NAME__);
+
+  if(_nbFitCalls_ != 0){
+    _outEvalFitAvgTimer_.counts++ ; _outEvalFitAvgTimer_.cumulated += GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds("out_evalFit");
+  }
+  ++_nbFitCalls_;
+
+  // Update fit parameter values:
+  int iFitPar{0};
+  for( auto* par : _minimizerFitParameterPtr_ ){
+    if( getUseNormalizedFitSpace() ) par->setParameterValue(FitParameterSet::toRealParValue(parArray_[iFitPar++], *par));
+    else par->setParameterValue(parArray_[iFitPar++]);
+  }
+
+  // Compute the Chi2
+  _owner_->getPropagator().updateLlhCache();
+
+  _evalFitAvgTimer_.counts++; _evalFitAvgTimer_.cumulated += GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds(__METHOD_NAME__);
+
+  if(_enableFitMonitor_ && _convergenceMonitor_.isGenerateMonitorStringOk()){
+    if( _itSpeed_.counts != 0 ){
+      _itSpeed_.counts = _nbFitCalls_ - _itSpeed_.counts; // how many cycles since last print
+      _itSpeed_.cumulated = GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds("itSpeed"); // time since last print
+    }
+    else{
+      _itSpeed_.counts = _nbFitCalls_;
+      GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds("itSpeed");
+    }
+
+    std::stringstream ssHeader;
+    ssHeader << std::endl << __METHOD_NAME__ << ": call #" << _nbFitCalls_;
+    ssHeader << std::endl << "Target EDM: " << _targetEDM_;
+    ssHeader << std::endl << "Current RAM usage: " << GenericToolbox::parseSizeUnits(double(GenericToolbox::getProcessMemoryUsage()));
+    double cpuPercent = GenericToolbox::getCpuUsageByProcess();
+    ssHeader << std::endl << "Current CPU usage: " << cpuPercent << "% (" << cpuPercent / GlobalVariables::getNbThreads() << "% efficiency)";
+    ssHeader << std::endl << "Avg " << GUNDAM_CHI2 << " computation time: " << _evalFitAvgTimer_;
+    ssHeader << std::endl << GUNDAM_CHI2 << "/dof: " << _owner_->getPropagator().getLlhBuffer() / double(_nbFitBins_ - _nbFreePars_);
+    ssHeader << std::endl;
+#ifndef GUNDAM_BATCH
+    ssHeader << "├─";
+#endif
+    ssHeader << " Current speed:                 " << (double)_itSpeed_.counts / (double)_itSpeed_.cumulated * 1E6 << " it/s";
+    ssHeader << std::endl;
+#ifndef GUNDAM_BATCH
+    ssHeader << "├─";
+#endif
+    ssHeader << " Avg time for " << _minimizerType_ << "/" << _minimizerAlgo_ << ":   " << _outEvalFitAvgTimer_;
+    ssHeader << std::endl;
+#ifndef GUNDAM_BATCH
+    ssHeader << "├─";
+#endif
+    ssHeader << " Avg time to propagate weights: " << _owner_->getPropagator().weightProp;
+    ssHeader << std::endl;
+#ifndef GUNDAM_BATCH
+    ssHeader << "├─";
+#endif
+    ssHeader << " Avg time to fill histograms:   " << _owner_->getPropagator().fillProp;
+
+    if( _showParametersOnFitMonitor_ ){
+      std::string curParSet;
+      ssHeader << std::endl << std::setprecision(1) << std::scientific << std::showpos;
+      int nParPerLine{0};
+      for( auto* fitPar : _minimizerFitParameterPtr_ ){
+        if( fitPar->isFixed() ) continue;
+        if( curParSet != fitPar->getOwner()->getName() ){
+          if( not curParSet.empty() ) ssHeader << std::endl;
+          curParSet = fitPar->getOwner()->getName();
+          ssHeader << curParSet
+                   << (fitPar->getOwner()->isUseEigenDecompInFit()? " (eigen)": "")
+                   << ":" << std::endl;
+          nParPerLine = 0;
+        }
+        else{
+          ssHeader << ", ";
+          if( nParPerLine >= _maxNbParametersPerLineOnMonitor_ ) { ssHeader << std::endl; nParPerLine = 0; }
+        }
+        if(fitPar->gotUpdated()) ssHeader << GenericToolbox::ColorCodes::blueBackground;
+        if(getUseNormalizedFitSpace()) ssHeader << FitParameterSet::toNormalizedParValue(fitPar->getParameterValue(), *fitPar);
+        else ssHeader << fitPar->getParameterValue();
+        if(fitPar->gotUpdated()) ssHeader << GenericToolbox::ColorCodes::resetColor;
+        nParPerLine++;
+      }
+    }
+
+    _convergenceMonitor_.setHeaderString(ssHeader.str());
+    _convergenceMonitor_.getVariable("Total").addQuantity(_owner_->getPropagator().getLlhBuffer());
+    _convergenceMonitor_.getVariable("Stat").addQuantity(_owner_->getPropagator().getLlhStatBuffer());
+    _convergenceMonitor_.getVariable("Syst").addQuantity(_owner_->getPropagator().getLlhPenaltyBuffer());
+
+
+    if( _nbFitCalls_ == 1 ){
+      // don't erase these lines
+      LogWarning << _convergenceMonitor_.generateMonitorString();
+    }
+    else{
+      LogInfo << _convergenceMonitor_.generateMonitorString(
+          GenericToolbox::getTerminalWidth() != 0, // trail back if not in batch mode
+          true // force generate
+      );
+    }
+
+    _itSpeed_.counts = _nbFitCalls_;
+  }
+
+  // Fill History
+  _chi2HistoryTree_->Fill();
+
+  GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds("out_evalFit");
+  return _owner_->getPropagator().getLlhBuffer();
+}
+
+// An MIT Style License
+
+// Copyright (c) 2022 GUNDAM DEVELOPERS
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/tests/fast-tests/100CovarianceTree.C
+++ b/tests/fast-tests/100CovarianceTree.C
@@ -226,7 +226,7 @@ void writeCovariance() {
 int main() {
     std::shared_ptr<TFile> file(new TFile("100CovarianceTree.root","new"));
     if (!file || !file->IsOpen()) {
-        std::cout << "FAIL: TFile not openned" << std::endl;
+        std::cout << "FAIL: TFile not opened" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
This refactors `MinimizerInterface` to not directly implement the likelihood interface, and opens the possibility of alternative implementations to be used by `FitterEngine` (e.g. an `MCMCInterface`).  This refactoring means that all "Interface" classes will have identical likelihood calculation code paths and simplify overall validation.

This PR adds a new class `LikelihoodInterface` which is constructed in `FitterEngine`, and accessed in `MinimizerInterface` by way of the `_owner_` pointer to `FitterEngine`.  All of the necessary configuration for the `LikelihoodInterface` is done by setters called by `MinimizerInterface`, but a future direction might be to add a new optional "fitterEngineConfig" field in the yaml files (e.g. "likelihoodConfig").  The `LikelihoodInterface` class is not currently derived from `JsonBaseClass`, but it could be.

This passes all of the gundam-tests.sh tests on a local machine. 
