### PR TITLE
Fix/deprecate old dials API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ option(TTYCHECK "Enable check if output is being sent to terminal/TTY." ON)
 option(WITH_OPENMP "(OLD) Build with OpenMP libraries" OFF )
 option(WITH_CACHE_MANAGER "Build with precalculated weight cache" OFF)
 option(WITH_GENERIC_SPLINES "Do not solely depend on ROOT TSpline3" OFF)
-option(WITH_OLD_DIALS "Use the old dial implementation" ON)
+option(WITH_OLD_DIALS "Use the old dial implementation" OFF)
 option(DISABLE_CUDA "Disable CUDA language check (enable for testing only)" OFF)
 option(YAMLCPP_DIR "Set custom path to yaml-cpp lib" OFF )
 option(ENABLE_DEV_MODE "Enable specific dev related printouts" OFF )
@@ -251,6 +251,8 @@ endif(NOT WITH_GENERIC_SPLINES)
 
 if(NOT WITH_OLD_DIALS)
     add_definitions(-D USE_NEW_DIALS=1)
+else()
+    cmessage(WARNING "Using old dial implementation")
 endif(NOT WITH_OLD_DIALS)
   
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(WITH_OPENMP "(OLD) Build with OpenMP libraries" OFF )
 option(WITH_CACHE_MANAGER "Build with precalculated weight cache" OFF)
 option(WITH_GENERIC_SPLINES "Do not solely depend on ROOT TSpline3" OFF)
 option(WITH_OLD_DIALS "Use the old dial implementation" OFF)
+option(WITH_BREAKDOWN_CACHE "Use the breakdown cache" ON)
 option(DISABLE_CUDA "Disable CUDA language check (enable for testing only)" OFF)
 option(YAMLCPP_DIR "Set custom path to yaml-cpp lib" OFF )
 option(ENABLE_DEV_MODE "Enable specific dev related printouts" OFF )
@@ -254,6 +255,12 @@ if(NOT WITH_OLD_DIALS)
 else()
     cmessage(WARNING "Using old dial implementation")
 endif(NOT WITH_OLD_DIALS)
+  
+if(WITH_BREAKDOWN_CACHE)
+    add_definitions(-D USE_BREAKDOWN_CACHE)
+else()
+    cmessage(WARNING "Not using breakdown cache")
+endif(WITH_BREAKDOWN_CACHE)
   
 ################################################################################
 #                       SubModules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(TTYCHECK "Enable check if output is being sent to terminal/TTY." ON)
 option(WITH_OPENMP "(OLD) Build with OpenMP libraries" OFF )
 option(WITH_CACHE_MANAGER "Build with precalculated weight cache" OFF)
 option(WITH_GENERIC_SPLINES "Do not solely depend on ROOT TSpline3" OFF)
+option(WITH_OLD_DIALS "Use the old dial implementation" ON)
 option(DISABLE_CUDA "Disable CUDA language check (enable for testing only)" OFF)
 option(YAMLCPP_DIR "Set custom path to yaml-cpp lib" OFF )
 option(ENABLE_DEV_MODE "Enable specific dev related printouts" OFF )
@@ -18,7 +19,6 @@ option(BATCH_MODE "Build to run in a batch queue (affects output)" OFF)
 option(BUILD_DOC "Build documentation" OFF)
 option(WITH_XSLLHFITTER "Build old xsllhFitter apps/libraries" OFF)
 option(USE_STATIC_LINKS "Library build in static mod" OFF)
-
 
 # Cmake includes
 include(CTest)
@@ -61,10 +61,6 @@ else()
     cmessage(WARNING "Bad exit status")
     set (GUNDAM_VERSION_STRING "X.X.X")
 endif()
-
-
-
-
 
 set(VERBOSE TRUE)
 
@@ -112,7 +108,6 @@ if(NOT DEFINED CMAKE_BUILD_TYPE
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 cmessage(STATUS "CMAKE_BUILD_TYPE: \"${CMAKE_BUILD_TYPE}\"")
-
 
 if(BATCH_MODE)
     set(COLOR_OUTPUT NO)
@@ -229,8 +224,6 @@ else()
     add_definitions( -D USE_ZLIB=0 )
 endif ()
 
-
-
 if (WITH_CACHE_MANAGER)
     add_definitions( -DGUNDAM_USING_CACHE_MANAGER)
 
@@ -243,7 +236,9 @@ if (WITH_CACHE_MANAGER)
         add_definitions( -DCACHE_MANAGER_SLOW_VALIDATION)
     endif (CACHE_MANAGER_SLOW_VALIDATION)
 
-    cmessage(STATUS "Enable GPU support (compiled, but only used when CUDA enabled)")
+    cmessage(STATUS "GPU support is enabled (compiled, but only used when CUDA enabled)")
+else()
+    cmessage(STATUS "GPU support is disabled")
 endif()
 
 if(NOT WITH_GENERIC_SPLINES)
@@ -254,6 +249,10 @@ if(NOT WITH_GENERIC_SPLINES)
     endif(WITH_CACHE_MANAGER)
 endif(NOT WITH_GENERIC_SPLINES)
 
+if(NOT WITH_OLD_DIALS)
+    add_definitions(-D USE_NEW_DIALS=1)
+endif(NOT WITH_OLD_DIALS)
+  
 ################################################################################
 #                       SubModules
 ################################################################################
@@ -418,18 +417,17 @@ endif()
 #                            Specify Target Subdirs
 ################################################################################
 
-set( MODULES
-    Utils
-    DialDictionary
-    FitParameters
-    FitSamples
-    DatasetManager
-    Propagator
-    Fitter
-    )
+set( MODULES Utils)
+
+# Add the basic modules
+list( APPEND MODULES DialDictionary)
+list( APPEND MODULES FitParameters)
+list( APPEND MODULES FitSamples)
+list( APPEND MODULES DatasetManager)
+list( APPEND MODULES Propagator)
+list( APPEND MODULES Fitter)
 
 if(WITH_CACHE_MANAGER)
-    cmessage (STATUS "Adding cmake module: CacheManager")
     list( APPEND MODULES CacheManager )
 endif()
 

--- a/cmake/gundam-build.sh
+++ b/cmake/gundam-build.sh
@@ -55,6 +55,7 @@ RUN_CLEAN="no"
 RUN_TEST="no"
 DEFINES=" -DCMAKE_INSTALL_PREFIX=${GUNDAM_INSTALL} "
 DEFINES="${DEFINES} -DCMAKE_EXPORT_COMPILE_COMMANDS=1 "
+MAKE_OPTIONS=" -j1 "
 while [ "x${1}" != "x" ]; do
     case ${1} in
         fo*) # force
@@ -76,6 +77,11 @@ while [ "x${1}" != "x" ]; do
             shift
             echo Clean the build area
             RUN_CLEAN="yes"
+            ;;
+        ke*) # Keep going
+            shift
+            echo Continue on errors
+            MAKE_OPTIONS=" -k ${MAKE_OPTIONS}"
             ;;
         te*) # test
             shift
@@ -113,7 +119,7 @@ fi
 
 if [ ${RUN_CLEAN} = "yes" ]; then
     echo make clean
-    make clean
+    make ${MAKE_OPTIONS} clean
     echo Source cleaned.
 fi
 
@@ -121,14 +127,14 @@ if [ ${ONLY_CMAKE} = "yes" ]; then
     exit 0
 fi
 
-echo make -j1
-make -j1 || exit 1
+echo make ${MAKE_OPTIONS}
+make ${MAKE_OPTIONS} || exit 1
 echo make install
-make install || exit 1
+make ${MAKE_OPTIONS} install || exit 1
 
 if [ ${RUN_TEST} = "yes" ]; then
     echo make test
-    make test || exit 1
+    make ${MAKE_OPTIONS} test || exit 1
 fi
 
 echo "build:       " ${BUILD_LOCATION}

--- a/src/DatasetManager/include/DataDispenser.h
+++ b/src/DatasetManager/include/DataDispenser.h
@@ -7,6 +7,9 @@
 
 #include "EventVarTransformLib.h"
 #include "FitSampleSet.h"
+#ifndef USE_NEW_DIALS
+#include "DialSet.h"
+#endif
 #include "FitParameterSet.h"
 #include "PlotGenerator.h"
 #include "JsonBaseClass.h"
@@ -55,7 +58,9 @@ struct DataDispenserCache{
   std::vector<std::vector<bool>> eventIsInSamplesList{};
   std::vector<GenericToolbox::CopiableAtomic<size_t>> sampleIndexOffsetList;
   std::vector< std::vector<PhysicsEvent>* > sampleEventListPtrToFill;
+#ifndef USE_NEW_DIALS
   std::map<FitParameterSet*, std::vector<DialSet*>> dialSetPtrMap;
+#endif
   std::vector<DialCollection*> dialCollectionsRefList{};
 
   std::vector<std::string> varsRequestedForIndexing{};
@@ -74,7 +79,9 @@ struct DataDispenserCache{
 
     sampleIndexOffsetList.clear();
     sampleEventListPtrToFill.clear();
+#ifndef USE_NEW_DIALS
     dialSetPtrMap.clear();
+#endif
 
     varsRequestedForIndexing.clear();
     varsRequestedForStorage.clear();

--- a/src/DatasetManager/src/DatasetLoader.cpp
+++ b/src/DatasetManager/src/DatasetLoader.cpp
@@ -4,10 +4,7 @@
 
 #include "DatasetLoader.h"
 
-#include "DialSet.h"
 #include "GlobalVariables.h"
-#include "GraphDial.h"
-#include "SplineDial.h"
 #include "GenericToolbox.Json.h"
 
 #include "GenericToolbox.h"

--- a/src/DialDictionary/src/DialCollection.cpp
+++ b/src/DialDictionary/src/DialCollection.cpp
@@ -2,6 +2,7 @@
 // Created by Adrien Blanchet on 29/11/2022.
 //
 
+#include "GlobalVariables.h"
 #include "DialCollection.h"
 #include "DialTypes.h"
 
@@ -673,7 +674,3 @@ nlohmann::json DialCollection::fetchDialsDefinition(const nlohmann::json &defini
   }
   return {};
 }
-
-
-
-

--- a/src/FitParameters/include/Dial.h
+++ b/src/FitParameters/include/Dial.h
@@ -18,6 +18,11 @@
 #include "mutex"
 #include "memory"
 
+#ifdef USE_NEW_DIALS
+#define DEPRECATED [[deprecated("Not used with new dial implementation")]]
+#else
+#define DEPRECATED /*[[deprecated("Not used with new dial implementation")]]*/
+#endif
 
 namespace DialType{
   ENUM_EXPANDER(
@@ -32,7 +37,7 @@ namespace DialType{
 class DialSet; // owner
 class DialWrapper;
 
-class Dial {
+class DEPRECATED Dial {
 
 public:
   // Don't check the mask everytime since it is memory delocalized

--- a/src/FitParameters/include/DialSet.h
+++ b/src/FitParameters/include/DialSet.h
@@ -19,8 +19,13 @@
 #include "vector"
 #include "memory"
 
-
 class FitParameter;
+
+#ifdef USE_NEW_DIALS
+#define DEPRECATED [[deprecated("Not used with new dial implementation")]]
+#else
+#define DEPRECATED /*[[deprecated("Not used with new dial implementation")]]*/
+#endif
 
 class DialSet : public JsonBaseClass {
 

--- a/src/FitParameters/include/DialWrapper.h
+++ b/src/FitParameters/include/DialWrapper.h
@@ -12,8 +12,13 @@
 #include <vector>
 #include "type_traits"
 
+#ifdef USE_NEW_DIALS
+#define DEPRECATED [[deprecated("Not used with new dial implementation")]]
+#else
+#define DEPRECATED /*[[deprecated("Not used with new dial implementation")]]*/
+#endif
 
-class DialWrapper{
+class DEPRECATED DialWrapper{
 public:
   DialWrapper() = default;
 

--- a/src/FitParameters/include/FitParameterSet.h
+++ b/src/FitParameters/include/FitParameterSet.h
@@ -6,7 +6,9 @@
 #define GUNDAM_FITPARAMETERSET_H
 
 #include "FitParameter.h"
+#ifndef USE_NEW_DIALS
 #include "NestedDialTest.h"
+#endif
 #include "JsonBaseClass.h"
 #include "ParameterThrowerMarkHarz.h"
 
@@ -95,7 +97,9 @@ protected:
 private:
   // Internals
   std::vector<FitParameter> _parameterList_;
+#ifndef USE_NEW_DIALS
   std::vector<NestedDialTest> _nestedDialList_;
+#endif
 
   // JSON
   std::string _name_{};

--- a/src/FitParameters/include/GraphDial.h
+++ b/src/FitParameters/include/GraphDial.h
@@ -9,6 +9,10 @@
 
 #include "Dial.h"
 
+#ifdef USE_NEW_DIALS
+#warning Not used with new dial implementation
+#endif
+
 class GraphDial : public Dial {
 
 public:

--- a/src/FitParameters/include/NestedDialTest.h
+++ b/src/FitParameters/include/NestedDialTest.h
@@ -15,6 +15,10 @@
 #include "vector"
 #include "string"
 
+#ifdef USE_NEW_DIALS
+#warning Not used with new dial implementation
+#endif
+
 class NestedDialTest {
 
 public:

--- a/src/FitParameters/include/NormDial.h
+++ b/src/FitParameters/include/NormDial.h
@@ -9,6 +9,9 @@
 
 #include "memory"
 
+#ifdef USE_NEW_DIALS
+#warning Not used with new dial implementation
+#endif
 
 class NormDial : public Dial {
 

--- a/src/FitParameters/include/SplineDial.h
+++ b/src/FitParameters/include/SplineDial.h
@@ -12,6 +12,10 @@
 #include "memory"
 #include "string"
 
+#ifdef USE_NEW_DIALS
+#warning Not used with new dial implementation
+#endif
+
 class SplineDial : public Dial {
 
 public:

--- a/src/FitParameters/src/Dial.cpp
+++ b/src/FitParameters/src/Dial.cpp
@@ -2,13 +2,19 @@
 // Created by Nadrino on 21/05/2021.
 //
 
-#include "Dial.h"
-#include "DialSet.h"
 #include "FitParameterSet.h"
 
 #include "Logger.h"
 
 #include "sstream"
+
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
+#include "Dial.h"
+#include "DialSet.h"
 
 LoggerInit([]{
   Logger::setUserHeaderStr("[Dial]");
@@ -161,6 +167,3 @@ std::string Dial::getSummary(){
 //      new TSpline3(Form("%p", this), &xSigmaSteps[0], &yResponse[0], int(xSigmaSteps.size()))
 //  );
 //}
-
-
-

--- a/src/FitParameters/src/DialSet.cpp
+++ b/src/FitParameters/src/DialSet.cpp
@@ -2,11 +2,7 @@
 // Created by Nadrino on 21/05/2021.
 //
 
-#include "DialSet.h"
 #include "DataBinSet.h"
-#include "NormDial.h"
-#include "SplineDial.h"
-#include "GraphDial.h"
 #include "FitParameter.h"
 
 #include "Logger.h"
@@ -17,6 +13,15 @@
 #include "TFile.h"
 #include "TTree.h"
 
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
+#include "DialSet.h"
+#include "NormDial.h"
+#include "SplineDial.h"
+#include "GraphDial.h"
 
 bool DialSet::verboseMode{false};
 

--- a/src/FitParameters/src/FitParameterSet.cpp
+++ b/src/FitParameters/src/FitParameterSet.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "FitParameterSet.h"
+#include "DataBinSet.h"
 
 #include "GlobalVariables.h"
 #include "ParameterThrowerMarkHarz.h"

--- a/src/FitParameters/src/GraphDial.cpp
+++ b/src/FitParameters/src/GraphDial.cpp
@@ -2,6 +2,11 @@
 // Created by Adrien BLANCHET on 02/12/2021.
 //
 
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
 #include "GraphDial.h"
 #include "DialSet.h"
 
@@ -41,4 +46,3 @@ void GraphDial::setGraph(const TGraph &graph) {
   _graph_ = graph;
   _graph_.Sort();
 }
-

--- a/src/FitParameters/src/NestedDialTest.cpp
+++ b/src/FitParameters/src/NestedDialTest.cpp
@@ -2,6 +2,11 @@
 // Created by Adrien BLANCHET on 22/03/2022.
 //
 
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
 #include "NestedDialTest.h"
 
 #include "Logger.h"
@@ -54,4 +59,3 @@ void NestedDialTest::updateDialResponseCache(const std::vector<Dial*>& dialRefLi
     (*valIt) = (*dialIt)->evalResponse();
   }
 }
-

--- a/src/FitParameters/src/NormDial.cpp
+++ b/src/FitParameters/src/NormDial.cpp
@@ -2,9 +2,15 @@
 // Created by Nadrino on 26/05/2021.
 //
 
+#include "FitParameter.h"
+
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
 #include "NormDial.h"
 #include "DialSet.h"
-#include "FitParameter.h"
 
 #include "Logger.h"
 
@@ -29,4 +35,3 @@ std::string NormDial::getSummary() {
 
 double NormDial::evalResponse(double parameterValue_){ return this->capDialResponse(this->calcDial(parameterValue_)); } // no cache
 double NormDial::calcDial(double parameterValue_){ return parameterValue_; }
-

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -5,6 +5,7 @@
 
 #include "FitParameter.h"
 #include "SplineDial.h"
+#include "DialSet.h"
 #ifndef USE_TSPLINE3_EVAL
 #include "CalculateMonotonicSpline.h"
 #include "CalculateUniformSpline.h"

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -2,15 +2,21 @@
 // Created by Nadrino on 26/05/2021.
 //
 
-
 #include "FitParameter.h"
-#include "SplineDial.h"
-#include "DialSet.h"
+
 #ifndef USE_TSPLINE3_EVAL
 #include "CalculateMonotonicSpline.h"
 #include "CalculateUniformSpline.h"
 #include "CalculateGeneralSpline.h"
 #endif
+
+// Unset for this file since the entire file is deprecated.
+#ifdef USE_NEW_DIALS
+#undef USE_NEW_DIALS
+#endif
+
+#include "SplineDial.h"
+#include "DialSet.h"
 
 #include "Logger.h"
 #include "GenericToolbox.Root.h"

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -96,7 +96,7 @@ double SplineDial::calcDial(double parameterValue_) {
           _splineData_.data(), int(_splineData_.size()));
   }
   else if (_splineType_ == SplineDial::ROOTSpline) {
-      dialResponse = _graph_.Eval(parameterValue_);
+      dialResponse = _spline_.Eval(parameterValue_);
   }
   else {
       LogThrow("Must have a spline type defined");
@@ -106,7 +106,7 @@ double SplineDial::calcDial(double parameterValue_) {
   #ifdef SPLINE_DIAL_SLOW_VALIDATION
   #error Remove this to compile with validation.
   do {
-      double testVal = _graph_.Eval(parameterValue_);
+      double testVal = _spline_.Eval(parameterValue_);
       double avg = std::abs(testVal);
       if (avg < 1.0) avg = 1.0;
       double delta = std::abs(testVal-dialResponse)/avg;
@@ -139,15 +139,15 @@ void SplineDial::writeSpline(const std::string &fileName_) const{
 void SplineDial::fastEval(){
     //Function takes a spline with equidistant knots and the number of steps
     //between knots to evaluateSpline the spline at some position 'pos'.
-    fs.l = int((parameterValue_ - _graph_.GetXmin())
+    fs.l = int((parameterValue_ - _spline_.GetXmin())
                / fs.stepsize) + 1;
 
-    _graph_.GetCoeff(fs.l, fs.x, fs.y, fs.b, fs.c, fs.d);
+    _spline_.GetCoeff(fs.l, fs.x, fs.y, fs.b, fs.c, fs.d);
     fs.num = parameterValue_ - fs.x;
 
     if (fs.num < 0){
         fs.l -= 1;
-        _graph_.GetCoeff(fs.l, fs.x, fs.y, fs.b, fs.c, fs.d);
+        _spline_.GetCoeff(fs.l, fs.x, fs.y, fs.b, fs.c, fs.d);
         fs.num = parameterValue_ - fs.x;
     }
     _dialResponseCache_ = (fs.y + fs.num * fs.b + fs.num * fs.num * fs.c + fs.num * fs.num * fs.num * fs.d);
@@ -166,15 +166,15 @@ void SplineDial::fillSplineData() {
     // Check if the spline has uniformly spaced knots.  There is a flag for
     // this is TSpline3, but it's not uniformly (or ever) filled correctly.
     bool uniform = true;
-    for (int i = 1; i < _graph_.GetNp()-1; ++i) {
+    for (int i = 1; i < _spline_.GetNp()-1; ++i) {
         double x;
         double y;
-        _graph_.GetKnot(i-1,x,y);
+        _spline_.GetKnot(i-1,x,y);
         double d1 = x;
-        _graph_.GetKnot(i,x,y);
+        _spline_.GetKnot(i,x,y);
         d1 = x - d1;
         double d2 = x;
-        _graph_.GetKnot(i+1,x,y);
+        _spline_.GetKnot(i+1,x,y);
         d2 = x - d2;
         if (std::abs((d1-d2)/(d1+d2)) > 1E-6) {
             uniform = false;
@@ -203,13 +203,13 @@ bool SplineDial::fillMonotonicSpline(bool uniformKnots) {
     _splineType_ = SplineDial::Monotonic;
 
     // Copy the spline data into local storage.
-    _splineData_.push_back(_graph_.GetXmin());
-    _splineData_.push_back((_graph_.GetXmax()-_graph_.GetXmin())
-                           /(_graph_.GetNp()-1.0));
-    for (int i = 0; i < _graph_.GetNp(); ++i) {
+    _splineData_.push_back(_spline_.GetXmin());
+    _splineData_.push_back((_spline_.GetXmax()-_spline_.GetXmin())
+                           /(_spline_.GetNp()-1.0));
+    for (int i = 0; i < _spline_.GetNp(); ++i) {
         double x;
         double y;
-        _graph_.GetKnot(i,x,y);
+        _spline_.GetKnot(i,x,y);
         _splineData_.push_back(y);
     }
     return true;
@@ -219,15 +219,15 @@ bool SplineDial::fillNaturalSpline(bool uniformKnots) {
     else _splineType_ = SplineDial::General;
 
     // Copy the spline data into local storage.
-    _splineData_.push_back(_graph_.GetXmin());
-    _splineData_.push_back((_graph_.GetXmax()-_graph_.GetXmin())
-                           /(_graph_.GetNp()-1.0));
-    for (int i = 0; i < _graph_.GetNp(); ++i) {
+    _splineData_.push_back(_spline_.GetXmin());
+    _splineData_.push_back((_spline_.GetXmax()-_spline_.GetXmin())
+                           /(_spline_.GetNp()-1.0));
+    for (int i = 0; i < _spline_.GetNp(); ++i) {
         double x;
         double y;
-        _graph_.GetKnot(i,x,y);
+        _spline_.GetKnot(i,x,y);
         _splineData_.push_back(y);
-         _splineData_.push_back(_graph_.Derivative(x));
+         _splineData_.push_back(_spline_.Derivative(x));
          if (_splineType_ == SplineDial::Uniform) continue;
         _splineData_.push_back(x);
     }

--- a/src/FitSamples/include/PhysicsEvent.h
+++ b/src/FitSamples/include/PhysicsEvent.h
@@ -6,8 +6,11 @@
 #define GUNDAM_PHYSICSEVENT_H
 
 #include "FitParameterSet.h"
+
+#ifndef USE_NEW_DIALS
 #include "Dial.h"
 #include "NestedDialTest.h"
+#endif
 
 #include "GenericToolbox.Root.TreeEntryBuffer.h"
 #include "GenericToolbox.Root.LeafHolder.h"

--- a/src/FitSamples/src/PhysicsEvent.cpp
+++ b/src/FitSamples/src/PhysicsEvent.cpp
@@ -3,7 +3,10 @@
 //
 
 #include "PhysicsEvent.h"
+
+#ifndef USE_NEW_DIALS
 #include "SplineDial.h"
+#endif
 
 #include "GenericToolbox.Root.h"
 #include "Logger.h"

--- a/src/Propagator/CMakeLists.txt
+++ b/src/Propagator/CMakeLists.txt
@@ -31,23 +31,17 @@ target_include_directories( GundamPropagator PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if( WITH_CACHE_MANAGER )
-  target_link_libraries(  GundamPropagator
-          GundamFitParameters
-          GundamFitSamples
-          GundamDatasetManager
-          GundamCache
-          GundamDials
-          ${ROOT_LIBRARIES}
-          )
-else()
-  target_link_libraries( GundamPropagator
-    GundamFitParameters
-    GundamFitSamples
-    GundamDatasetManager
-    GundamDialDictionary
-    ${ROOT_LIBRARIES}
-  )
+  set(CACHE_MANAGER_LIBRARIES "GundamCache")
 endif()
+
+target_link_libraries( GundamPropagator
+  GundamFitParameters
+  GundamFitSamples
+  ${CACHE_MANAGER_LIBRARIES}
+  GundamDatasetManager
+  GundamDialDictionary
+  ${ROOT_LIBRARIES}
+  )
 
 #set_target_properties( GundamPropagator PROPERTIES VERSION "${GUNDAM_VERSION_STRING}")
 

--- a/src/Propagator/CMakeLists.txt
+++ b/src/Propagator/CMakeLists.txt
@@ -32,14 +32,16 @@ target_include_directories( GundamPropagator PUBLIC
 
 if( WITH_CACHE_MANAGER )
   set(CACHE_MANAGER_LIBRARIES "GundamCache")
+else()
+  set(CACHE_MANAGER_LIBRARIES "")
 endif()
 
 target_link_libraries( GundamPropagator
   GundamFitParameters
   GundamFitSamples
-  ${CACHE_MANAGER_LIBRARIES}
   GundamDatasetManager
   GundamDialDictionary
+  ${CACHE_MANAGER_LIBRARIES}
   ${ROOT_LIBRARIES}
   )
 

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -9,7 +9,9 @@
 #endif
 
 #include "FitParameterSet.h"
+#ifndef USE_NEW_DIALS
 #include "Dial.h"
+#endif
 #include "GenericToolbox.Json.h"
 #include "GlobalVariables.h"
 #include "ConfigUtils.h"
@@ -391,7 +393,9 @@ void Propagator::initializeImpl() {
     if(true){
       // STAGED MASK
       LogWarning << "Staged event breakdown:" << std::endl;
+#ifndef USE_NEW_DIALS
       Dial::enableMaskCheck = true;
+#endif
       std::vector<std::vector<double>> stageBreakdownList(
           _fitSampleSet_.getFitSampleList().size(),
           std::vector<double>(_parameterSetList_.size() + 1, 0)
@@ -437,7 +441,9 @@ void Propagator::initializeImpl() {
         t.addTableLine(tableLine);
       }
       t.printTable();
+#ifndef USE_NEW_DIALS
       Dial::enableMaskCheck = false;
+#endif
     }
 
     LogWarning << "Sample breakdown:" << std::endl;
@@ -783,6 +789,3 @@ void Propagator::reweightMcEvents(int iThread_) {
 
 
 }
-
-
-

--- a/src/Utils/include/GlobalVariables.h
+++ b/src/Utils/include/GlobalVariables.h
@@ -26,9 +26,7 @@
 #define GUNDAM_DELTA "delta-"
 #endif
 
-#define USE_NEW_DIALS 1
 #define USE_BREAKDOWN_CACHE
-
 
 ENUM_EXPANDER(
     VerboseLevel, 0,

--- a/src/Utils/include/GlobalVariables.h
+++ b/src/Utils/include/GlobalVariables.h
@@ -26,8 +26,6 @@
 #define GUNDAM_DELTA "delta-"
 #endif
 
-#define USE_BREAKDOWN_CACHE
-
 ENUM_EXPANDER(
     VerboseLevel, 0,
     NORMAL_MODE,


### PR DESCRIPTION
Apply fixes to the build for USE_NEW_DIALS

* The USE_NEW_DIALS ifdef to use the new API was defined in GlobalVariables.h and wasn't uniformly being used.  In a few places the ifdef was being missed because the include file was placed before GlobalVariables.h.  
* This moves the USE_NEW_DIALS into the CMakeLists.txt file.  
* It also applies the deprecated attribute to the base classes that are being removed by the new interface.

