### PR TITLE
Feature/minimizer interface base class

### DIFF
--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRCFILES
         src/FitterEngine.cpp
+        src/MinimizerBase.cpp
         src/MinimizerInterface.cpp
         src/LikelihoodInterface.cpp
   )

--- a/src/Fitter/include/FitterEngine.h
+++ b/src/Fitter/include/FitterEngine.h
@@ -44,8 +44,8 @@ public:
   // Getters
   const Propagator& getPropagator() const;
   Propagator& getPropagator();
-  const MinimizerInterface& getMinimizer() const { return *_minimizer_; }
-  MinimizerInterface& getMinimizer(){ return *_minimizer_; }
+  const MinimizerBase& getMinimizer() const { return *_minimizer_; }
+  MinimizerBase& getMinimizer(){ return *_minimizer_; }
   const LikelihoodInterface& getLikelihood() const { return _likelihood_; }
   LikelihoodInterface& getLikelihood(){ return _likelihood_; }
 
@@ -60,7 +60,12 @@ protected:
 
   void fixGhostFitParameters();
   void rescaleParametersStepSize();
-  void scanMinimizerParameters(TDirectory* saveDir_);
+
+  // Scan the parameters as used by the minimizer (e.g. MINUIT).  This has
+  // been replaced by MinimizerBase::scanParameters() which can be accessed
+  // through the getMinimizer() method.  For example:
+  // "fitter.scanMinimizerParameters(dir)" should be replaced by "fitter.getMinimizer().scanParameters(dir)"
+  [[deprecated("Use getMinimizer().scanParameters(dir) instead")]] void scanMinimizerParameters(TDirectory* saveDir_);
   void checkNumericalAccuracy();
 
 
@@ -84,7 +89,7 @@ private:
   // Internals
   TDirectory* _saveDir_{nullptr};
   Propagator _propagator_{};
-  std::unique_ptr<MinimizerInterface> _minimizer_{nullptr};
+  std::unique_ptr<MinimizerBase> _minimizer_{nullptr};
   LikelihoodInterface _likelihood_{this};
 };
 

--- a/src/Fitter/include/FitterEngine.h
+++ b/src/Fitter/include/FitterEngine.h
@@ -44,7 +44,9 @@ public:
   // Getters
   const Propagator& getPropagator() const;
   Propagator& getPropagator();
-  MinimizerInterface& getMinimizer(){ return _minimizer_; }
+  const MinimizerInterface& getMinimizer() const { return *_minimizer_; }
+  MinimizerInterface& getMinimizer(){ return *_minimizer_; }
+  const LikelihoodInterface& getLikelihood() const { return _likelihood_; }
   LikelihoodInterface& getLikelihood(){ return _likelihood_; }
 
   TDirectory* getSaveDir(){ return _saveDir_; }
@@ -82,7 +84,7 @@ private:
   // Internals
   TDirectory* _saveDir_{nullptr};
   Propagator _propagator_{};
-  MinimizerInterface _minimizer_{this};
+  std::unique_ptr<MinimizerInterface> _minimizer_{nullptr};
   LikelihoodInterface _likelihood_{this};
 };
 

--- a/src/Fitter/include/LikelihoodInterface.h
+++ b/src/Fitter/include/LikelihoodInterface.h
@@ -84,13 +84,13 @@ public:
   void disableFitMonitor(){ _enableFitMonitor_ = false; }
 
   /// Set whether fit parameters should be shown in the monitor output.
-  void setShowParametersOnFitMonitor(bool v)
-    {_showParametersOnFitMonitor_=v;}
+  void setShowParametersOnFitMonitor(bool v) {_showParametersOnFitMonitor_=v;}
+  bool getShowParametersOnFitMonitor() {return _showParametersOnFitMonitor_;}
 
   /// Set the maximum number of parameters to show on a line when parameters
   /// are being show by the monitor.
-  void setMaxNbParametersPerLineOnMonitor(int v)
-    {_maxNbParametersPerLineOnMonitor_=v;}
+  void setMaxNbParametersPerLineOnMonitor(int v) {_maxNbParametersPerLineOnMonitor_=v;}
+  bool getMaxNbParametersPerLineOnMonitor() {return _maxNbParametersPerLineOnMonitor_;}
 
   /// Save the chi2 history to the current output file.
   void saveChi2History();

--- a/src/Fitter/include/MinimizerBase.h
+++ b/src/Fitter/include/MinimizerBase.h
@@ -8,6 +8,7 @@
 #include "JsonBaseClass.h"
 #include "GenericToolbox.VariablesMonitor.h"
 
+class TDirectory;
 class FitterEngine;
 class FitParameter;
 class Propagator;
@@ -34,6 +35,20 @@ public:
   /// should either be skipped, or the covariance can be filled using
   /// information from the posterior.
   virtual void calcErrors() = 0;
+
+  /// A pure virtual method that returns true if the fit has converted.
+  [[nodiscard]] virtual bool isFitHasConverged() const = 0;
+
+  /// A virtual method that should scan the parameters used by the minimizer.
+  /// This provides a view of the parameters seen by the minimizer, which may
+  /// be different from the parameters used for the likelihood.  Most
+  /// MinimizerBase derived classes should override this method.  If it is not
+  /// provided then it will be a no-op.
+  virtual void scanParameters(TDirectory* saveDir_);
+
+  /// Set if the calcErrors method should be called by the FitterEngine.
+  void setEnablePostFitErrorEval(bool enablePostFitErrorEval_) {_enablePostFitErrorEval_ = enablePostFitErrorEval_;}
+  [[nodiscard]] bool isEnablePostFitErrorEval() const {return _enablePostFitErrorEval_;}
 
 protected:
   /// Get a reference to the FitterEngine that owns this minimizer.
@@ -71,6 +86,9 @@ protected:
 private:
   /// Save a copy of the address of the engine that owns this object.
   FitterEngine* _owner_{nullptr};
+
+  bool _enablePostFitErrorEval_{true};
+
 };
 #endif //GUNDAM_MinimizerBase_h
 

--- a/src/Fitter/include/MinimizerBase.h
+++ b/src/Fitter/include/MinimizerBase.h
@@ -1,0 +1,103 @@
+//
+// Created by Clark McGrew on 25/01/2023.
+//
+
+#ifndef GUNDAM_MinimizerBase_h
+#define GUNDAM_MinimizerBase_h
+
+#include "JsonBaseClass.h"
+#include "GenericToolbox.VariablesMonitor.h"
+
+class FitterEngine;
+class FitParameter;
+class Propagator;
+class LikelihoodInterface;
+
+/// An (almost) abstract base class for minimizer interfaces.  Classes derived
+/// from MinimizerBase are used by the FitterEngine to run different types of
+/// fits (primarily a MINUIT based maximization of the likelihood the fits).
+/// Classes need to implement two worker methods.  The minimize() method is
+/// expected to find the minimim of the LLH function (or Chi-Squared), and the
+/// calcErrors() is expected to calculate the covariance of the LLH function.
+class MinimizerBase : public JsonBaseClass {
+
+public:
+  explicit MinimizerBase(FitterEngine* owner_);
+
+  /// A pure virtual method that is called by the FitterEngine to find the
+  /// minimum of the likelihood, or, in the case of a Bayesian integration find
+  /// the posterior distribution.
+  virtual void minimize() = 0;
+
+  /// A pure virtual method that is called by the FiterEngine to calculate the
+  /// covariance at best fit point.  In the case of a Bayesian integration, it
+  /// should either be skipped, or the covariance can be filled using
+  /// information from the posterior.
+  virtual void calcErrors() = 0;
+
+protected:
+  /// Get a reference to the FitterEngine that owns this minimizer.
+  inline FitterEngine& owner() { return *_owner_; }
+  inline const FitterEngine& owner() const { return *_owner_; }
+
+  // Implement the methods required by JsonBaseClass.  These MinimizerBase
+  // methods may be overridden by the derived class, but if overriden, the
+  // derived class must run these instantiations (i.e. call
+  // MinimizerBase::readConfigImpl() and MinimizerBase::initializeImpl in the
+  // respective methods).
+  virtual void readConfigImpl() override;
+  virtual void initializeImpl() override;
+
+  // Get the propagator being used to calculate the likelihood.  This is a
+  // local convenience function to get the propagator from the owner.
+  Propagator& getPropagator();
+  const Propagator& getPropagator() const;
+
+  // Get the likelihood that should be used by the minimization.  This is a
+  // local convenience function to get the likelihood from the owner.
+  LikelihoodInterface& getLikelihood();
+  const LikelihoodInterface& getLikelihood() const;
+
+  // Get the convergence monitor that is maintained by the likelihood
+  // interface.  A local convenience function to get the convergence monitor.
+  // The monitor actually lives in the likelihood).
+  GenericToolbox::VariablesMonitor &getConvergenceMonitor();
+
+  // Get the vector of parameters being fitted.  This is a local convenience
+  // function to get the vector of fit parameter pointers.  The actual vector
+  // lives in the likelihood.
+  std::vector<FitParameter *> &getMinimizerFitParameterPtr();
+
+private:
+  /// Save a copy of the address of the engine that owns this object.
+  FitterEngine* _owner_{nullptr};
+};
+#endif //GUNDAM_MinimizerBase_h
+
+// An MIT Style License
+
+// Copyright (c) 2022 GUNDUM DEVELOPERS
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/Fitter/include/MinimizerInterface.h
+++ b/src/Fitter/include/MinimizerInterface.h
@@ -28,14 +28,13 @@ class MinimizerInterface : public MinimizerBase {
 public:
   explicit MinimizerInterface(FitterEngine* owner_);
 
-  void setEnablePostFitErrorEval(bool enablePostFitErrorEval_);
+  [[nodiscard]] virtual bool isFitHasConverged() const override;
 
-  [[nodiscard]] bool isFitHasConverged() const;
-  [[nodiscard]] bool isEnablePostFitErrorEval() const;
   [[nodiscard]] const std::unique_ptr<ROOT::Math::Minimizer> &getMinimizer() const;
 
   void minimize() override;
   void calcErrors() override;
+  void scanParameters(TDirectory* saveDir_) override;
 
 protected:
   void readConfigImpl() override;
@@ -49,7 +48,7 @@ private:
 
   // Parameters
   bool _enableSimplexBeforeMinimize_{false};
-  bool _enablePostFitErrorEval_{true};
+  // bool _enablePostFitErrorEval_{true};
   bool _restoreStepSizeBeforeHesse_{false};
   bool _generatedPostFitParBreakdown_{false};
   bool _generatedPostFitEigenBreakdown_{false};

--- a/src/Fitter/include/MinimizerInterface.h
+++ b/src/Fitter/include/MinimizerInterface.h
@@ -7,6 +7,7 @@
 
 
 #include "FitParameterSet.h"
+#include "MinimizerBase.h"
 #include "JsonBaseClass.h"
 
 #include "GenericToolbox.VariablesMonitor.h"
@@ -20,24 +21,21 @@
 #include "memory"
 #include "vector"
 
-
 class FitterEngine;
 
-class MinimizerInterface : public JsonBaseClass {
+class MinimizerInterface : public MinimizerBase {
 
 public:
   explicit MinimizerInterface(FitterEngine* owner_);
 
-  void setOwner(FitterEngine* owner_);
   void setEnablePostFitErrorEval(bool enablePostFitErrorEval_);
-  void setMonitorRefreshRateInMs(int monitorRefreshRateInMs_);
 
   [[nodiscard]] bool isFitHasConverged() const;
   [[nodiscard]] bool isEnablePostFitErrorEval() const;
   [[nodiscard]] const std::unique_ptr<ROOT::Math::Minimizer> &getMinimizer() const;
 
-  void minimize();
-  void calcErrors();
+  void minimize() override;
+  void calcErrors() override;
 
 protected:
   void readConfigImpl() override;
@@ -48,28 +46,16 @@ protected:
   void updateCacheToBestfitPoint();
 
 private:
-  // A local convenience function to get the convergence monitor.  The monitor
-  // actually lives in the likelihood).
-  GenericToolbox::VariablesMonitor &getConvergenceMonitor();
-
-  // A local convenience function to get the vector of fit parameter pointers.
-  // The actual vector lives in the likelihood.
-  std::vector<FitParameter *> &getMinimizerFitParameterPtr();
 
   // Parameters
-  bool _useNormalizedFitSpace_{true};
   bool _enableSimplexBeforeMinimize_{false};
   bool _enablePostFitErrorEval_{true};
   bool _restoreStepSizeBeforeHesse_{false};
   bool _generatedPostFitParBreakdown_{false};
   bool _generatedPostFitEigenBreakdown_{false};
-  bool _showParametersOnFitMonitor_{false};
   int _strategy_{1};
   int _printLevel_{2};
   int _simplexStrategy_{1};
-  int _monitorRefreshRateInMs_{5000};
-  int _monitorBashModeRefreshRateInS_{30};
-  int _maxNbParametersPerLineOnMonitor_{15};
   double _tolerance_{1E-4};
   double _simplexToleranceLoose_{1000.};
   unsigned int _maxIterations_{500};
@@ -83,7 +69,6 @@ private:
   bool _fitHasConverged_{false};
   bool _isBadCovMat_{false};
 
-  FitterEngine* _owner_{nullptr};
   std::unique_ptr<ROOT::Math::Minimizer> _minimizer_{nullptr};
 
   // dict

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -217,7 +217,7 @@ void FitterEngine::fit(){
   }
   if( _enablePreFitScan_ ){
     LogInfo << "Scanning fit parameters before minimizing..." << std::endl;
-    this->scanMinimizerParameters(GenericToolbox::mkdirTFile(_saveDir_, "preFit/scan"));
+    getMinimizer().scanParameters(GenericToolbox::mkdirTFile(_saveDir_, "preFit/scan"));
     GenericToolbox::triggerTFileWrite(_saveDir_);
   }
   if( _throwMcBeforeFit_ ){
@@ -276,7 +276,7 @@ void FitterEngine::fit(){
   }
   if( _enablePostFitScan_ ){
     LogInfo << "Scanning fit parameters around the minimum point..." << std::endl;
-    this->scanMinimizerParameters(GenericToolbox::mkdirTFile(_saveDir_, "postFit/scan"));
+    getMinimizer().scanParameters(GenericToolbox::mkdirTFile(_saveDir_, "postFit/scan"));
     GenericToolbox::triggerTFileWrite(_saveDir_);
   }
 
@@ -440,14 +440,15 @@ void FitterEngine::rescaleParametersStepSize(){
 void FitterEngine::scanMinimizerParameters(TDirectory* saveDir_){
   LogThrowIf(not isInitialized());
   LogInfo << "Performing scans of fit parameters..." << std::endl;
-  for( int iPar = 0 ; iPar < getMinimizer().getMinimizer()->NDim() ; iPar++ ){
-    if( getMinimizer().getMinimizer()->IsFixedVariable(iPar) ){
-      LogWarning << getMinimizer().getMinimizer()->VariableName(iPar)
-                 << " is fixed. Skipping..." << std::endl;
-      continue;
-    }
-    _propagator_.getParScanner().scanFitParameter(*_likelihood_.getMinimizerFitParameterPtr()[iPar], saveDir_);
-  } // iPar
+  getMinimizer().scanParameters(saveDir_);
+  // for( int iPar = 0 ; iPar < getMinimizer().getMinimizer()->NDim() ; iPar++ ){
+  //   if( getMinimizer().getMinimizer()->IsFixedVariable(iPar) ){
+  //     LogWarning << getMinimizer().getMinimizer()->VariableName(iPar)
+  //                << " is fixed. Skipping..." << std::endl;
+  //     continue;
+  //   }
+  //   _propagator_.getParScanner().scanFitParameter(*_likelihood_.getMinimizerFitParameterPtr()[iPar], saveDir_);
+  // } // iPar
 }
 void FitterEngine::checkNumericalAccuracy(){
   LogWarning << __METHOD_NAME__ << std::endl;

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -10,7 +10,6 @@
 #include "GenericToolbox.Root.h"
 #include "Logger.h"
 
-
 LoggerInit([]{
   Logger::setUserHeaderStr("[Likelihood]");
 });

--- a/src/Fitter/src/MinimizerBase.cpp
+++ b/src/Fitter/src/MinimizerBase.cpp
@@ -1,0 +1,86 @@
+#include "MinimizerBase.h"
+#include "FitterEngine.h"
+
+#include "JsonUtils.h"
+#include "Logger.h"
+
+LoggerInit([]{
+  Logger::setUserHeaderStr("[MinimizerBase]");
+});
+
+
+MinimizerBase::MinimizerBase(FitterEngine* owner_): _owner_(owner_){}
+
+void MinimizerBase::readConfigImpl(){
+  LogInfo << "Reading MinimizerBase config..." << std::endl;
+
+  bool useNormalizedFitSpace = getLikelihood().getUseNormalizedFitSpace();
+  useNormalizedFitSpace = JsonUtils::fetchValue(_config_, "useNormalizedFitSpace", useNormalizedFitSpace);
+  getLikelihood().setUseNormalizedFitSpace(useNormalizedFitSpace);
+
+  bool showParametersOnFitMonitor = getLikelihood().getShowParametersOnFitMonitor();
+  showParametersOnFitMonitor = JsonUtils::fetchValue(_config_, "showParametersOnFitMonitor", showParametersOnFitMonitor);
+  getLikelihood().setShowParametersOnFitMonitor(showParametersOnFitMonitor);
+
+  bool maxNbParametersPerLineOnMonitor = getLikelihood().getMaxNbParametersPerLineOnMonitor();
+  maxNbParametersPerLineOnMonitor = JsonUtils::fetchValue(_config_, "maxNbParametersPerLineOnMonitor", maxNbParametersPerLineOnMonitor);
+  getLikelihood().setMaxNbParametersPerLineOnMonitor(maxNbParametersPerLineOnMonitor);
+
+  if( GenericToolbox::getTerminalWidth() == 0 ){
+    // batch mode
+    double monitorBashModeRefreshRateInS = JsonUtils::fetchValue(_config_, "monitorBashModeRefreshRateInS", 30.0);
+    getConvergenceMonitor().setMaxRefreshRateInMs(monitorBashModeRefreshRateInS * 1000.);
+  }
+  else{
+    int monitorRefreshRateInMs = JsonUtils::fetchValue(_config_, "monitorRefreshRateInMs", 5000);
+    getConvergenceMonitor().setMaxRefreshRateInMs(monitorRefreshRateInMs);
+  }
+
+}
+
+void MinimizerBase::initializeImpl(){
+  LogInfo << "Initializing the minimizer..." << std::endl;
+  LogThrowIf( _owner_== nullptr, "FitterEngine ptr not set." );
+}
+
+std::vector<FitParameter *>& MinimizerBase::getMinimizerFitParameterPtr() {
+  return getLikelihood().getMinimizerFitParameterPtr();
+}
+
+GenericToolbox::VariablesMonitor &MinimizerBase::getConvergenceMonitor() {
+  return getLikelihood().getConvergenceMonitor();
+}
+
+Propagator& MinimizerBase::getPropagator() {return owner().getPropagator();}
+const Propagator& MinimizerBase::getPropagator() const { return owner().getPropagator(); }
+
+LikelihoodInterface& MinimizerBase::getLikelihood() {return owner().getLikelihood();}
+const LikelihoodInterface& MinimizerBase::getLikelihood() const {return owner().getLikelihood();}
+
+// An MIT Style License
+
+// Copyright (c) 2022 GUNDUM DEVELOPERS
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/Fitter/src/MinimizerBase.cpp
+++ b/src/Fitter/src/MinimizerBase.cpp
@@ -14,6 +14,8 @@ MinimizerBase::MinimizerBase(FitterEngine* owner_): _owner_(owner_){}
 void MinimizerBase::readConfigImpl(){
   LogInfo << "Reading MinimizerBase config..." << std::endl;
 
+  _enablePostFitErrorEval_ = JsonUtils::fetchValue(_config_, "enablePostFitErrorFit", _enablePostFitErrorEval_);
+
   bool useNormalizedFitSpace = getLikelihood().getUseNormalizedFitSpace();
   useNormalizedFitSpace = JsonUtils::fetchValue(_config_, "useNormalizedFitSpace", useNormalizedFitSpace);
   getLikelihood().setUseNormalizedFitSpace(useNormalizedFitSpace);
@@ -41,6 +43,11 @@ void MinimizerBase::readConfigImpl(){
 void MinimizerBase::initializeImpl(){
   LogInfo << "Initializing the minimizer..." << std::endl;
   LogThrowIf( _owner_== nullptr, "FitterEngine ptr not set." );
+}
+
+void MinimizerBase::scanParameters(TDirectory* saveDir_) {
+  LogWarning << "Parameter scanning is not implemented for this minimizer"
+             << std::endl;
 }
 
 std::vector<FitParameter *>& MinimizerBase::getMinimizerFitParameterPtr() {

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -23,25 +23,18 @@ LoggerInit([]{
 });
 
 
-MinimizerInterface::MinimizerInterface(FitterEngine* owner_): _owner_(owner_){}
-
-void MinimizerInterface::setOwner(FitterEngine* owner_){ _owner_ = owner_; }
+MinimizerInterface::MinimizerInterface(FitterEngine* owner_):
+  MinimizerBase(owner_){}
 
 void MinimizerInterface::setEnablePostFitErrorEval(bool enablePostFitErrorEval_){ _enablePostFitErrorEval_ = enablePostFitErrorEval_; }
 
-void MinimizerInterface::setMonitorRefreshRateInMs(int monitorRefreshRateInMs_){ _monitorRefreshRateInMs_ = monitorRefreshRateInMs_; }
-
-GenericToolbox::VariablesMonitor &MinimizerInterface::getConvergenceMonitor() {
-  return _owner_->getLikelihood().getConvergenceMonitor();
-}
 
 void MinimizerInterface::readConfigImpl(){
+  MinimizerBase::readConfigImpl();
   LogInfo << "Reading minimizer config..." << std::endl;
 
   _minimizerType_ = JsonUtils::fetchValue(_config_, "minimizer", _minimizerType_);
   _minimizerAlgo_ = JsonUtils::fetchValue(_config_, "algorithm", _minimizerAlgo_);
-
-  _useNormalizedFitSpace_ = JsonUtils::fetchValue(_config_, "useNormalizedFitSpace", _useNormalizedFitSpace_);
 
   _strategy_ = JsonUtils::fetchValue(_config_, "strategy", _strategy_);
   _printLevel_ = JsonUtils::fetchValue(_config_, "print_level", _printLevel_);
@@ -61,14 +54,10 @@ void MinimizerInterface::readConfigImpl(){
   _generatedPostFitParBreakdown_ = JsonUtils::fetchValue(_config_, "generatedPostFitParBreakdown", _generatedPostFitParBreakdown_);
   _generatedPostFitEigenBreakdown_ = JsonUtils::fetchValue(_config_, "generatedPostFitEigenBreakdown", _generatedPostFitEigenBreakdown_);
 
-  _monitorRefreshRateInMs_ = JsonUtils::fetchValue(_config_, "monitorRefreshRateInMs", _monitorRefreshRateInMs_);
-  _showParametersOnFitMonitor_ = JsonUtils::fetchValue(_config_, "showParametersOnFitMonitor", _showParametersOnFitMonitor_);
-  _maxNbParametersPerLineOnMonitor_ = JsonUtils::fetchValue(_config_, "maxNbParametersPerLineOnMonitor", _maxNbParametersPerLineOnMonitor_);
-  _monitorBashModeRefreshRateInS_ = JsonUtils::fetchValue(_config_, "monitorBashModeRefreshRateInS", _monitorBashModeRefreshRateInS_);
 }
 void MinimizerInterface::initializeImpl(){
+  MinimizerBase::initializeImpl();
   LogInfo << "Initializing the minimizer..." << std::endl;
-  LogThrowIf( _owner_== nullptr, "FitterEngine ptr not set." );
 
   _minimizer_ = std::unique_ptr<ROOT::Math::Minimizer>(
       ROOT::Math::Factory::CreateMinimizer(_minimizerType_, _minimizerAlgo_)
@@ -79,15 +68,13 @@ void MinimizerInterface::initializeImpl(){
     LogWarning << "Using default minimizer algo: " << _minimizerAlgo_ << std::endl;
   }
 
-  // Configure the likelihood with the local settings and then initialize.
-  _owner_->getLikelihood().setMinimizerInfo(_minimizerType_,_minimizerAlgo_);
-  _owner_->getLikelihood().setTargetEDM(0.001*_tolerance_*2);
-  _owner_->getLikelihood().setUseNormalizedFitSpace(_useNormalizedFitSpace_);
-  _owner_->getLikelihood().setShowParametersOnFitMonitor(_showParametersOnFitMonitor_);
-  _owner_->getLikelihood().setMaxNbParametersPerLineOnMonitor(_maxNbParametersPerLineOnMonitor_);
-  _owner_->getLikelihood().initialize();
+  // Configure the likelihood with the local settings.  These are used by the
+  // likelihood to print informational messages, but do not affect how the
+  // likelihood code runs.
+  getLikelihood().setMinimizerInfo(_minimizerType_,_minimizerAlgo_);
+  getLikelihood().setTargetEDM(0.001*_tolerance_*2);
 
-  _minimizer_->SetFunction(*(_owner_->getLikelihood().evalFitFunctor()));
+  _minimizer_->SetFunction(*(getLikelihood().evalFitFunctor()));
   _minimizer_->SetStrategy(_strategy_);
   _minimizer_->SetPrintLevel(_printLevel_);
   _minimizer_->SetTolerance(_tolerance_);
@@ -97,7 +84,7 @@ void MinimizerInterface::initializeImpl(){
   for( std::size_t iFitPar = 0 ; iFitPar < getMinimizerFitParameterPtr().size() ; iFitPar++ ){
     auto& fitPar = *(getMinimizerFitParameterPtr()[iFitPar]);
 
-    if( not _useNormalizedFitSpace_ ){
+    if( not getLikelihood().getUseNormalizedFitSpace() ){
       _minimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),fitPar.getParameterValue(),fitPar.getStepSize());
       if( not std::isnan( fitPar.getMinValue() ) ){ _minimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue()); }
       if( not std::isnan( fitPar.getMaxValue() ) ){ _minimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue()); }
@@ -117,14 +104,6 @@ void MinimizerInterface::initializeImpl(){
       _minimizer_->SetVariableStepSize(iFitPar, FitParameterSet::toNormalizedParRange(fitPar.getStepSize(), fitPar));
     }
   }
-
-  if( GenericToolbox::getTerminalWidth() == 0 ){
-    // batch mode
-    getConvergenceMonitor().setMaxRefreshRateInMs(_monitorBashModeRefreshRateInS_ * 1000.);
-  }
-  else{
-    getConvergenceMonitor().setMaxRefreshRateInMs(_monitorRefreshRateInMs_);
-  }
 }
 
 bool MinimizerInterface::isFitHasConverged() const {
@@ -138,15 +117,11 @@ const std::unique_ptr<ROOT::Math::Minimizer> &MinimizerInterface::getMinimizer()
   return _minimizer_;
 }
 
-std::vector<FitParameter *>& MinimizerInterface::getMinimizerFitParameterPtr() {
-  return _owner_->getLikelihood().getMinimizerFitParameterPtr();
-}
-
 void MinimizerInterface::minimize(){
   LogThrowIf(not isInitialized(), "not initialized");
 
   LogWarning << std::endl << GenericToolbox::addUpDownBars("Summary of the fit parameters:") << std::endl;
-  for( const auto& parSet : _owner_->getPropagator().getParameterSetsList() ){
+  for( const auto& parSet : getPropagator().getParameterSetsList() ){
 
     GenericToolbox::TablePrinter t;
     t.setColTitles({ {"Title"}, {"Starting"}, {"Prior"}, {"StdDev"}, {"Min"}, {"Max"}, {"Status"} });
@@ -184,18 +159,18 @@ void MinimizerInterface::minimize(){
     t.printTable();
   }
 
-  _owner_->getPropagator().updateLlhCache();
+  getPropagator().updateLlhCache();
 
   LogWarning << std::endl << GenericToolbox::addUpDownBars("Calling minimize...") << std::endl;
   LogInfo << "Number of defined parameters: " << _minimizer_->NDim() << std::endl
           << "Number of fit parameters   : " << _minimizer_->NFree() << std::endl
-          << "Number of free parameters : " << _owner_->getLikelihood().getNbFreePars() << std::endl
+          << "Number of free parameters : " << getLikelihood().getNbFreePars() << std::endl
           << "Number of fixed parameters  : " << _minimizer_->NDim() - _minimizer_->NFree() << std::endl
-          << "Number of fit bins : " << _owner_->getLikelihood().getNbFitBins() << std::endl
-          << "Chi2 # DoF : " << _owner_->getLikelihood().getNbFitBins() - _owner_->getLikelihood().getNbFreePars()
+          << "Number of fit bins : " << getLikelihood().getNbFitBins() << std::endl
+          << "Chi2 # DoF : " << getLikelihood().getNbFitBins() - getLikelihood().getNbFreePars()
           << std::endl;
 
-  int nbFitCallOffset = _owner_->getLikelihood().getNbFitCalls();
+  int nbFitCallOffset = getLikelihood().getNbFitCalls();
   LogInfo << "Fit call offset: " << nbFitCallOffset << std::endl;
 
   if( _enableSimplexBeforeMinimize_ ){
@@ -210,9 +185,9 @@ void MinimizerInterface::minimize(){
     _minimizer_->SetStrategy(0);
 
     // SIMPLEX
-    _owner_->getLikelihood().enableFitMonitor();
+    getLikelihood().enableFitMonitor();
     _fitHasConverged_ = _minimizer_->Minimize();
-    _owner_->getLikelihood().disableFitMonitor();
+    getLikelihood().disableFitMonitor();
 
     // Back to original
     _minimizer_->Options().SetMinimizerAlgorithm(originalAlgo.c_str());
@@ -221,14 +196,14 @@ void MinimizerInterface::minimize(){
     _minimizer_->SetStrategy(_strategy_);
 
     LogInfo << getConvergenceMonitor().generateMonitorString(); // lasting printout
-    LogWarning << "Simplex ended after " << _owner_->getLikelihood().getNbFitCalls() - nbFitCallOffset << " calls." << std::endl;
+    LogWarning << "Simplex ended after " << getLikelihood().getNbFitCalls() - nbFitCallOffset << " calls." << std::endl;
   }
 
-  _owner_->getLikelihood().enableFitMonitor();
+  getLikelihood().enableFitMonitor();
   _fitHasConverged_ = _minimizer_->Minimize();
-  _owner_->getLikelihood().disableFitMonitor();
+  getLikelihood().disableFitMonitor();
 
-  int nbMinimizeCalls = _owner_->getLikelihood().getNbFitCalls() - nbFitCallOffset;
+  int nbMinimizeCalls = getLikelihood().getNbFitCalls() - nbFitCallOffset;
 
   LogInfo << getConvergenceMonitor().generateMonitorString(); // lasting printout
   LogInfo << "Minimization ended after " << nbMinimizeCalls << " calls." << std::endl;
@@ -240,24 +215,24 @@ void MinimizerInterface::minimize(){
   // Make sure we are on the right spot
   updateCacheToBestfitPoint();
 
-  _owner_->getLikelihood().saveChi2History();
+  getLikelihood().saveChi2History();
 
   if( _fitHasConverged_ ){ LogInfo << "Minimization has converged!" << std::endl; }
   else{ LogError << "Minimization did not converged." << std::endl; }
 
 
   LogInfo << "Writing convergence stats..." << std::endl;
-  int toyIndex = _owner_->getPropagator().getIThrow();
+  int toyIndex = getPropagator().getIThrow();
   int nIterations = int(_minimizer_->NIterations());
   int nFitPars = int(_minimizer_->NFree());
-  int nDof = _owner_->getLikelihood().getNbFitBins() - _owner_->getLikelihood().getNbFreePars();
+  int nDof = getLikelihood().getNbFitBins() - getLikelihood().getNbFreePars();
   double edmBestFit = _minimizer_->Edm();
   double fitStatus = _minimizer_->Status();
   double covStatus = _minimizer_->CovMatrixStatus();
   double chi2MinFitter = _minimizer_->MinValue();
-  int nbFreePars = _owner_->getLikelihood().getNbFreePars();
-  int nbFitCalls = _owner_->getLikelihood().getNbFitCalls();
-  int nbFitBins = _owner_->getLikelihood().getNbFitBins();
+  int nbFreePars = getLikelihood().getNbFreePars();
+  int nbFitCalls = getLikelihood().getNbFitCalls();
+  int nbFitBins = getLikelihood().getNbFitBins();
 
   auto bestFitStats = std::make_unique<TTree>("bestFitStats", "bestFitStats");
   bestFitStats->SetDirectory(nullptr);
@@ -273,25 +248,25 @@ void MinimizerInterface::minimize(){
   bestFitStats->Branch("nFreePars", &nbFreePars);
   bestFitStats->Branch("nFitPars", &nFitPars);
   bestFitStats->Branch("nDof", &nDof);
-  bestFitStats->Branch("chi2BestFit", _owner_->getPropagator().getLlhBufferPtr());
-  bestFitStats->Branch("chi2StatBestFit", _owner_->getPropagator().getLlhStatBufferPtr());
-  bestFitStats->Branch("chi2PullsBestFit", _owner_->getPropagator().getLlhPenaltyBufferPtr());
+  bestFitStats->Branch("chi2BestFit", getPropagator().getLlhBufferPtr());
+  bestFitStats->Branch("chi2StatBestFit", getPropagator().getLlhStatBufferPtr());
+  bestFitStats->Branch("chi2PullsBestFit", getPropagator().getLlhPenaltyBufferPtr());
 
-  std::vector<GenericToolbox::RawDataArray> samplesArrList(_owner_->getPropagator().getFitSampleSet().getFitSampleList().size());
+  std::vector<GenericToolbox::RawDataArray> samplesArrList(getPropagator().getFitSampleSet().getFitSampleList().size());
   int iSample{-1};
-  for( auto& sample : _owner_->getPropagator().getFitSampleSet().getFitSampleList() ){
+  for( auto& sample : getPropagator().getFitSampleSet().getFitSampleList() ){
     if( not sample.isEnabled() ) continue;
 
     std::vector<std::string> leavesDict;
     iSample++;
 
     leavesDict.emplace_back("llhSample/D");
-    samplesArrList[iSample].writeRawData(_owner_->getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample));
+    samplesArrList[iSample].writeRawData(getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample));
 
     int nBins = int(sample.getBinning().getBinsList().size());
     for( int iBin = 1 ; iBin <= nBins ; iBin++ ){
       leavesDict.emplace_back("llhSample_bin" + std::to_string(iBin) + "/D");
-      samplesArrList[iSample].writeRawData(_owner_->getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample, iBin));
+      samplesArrList[iSample].writeRawData(getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample, iBin));
     }
 
     samplesArrList[iSample].lockArraySize();
@@ -302,9 +277,9 @@ void MinimizerInterface::minimize(){
     );
   }
 
-  std::vector<GenericToolbox::RawDataArray> parameterSetArrList(_owner_->getPropagator().getParameterSetsList().size());
+  std::vector<GenericToolbox::RawDataArray> parameterSetArrList(getPropagator().getParameterSetsList().size());
   int iParSet{-1};
-  for( auto& parSet : _owner_->getPropagator().getParameterSetsList() ){
+  for( auto& parSet : getPropagator().getParameterSetsList() ){
     if( not parSet.isEnabled() ) continue;
 
     std::vector<std::string> leavesDict;
@@ -326,24 +301,24 @@ void MinimizerInterface::minimize(){
   }
 
   bestFitStats->Fill();
-  GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "postFit")->WriteObject(bestFitStats.get(), bestFitStats->GetName());
+  GenericToolbox::mkdirTFile(owner().getSaveDir(), "postFit")->WriteObject(bestFitStats.get(), bestFitStats->GetName());
 
   LogInfo << "Writing " << _minimizerType_ << "/" << _minimizerAlgo_ << " post-fit errors" << std::endl;
-  this->writePostFitData(GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "postFit/" + _minimizerAlgo_));
-  GenericToolbox::triggerTFileWrite(GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "postFit/" + _minimizerAlgo_));
+  this->writePostFitData(GenericToolbox::mkdirTFile(owner().getSaveDir(), "postFit/" + _minimizerAlgo_));
+  GenericToolbox::triggerTFileWrite(GenericToolbox::mkdirTFile(owner().getSaveDir(), "postFit/" + _minimizerAlgo_));
 }
 void MinimizerInterface::calcErrors(){
   LogThrowIf(not isInitialized(), "not initialized");
 
-  int nbFitCallOffset = _owner_->getLikelihood().getNbFitCalls();
+  int nbFitCallOffset = getLikelihood().getNbFitCalls();
 
   LogWarning << std::endl << GenericToolbox::addUpDownBars("Calling HESSE...") << std::endl;
   LogInfo << "Number of defined parameters: " << _minimizer_->NDim() << std::endl
           << "Number of fit parameters   : " << _minimizer_->NFree() << std::endl
-          << "Number of free parameters : " << _owner_->getLikelihood().getNbFreePars() << std::endl
+          << "Number of free parameters : " << getLikelihood().getNbFreePars() << std::endl
           << "Number of fixed parameters  : " << _minimizer_->NDim() - _minimizer_->NFree() << std::endl
-          << "Number of fit bins : " << _owner_->getLikelihood().getNbFitBins() << std::endl
-          << "Chi2 # DoF : " << _owner_->getLikelihood().getNbFitBins() - _owner_->getLikelihood().getNbFreePars()  << std::endl
+          << "Number of fit bins : " << getLikelihood().getNbFitBins() << std::endl
+          << "Chi2 # DoF : " << getLikelihood().getNbFitBins() - getLikelihood().getNbFreePars()  << std::endl
           << "Fit call offset: " << nbFitCallOffset << std::endl;
 
   if     ( _errorAlgo_ == "Minos" ){
@@ -355,9 +330,9 @@ void MinimizerInterface::calcErrors(){
     for( int iFitPar = 0 ; iFitPar < _minimizer_->NDim() ; iFitPar++ ){
       LogInfo << "Evaluating: " << _minimizer_->VariableName(iFitPar) << "..." << std::endl;
 
-      _owner_->getLikelihood().enableFitMonitor();
+      getLikelihood().enableFitMonitor();
       bool isOk = _minimizer_->GetMinosError(iFitPar, errLow, errHigh);
-      _owner_->getLikelihood().disableFitMonitor();
+      getLikelihood().disableFitMonitor();
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,23,02)
       LogWarning << minosStatusCodeStr.at(_minimizer_->MinosStatus()) << std::endl;
@@ -382,16 +357,16 @@ void MinimizerInterface::calcErrors(){
       LogWarning << "Restoring step size before HESSE..." << std::endl;
       for( int iFitPar = 0 ; iFitPar < _minimizer_->NDim() ; iFitPar++ ){
         auto& par = *getMinimizerFitParameterPtr()[iFitPar];
-        if(not _useNormalizedFitSpace_){ _minimizer_->SetVariableStepSize(iFitPar, par.getStepSize()); }
+        if(not getLikelihood().getUseNormalizedFitSpace()){ _minimizer_->SetVariableStepSize(iFitPar, par.getStepSize()); }
         else{ _minimizer_->SetVariableStepSize(iFitPar, FitParameterSet::toNormalizedParRange(par.getStepSize(), par)); } // should be 1
       }
     }
 
-    _owner_->getLikelihood().enableFitMonitor();
+    getLikelihood().enableFitMonitor();
     _fitHasConverged_ = _minimizer_->Hesse();
-    _owner_->getLikelihood().disableFitMonitor();
+    getLikelihood().disableFitMonitor();
 
-    LogInfo << "Hesse ended after " << _owner_->getLikelihood().getNbFitCalls() - nbFitCallOffset << " calls." << std::endl;
+    LogInfo << "Hesse ended after " << getLikelihood().getNbFitCalls() - nbFitCallOffset << " calls." << std::endl;
     LogWarning << "HESSE status code: " << hesseStatusCodeStr.at(_minimizer_->Status()) << std::endl;
     LogWarning << "Covariance matrix status code: " << covMatrixStatusCodeStr.at(_minimizer_->CovMatrixStatus()) << std::endl;
 
@@ -410,8 +385,8 @@ void MinimizerInterface::calcErrors(){
     }
 
     LogInfo << "Writing HESSE post-fit errors" << std::endl;
-    this->writePostFitData(GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "postFit/Hesse"));
-    GenericToolbox::triggerTFileWrite(GenericToolbox::mkdirTFile(_owner_->getSaveDir(), "postFit/Hesse"));
+    this->writePostFitData(GenericToolbox::mkdirTFile(owner().getSaveDir(), "postFit/Hesse"));
+    GenericToolbox::triggerTFileWrite(GenericToolbox::mkdirTFile(owner().getSaveDir(), "postFit/Hesse"));
   }
   else{
     LogError << GET_VAR_NAME_VALUE(_errorAlgo_) << " not implemented." << std::endl;
@@ -620,14 +595,14 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
       };
 
       int nGlobalPars{0};
-      for( const auto& parSet : _owner_->getPropagator().getParameterSetsList() ){ if( parSet.isEnabled() ) nGlobalPars += int(parSet.getNbParameters()); }
+      for( const auto& parSet : getPropagator().getParameterSetsList() ){ if( parSet.isEnabled() ) nGlobalPars += int(parSet.getNbParameters()); }
 
       // Reconstruct the global passage matrix
       std::vector<std::string> parameterLabels(nGlobalPars);
       auto globalPassageMatrix = std::make_unique<TMatrixD>(nGlobalPars, nGlobalPars);
       for(int i = 0 ; i < nGlobalPars; i++ ){ (*globalPassageMatrix)[i][i] = 1; }
       int blocOffset{0};
-      for( const auto& parSet : _owner_->getPropagator().getParameterSetsList() ){
+      for( const auto& parSet : getPropagator().getParameterSetsList() ){
         if( not parSet.isEnabled() ) continue;
 
         auto* parList = &parSet.getParameterList(); // we want the original names
@@ -652,7 +627,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
       // Reconstruct the global cov matrix (including eigen decomp parameters)
       auto unstrippedCovMatrix = std::make_unique<TMatrixD>(nGlobalPars, nGlobalPars);
       int iOffset{0};
-      for( const auto& iParSet : _owner_->getPropagator().getParameterSetsList() ){
+      for( const auto& iParSet : getPropagator().getParameterSetsList() ){
         if( not iParSet.isEnabled() ) continue;
 
         auto* iParList = &iParSet.getEffectiveParameterList();
@@ -660,7 +635,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
             int iMinimizerIndex = GenericToolbox::findElementIndex((FitParameter*) &iPar, getMinimizerFitParameterPtr());
 
           int jOffset{0};
-          for( const auto& jParSet : _owner_->getPropagator().getParameterSetsList() ){
+          for( const auto& jParSet : getPropagator().getParameterSetsList() ){
             if( not jParSet.isEnabled() ) continue;
 
             auto* jParList = &jParSet.getEffectiveParameterList();
@@ -729,7 +704,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
 
   };
 
-  if( _useNormalizedFitSpace_ ){
+  if( getLikelihood().getUseNormalizedFitSpace() ){
     LogInfo << "Writing normalized decomposition of the output matrix..." << std::endl;
     decomposeCovarianceMatrixFct(GenericToolbox::mkdirTFile(matricesDir, "normalizedFitSpace"));
 
@@ -909,7 +884,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
             } // norm
           } // par
 
-          if( _owner_->getPropagator().isThrowAsimovToyParameters() ){
+          if( getPropagator().isThrowAsimovToyParameters() ){
             bool draw{false};
 
             for( auto& par : parList_ ){
@@ -1021,7 +996,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
       }; // savePostFitObjFct
 
   LogInfo << "Extracting post-fit errors..." << std::endl;
-  for( const auto& parSet : _owner_->getPropagator().getParameterSetsList() ){
+  for( const auto& parSet : getPropagator().getParameterSetsList() ){
     if( not parSet.isEnabled() ){ continue; }
 
     LogInfo << "Extracting post-fit errors of parameter set: " << parSet.getName() << std::endl;
@@ -1083,7 +1058,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
 void MinimizerInterface::updateCacheToBestfitPoint(){
   if( _minimizer_->X() != nullptr ){
     LogWarning << "Updating propagator cache to the best fit point..." << std::endl;
-    _owner_->getLikelihood().evalFit( _minimizer_->X() );
+    getLikelihood().evalFit( _minimizer_->X() );
   }
   else{
     LogAlert << "No best fit point provided by minimized." << std::endl;


### PR DESCRIPTION
Refactor `MinimizerInterface` to use a base class `MinimizerBase`.  The `MinimizerBase` is essentially an ABC, but does include a bit of glue code to handle YAML fields that are common across all possible minimizers (e.g. the monitor settings).  This also does a small bit of refactoring to move some of the `FitterEngine` code so that it doesn't assume that `MinimizerInterface` is being used with Minuit.

The external behavior of `FitterEngine` hasn't changed, and the public API has stayed the same.  There are some minor internal changes to support the refactoring.  This passes `gundam-tests.sh` on a local machine.
