### PR TITLE
Feature: Command line overrides

### DIFF
--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -99,9 +99,14 @@ void MCMCInterface::readConfigImpl(){
     _config_, "burninWindow", _burninWindow_);
 
   // Set the name of a file containing a previous sequence of the chain.  This
-  // restores the state from the end of the chain and continues.  This should
-  // also be settable from the command line (setting from the command line is
-  // the better option).
+  // restores the state from the end of the chain and continues.  This is also
+  // be settable from the command line (setting from the command line is the
+  // better option) using the override option
+  //
+  // "-O /fitterEngineConfig/mcmcConfig/adaptiveRestore=<filename>"
+  //
+  // If restore is going to be used, the adaptiveRestore value must exist in
+  // the configuration file (with a NULL value)
   _adaptiveRestore_ = GenericToolbox::Json::fetchValue(
     _config_, "adaptiveRestore", _adaptiveRestore_);
 
@@ -276,22 +281,22 @@ void MCMCInterface::setupAndRunAdaptiveStep(
   mcmc.SetStepRMSWindow(_adaptiveWindow_);
 
   // Restore the chain if exist
-  if (!_adaptiveRestore_.empty()) {
+  if (!_adaptiveRestore_.empty() && _adaptiveRestore_ != "none") {
     // Check for restore file
     LogInfo << "Restore from: " << _adaptiveRestore_ << std::endl;
     std::unique_ptr<TFile> restoreFile
       (new TFile(_adaptiveRestore_.c_str(), "old"));
-    if (!restoreFile) {
-      LogInfo << "File to restore was not openned: "
+    if (!restoreFile || !restoreFile->IsOpen()) {
+      LogInfo << "File to restore was is found: "
               << _adaptiveRestore_ << std::endl;
-      std::runtime_error("Old state file not open");
+      throw std::runtime_error("Old state file not open");
     }
     std::string treeName = "FitterEngine/fit/" + _outTreeName_;
     TTree* restoreTree = (TTree*) restoreFile->Get(treeName.c_str());
     if (!restoreTree) {
       LogInfo << "Tree to restore state is not found"
               << treeName << std::endl;
-      std::runtime_error("Old state tree not open");
+      throw std::runtime_error("Old state tree not open");
     }
     // Set the deweighting to zero so the previous state is directly used.
     mcmc.GetProposeStep().SetCovarianceUpdateDeweighting(0.0);

--- a/tests/extended-tests/200NormalizationMCMC-config.yaml
+++ b/tests/extended-tests/200NormalizationMCMC-config.yaml
@@ -17,6 +17,8 @@ fitterEngineConfig:
   mcmcConfig:
     algorithm: metropolis
     proposal: adaptive
+    adaptiveRestore: none
+    
     burninCycles: 4
     burninSteps: 1000
     burninResets: 1


### PR DESCRIPTION
Allow configuration file values to be *carefully* overridden from the command line.

An `--override key=value` command line option is added to allow particular key values in the configuration files to be overridden at the run-time.  The short option is `-O key=value`. 

Since this should not be used to rewrite a configuration, keys cannot be added to the configuration, but must exist in the original configuration file.  Examples of when this might be useful

* Change the /fitterEngineConfig/engineType between minimizer and mcmc. 
  * To select the minimizer use `--override /fitterEngineConfig/engineType=minimizer`
  * To select the mcmc use `--override /fitterEngineConfig/engineType=mcmc`
  * This override is enabled by explicitly adding the `engineType` field to the `fitterEngineConfig` in the input configuration files. 
* Set an input root file to restore the mcmc state
* Change the minimizer tolerance
* Et cetera

The override happens immediately after reading the configuration files, and before the configuration is used.  That means it's transparent to the rest of gundam.  The configuration used for the job is saved in the output file.  The saved configuration reflects the configuration actually used (including the effect of the command line overrides).

Also included: This debugs the interface to the MCMC restore functionality.  That had problems with not properly restoring the current root file and directory after the state was restored.