### PR TITLE
Feature/cache manager new dials

### DIFF
--- a/src/CacheManager/CMakeLists.txt
+++ b/src/CacheManager/CMakeLists.txt
@@ -6,6 +6,7 @@ set(HEADERS
   include/CacheParameters.h
   include/CacheWeights.h
   include/WeightNormalization.h
+  include/WeightCompactSpline.h
   include/WeightMonotonicSpline.h
   include/WeightUniformSpline.h
   include/WeightGeneralSpline.h
@@ -16,6 +17,7 @@ set(HEADERS
 if(CMAKE_CUDA_COMPILER)
   cmessage(STATUS "CUDA utilities being compiled")
   set(SRCFILES ${SRCFILES} src/WeightNormalization.cu)
+  set(SRCFILES ${SRCFILES} src/WeightCompactSpline.cu)
   set(SRCFILES ${SRCFILES} src/WeightMonotonicSpline.cu)
   set(SRCFILES ${SRCFILES} src/WeightUniformSpline.cu)
   set(SRCFILES ${SRCFILES} src/WeightGeneralSpline.cu)
@@ -25,6 +27,7 @@ if(CMAKE_CUDA_COMPILER)
 else(CMAKE_CUDA_COMPILER)
   cmessage(STATUS "CUDA utilities are not being compiled")
   set(SRCFILES ${SRCFILES} src/WeightNormalization.cpp)
+  set(SRCFILES ${SRCFILES} src/WeightCompactSpline.cpp)
   set(SRCFILES ${SRCFILES} src/WeightMonotonicSpline.cpp)
   set(SRCFILES ${SRCFILES} src/WeightUniformSpline.cpp)
   set(SRCFILES ${SRCFILES} src/WeightGeneralSpline.cpp)
@@ -44,7 +47,11 @@ endif()
 target_include_directories( GundamCache PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries( GundamCache PUBLIC GundamFitParameters GundamFitSamples ${ROOT_LIBRARIES} )
+target_link_libraries( GundamCache PUBLIC
+  GundamDialDictionary
+  GundamFitParameters
+  GundamFitSamples
+  ${ROOT_LIBRARIES} )
 
 #  set_target_properties(GundamCache PROPERTIES VERSION "${GUNDAM_VERSION_STRING}")
 

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -5,6 +5,7 @@
 
 #include "CacheWeights.h"
 #include "WeightNormalization.h"
+#include "WeightCompactSpline.h"
 #include "WeightMonotonicSpline.h"
 #include "WeightUniformSpline.h"
 #include "WeightGeneralSpline.h"
@@ -12,6 +13,7 @@
 #include "CacheIndexedSums.h"
 
 #include "FitSampleSet.h"
+#include "EventDialCache.h"
 
 #include "hemi/array.h"
 
@@ -37,7 +39,11 @@ public:
 
     // Build the cache and load it into the device.  This is used in
     // Propagator.cpp to fill the constants needed to for the calculations.
+#ifndef USE_NEW_DIALS
     static bool Build(FitSampleSet& sampleList);
+#else
+    static bool Build(FitSampleSet& sampleList, EventDialCache& eventDials);
+#endif
 
     /// This returns the index of the parameter in the cache.  If the
     /// parameter isn't defined, this will return a negative value.
@@ -54,20 +60,23 @@ private:
     Manager(int results, int parameters,
             int norms,
             int compactSplines, int compactPoints,
+            int monotonicSplines, int monotonicPoints,
             int uniformSplines, int uniformPoints,
             int generalSplines, int generalPoints,
-            int histBins);
+            int histBins, std::string spaceType);
     static Manager* fSingleton;  // You get one guess...
 
     // A map between the fit parameter pointers and the parameter index used
     // by the fitter.
     static std::map<const FitParameter*, int> ParameterMap;
 
+#ifndef USE_NEW_DIALS
     // Determine the type of spline cache to use.  The possible results are
     // "compactSpline", "uniformSpline", "generalSpline", or
     // "this-cannot-happen".  This is used to determine which cache is used
     // for each event.
     static std::string SplineType(const SplineDial* dial);
+#endif
 
     /// Declare all of the actual GPU caches here.  There is one GPU, so this
     /// is the ONE place that everything is collected together.
@@ -81,13 +90,16 @@ private:
     /// The cache for the normalizations
     std::unique_ptr<Cache::Weight::Normalization> fNormalizations;
 
+    /// The cache for the compact (Catmull-Rom) splines
+    std::unique_ptr<Cache::Weight::CompactSpline> fCompactSplines;
+
     /// The cache for the monotonic splines
     std::unique_ptr<Cache::Weight::MonotonicSpline> fMonotonicSplines;
 
-    /// The cache for the uniform splines (really compact splines for now).
+    /// The cache for the uniform splines
     std::unique_ptr<Cache::Weight::UniformSpline> fUniformSplines;
 
-    /// The cache for the general splines (really compact splines for now).
+    /// The cache for the general splines
     std::unique_ptr<Cache::Weight::GeneralSpline> fGeneralSplines;
 
     /// The cache for the summed histgram weights

--- a/src/CacheManager/include/WeightCompactSpline.h
+++ b/src/CacheManager/include/WeightCompactSpline.h
@@ -1,0 +1,174 @@
+#ifndef CacheCompactSpline_hxx_seen
+#define CacheCompactSpline_hxx_seen
+
+#include "CacheWeights.h"
+#include "WeightBase.h"
+
+#include "hemi/array.h"
+
+#include <TSpline.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+class SplineDial;
+
+namespace Cache {
+    namespace Weight {
+        class CompactSpline;
+    }
+}
+
+/// A class apply a splined weight parameter to the cached event weights.
+/// This will be used in Cache::Weights to run the GPU for this type of
+/// reweighting.  This spline is controlled by the value at uniformly spaced
+/// knots.  This basically uses Catmull-Rom, but without using an extra point
+/// at the end of the spline.
+class Cache::Weight::CompactSpline:
+    public Cache::Weight::Base {
+private:
+    Cache::Parameters::Clamps& fLowerClamp;
+    Cache::Parameters::Clamps& fUpperClamp;
+
+    ///////////////////////////////////////////////////////////////////////
+    /// An array of indices into the results that go for each spline.
+    /// This is copied from the CPU to the GPU once, and is then constant.
+    std::size_t fSplinesReserved;
+    std::size_t fSplinesUsed;
+    std::unique_ptr<hemi::Array<int>> fSplineResult;
+
+    /// An array of indices into the parameters that go for each spline.  This
+    /// is copied from the CPU to the GPU once, and is then constant.
+    std::unique_ptr<hemi::Array<short>> fSplineParameter;
+
+    /// An array of indices for the first knot of each spline.  This is copied
+    /// from the CPU to the GPU once, and is then constant.
+    std::unique_ptr<hemi::Array<int>> fSplineIndex;
+
+    /// An array of the knots to calculate the splines.  This is copied from
+    /// the CPU to the GPU once, and is then constant.
+    std::size_t    fSplineKnotsReserved;
+    std::size_t    fSplineKnotsUsed;
+    std::unique_ptr<hemi::Array<WEIGHT_BUFFER_FLOAT>> fSplineKnots;
+
+public:
+    // A static method to return the number of knots that will be used by this
+    // spline.
+    static int FindPoints(const TSpline3* s);
+
+    // Construct the class.  This should allocate all the memory on the host
+    // and on the GPU.  The "results" are the total number of results to be
+    // calculated (one result per event, often >1E+6).  The "parameters" are
+    // the number of input parameters that are used (often ~1000).  The norms
+    // are the total number of normalization parameters (typically a few per
+    // event) used to calculate the results.  The splines are the total number
+    // of spline parameters (with uniform knot spacing) used to calculate the
+    // results (typically a few per event).  The knots are the total number of
+    // knots in all of the uniform splines (e.g. For 1000 splines with 7
+    // knots for each spline, knots is 7000).
+    CompactSpline(Cache::Weights::Results& results,
+                  Cache::Parameters::Values& parameters,
+                  Cache::Parameters::Clamps& lowerClamps,
+                  Cache::Parameters::Clamps& upperClamps,
+                  std::size_t splines,
+                  std::size_t knots,
+                  std::string spaceOption);
+
+    // Deconstruct the class.  This should deallocate all the memory
+    // everyplace.
+    virtual ~CompactSpline();
+
+    // Apply the kernel to the event weights.
+    virtual bool Apply();
+
+    /// Return the number of parameters using a spline with uniform knots that
+    /// are reserved.
+    std::size_t GetSplinesReserved() {return fSplinesReserved;}
+
+    /// Return the number of parameters using a spline with uniform knots that
+    /// are used.
+    std::size_t GetSplinesUsed() {return fSplinesUsed;}
+
+    /// Return the number of elements reserved to hold knots.
+    std::size_t GetSplineKnotsReserved() const {return fSplineKnotsReserved;}
+
+    /// Return the number of elements currently used to hold knots.
+    std::size_t GetSplineKnotsUsed() const {return fSplineKnotsUsed;}
+
+    // Set a knot for a spline with uniform spacing.  This takes the index of
+    // the spline that this spline will fill and the index of the control
+    // point to be filled in that spline.  This can only be used after
+    // ReserveSpline has been called.  The sIndex is the value returned by
+    // ReserveSpline for the particular spline, and the kIndex is the knot
+    // that will be filled.
+    void SetSplineKnot(int sIndex, int kIndex, double value);
+
+    /// Add a spline for the dial.  This may modify the dial if debugging is
+    /// enabled.  This uses ReserveSpline and SetSplineKnot.
+    void AddSpline(int resultIndex, int parIndex, const std::vector<double>& dial);
+
+    // Get the index of the parameter for the spline at sIndex.
+    int GetSplineParameterIndex(int sIndex);
+
+    // Get the parameter value for the spline at sIndex.
+    double GetSplineParameter(int sIndex);
+
+    // Get the lower (upper) bound for the spline at sIndex.
+    double GetSplineLowerBound(int sIndex);
+    double GetSplineUpperBound(int sIndex);
+
+    // Get the lower (upper) clamp for the spline at sIndex.
+    double GetSplineLowerClamp(int sIndex);
+    double GetSplineUpperClamp(int sIndex);
+
+    // Get the number of knots in the spline at sIndex.
+    int GetSplineKnotCount(int sIndex);
+
+    // Get the function value for a knot in the spline at sIndex
+    double GetSplineKnot(int sIndex,int knot);
+
+    ////////////////////////////////////////////////////////////////////
+    // This section is for the validation methods.  They should mostly be
+    // NOOPs and should mostly not be called.
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+    double* GetCachePointer(int sIndex);
+
+    /// An array of values for the result of each spline.  When this is
+    /// active, it is filled but the kernel, but only copied to the CPU if
+    /// it's access.  NOTE: Enabling this significantly slows the calculation
+    /// since it adds another large copy from the GPU.
+    std::unique_ptr<hemi::Array<double>> fSplineValue;
+#endif
+
+};
+
+// An MIT Style License
+
+// Copyright (c) 2022 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+#endif

--- a/src/CacheManager/include/WeightGeneralSpline.h
+++ b/src/CacheManager/include/WeightGeneralSpline.h
@@ -72,7 +72,8 @@ public:
                   Cache::Parameters::Clamps& lowerClamps,
                   Cache::Parameters::Clamps& upperClamps,
                   std::size_t splines,
-                  std::size_t knots);
+                  std::size_t knots,
+                  std::string spaceOption);
 
     // Deconstruct the class.  This should deallocate all the memory
     // everyplace.
@@ -95,9 +96,8 @@ public:
     /// Return the number of elements currently used to hold knots.
     std::size_t GetSplineKnotsUsed() const {return fSplineKnotsUsed;}
 
-    /// Add a spline for the dial.  This may modify the dial if debugging is
-    /// enabled.
-    void AddSpline(int resultIndex, int parIndex, SplineDial* dial);
+    /// Add athe data for the spline.
+    void AddSpline(int resultIndex, int parIndex, const std::vector<double>& splineData);
 
     // Get the index of the parameter for the spline at sIndex.
     int GetSplineParameterIndex(int sIndex);

--- a/src/CacheManager/include/WeightMonotonicSpline.h
+++ b/src/CacheManager/include/WeightMonotonicSpline.h
@@ -23,9 +23,9 @@ namespace Cache {
 /// A class apply a splined weight parameter to the cached event weights.
 /// This will be used in Cache::Weights to run the GPU for this type of
 /// reweighting.  This spline is controlled by the value at uniformly spaced
-/// knots.  If COMPACT_SPLINE_AVERAGE is defined at compile time, this will
-/// use a monotonic spline.  Otherwise, this uses the average slope
-/// (e.g. basically uses Catmul-Rom).
+/// knots.  This starts with a Catmull-Rom spline and then modifies the
+/// weights to guarantee that the function is monotonic, except at cusp
+/// points..
 class Cache::Weight::MonotonicSpline:
     public Cache::Weight::Base {
 private:
@@ -69,11 +69,11 @@ public:
     // knots in all of the uniform splines (e.g. For 1000 splines with 7
     // knots for each spline, knots is 7000).
     MonotonicSpline(Cache::Weights::Results& results,
-                  Cache::Parameters::Values& parameters,
-                  Cache::Parameters::Clamps& lowerClamps,
-                  Cache::Parameters::Clamps& upperClamps,
-                  std::size_t splines,
-                  std::size_t knots);
+                    Cache::Parameters::Values& parameters,
+                    Cache::Parameters::Clamps& lowerClamps,
+                    Cache::Parameters::Clamps& upperClamps,
+                    std::size_t splines, std::size_t knots,
+                    std::string spaceOption);
 
     // Deconstruct the class.  This should deallocate all the memory
     // everyplace.
@@ -106,7 +106,7 @@ public:
 
     /// Add a spline for the dial.  This may modify the dial if debugging is
     /// enabled.  This uses ReserveSpline and SetSplineKnot.
-    void AddSpline(int resultIndex, int parIndex, SplineDial* dial);
+    void AddSpline(int resultIndex, int parIndex, const std::vector<double>& dial);
 
     // Get the index of the parameter for the spline at sIndex.
     int GetSplineParameterIndex(int sIndex);

--- a/src/CacheManager/include/WeightUniformSpline.h
+++ b/src/CacheManager/include/WeightUniformSpline.h
@@ -71,8 +71,8 @@ public:
                   Cache::Parameters::Values& parameters,
                   Cache::Parameters::Clamps& lowerClamps,
                   Cache::Parameters::Clamps& upperClamps,
-                  std::size_t splines,
-                  std::size_t knots);
+                  std::size_t splines,std::size_t knots,
+                  std::string spaceOption);
 
     // Deconstruct the class.  This should deallocate all the memory
     // everyplace.
@@ -95,9 +95,8 @@ public:
     /// Return the number of elements currently used to hold knots.
     std::size_t GetSplineKnotsUsed() const {return fSplineKnotsUsed;}
 
-    /// Add a spline for the dial.  This may modify the dial if debugging is
-    /// enabled.
-    void AddSpline(int resultIndex, int parIndex, SplineDial* dial);
+    /// Add a spline data.
+    void AddSpline(int resultIndex, int parIndex, const std::vector<double>& splineData);
 
     // Get the index of the parameter for the spline at sIndex.
     int GetSplineParameterIndex(int sIndex);

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -2,18 +2,29 @@
 #include "CacheParameters.h"
 #include "CacheWeights.h"
 #include "WeightNormalization.h"
+#include "WeightCompactSpline.h"
 #include "WeightMonotonicSpline.h"
 #include "WeightUniformSpline.h"
 #include "WeightGeneralSpline.h"
 #include "CacheIndexedSums.h"
 
 #include "FitParameterSet.h"
+#include "GlobalVariables.h"
+
+#ifndef USE_NEW_DIALS
 #include "Dial.h"
 #include "DialSet.h"
 #include "SplineDial.h"
 #include "GraphDial.h"
 #include "NormDial.h"
-#include "GlobalVariables.h"
+#else
+#include "EventDialCache.h"
+#include "Norm.h"
+#include "GeneralSpline.h"
+#include "UniformSpline.h"
+#include "CompactSpline.h"
+#include "MonotonicSpline.h"
+#endif
 
 #include "Logger.h"
 #include "GenericToolbox.Root.h"
@@ -29,6 +40,7 @@ LoggerInit([]{
 Cache::Manager* Cache::Manager::fSingleton = nullptr;
 std::map<const FitParameter*, int> Cache::Manager::ParameterMap;
 
+#ifndef USE_NEW_DIALS
 std::string Cache::Manager::SplineType(const SplineDial* dial) {
     const TSpline3* s = dial->getSplinePtr();
     if (!s) throw std::runtime_error("Null spline pointer");
@@ -57,15 +69,18 @@ std::string Cache::Manager::SplineType(const SplineDial* dial) {
 
     if (!uniform) return {"generalSpline"};
     if (subType == "compact") return {"compactSpline"};
+    if (subType == "monotonic") return {"monotonicSpline"};
     return {"uniformSpline"};
 }
+#endif
 
 Cache::Manager::Manager(int events, int parameters,
                         int norms,
                         int compactSplines, int compactPoints,
+                        int monotonicSplines, int monotonicPoints,
                         int uniformSplines, int uniformPoints,
                         int generalSplines, int generalPoints,
-                        int histBins) {
+                        int histBins, std::string spaceOption) {
     LogInfo << "Creating cache manager" << std::endl;
 
     fTotalBytes = 0;
@@ -87,12 +102,23 @@ Cache::Manager::Manager(int events, int parameters,
         fWeightsCache->AddWeightCalculator(fNormalizations.get());
         fTotalBytes += fNormalizations->GetResidentMemory();
 
+        fCompactSplines = std::make_unique<Cache::Weight::CompactSpline>(
+                                  fWeightsCache->GetWeights(),
+                                  fParameterCache->GetParameters(),
+                                  fParameterCache->GetLowerClamps(),
+                                  fParameterCache->GetUpperClamps(),
+                                  compactSplines, compactPoints,
+                                  spaceOption);
+        fWeightsCache->AddWeightCalculator(fCompactSplines.get());
+        fTotalBytes += fCompactSplines->GetResidentMemory();
+
         fMonotonicSplines = std::make_unique<Cache::Weight::MonotonicSpline>(
                                   fWeightsCache->GetWeights(),
                                   fParameterCache->GetParameters(),
                                   fParameterCache->GetLowerClamps(),
                                   fParameterCache->GetUpperClamps(),
-                                  compactSplines, compactPoints);
+                                  monotonicSplines, monotonicPoints,
+                                  spaceOption);
         fWeightsCache->AddWeightCalculator(fMonotonicSplines.get());
         fTotalBytes += fMonotonicSplines->GetResidentMemory();
 
@@ -101,7 +127,8 @@ Cache::Manager::Manager(int events, int parameters,
                                   fParameterCache->GetParameters(),
                                   fParameterCache->GetLowerClamps(),
                                   fParameterCache->GetUpperClamps(),
-                                  uniformSplines, uniformPoints);
+                                  uniformSplines, uniformPoints,
+                                  spaceOption);
         fWeightsCache->AddWeightCalculator(fUniformSplines.get());
         fTotalBytes += fUniformSplines->GetResidentMemory();
 
@@ -110,7 +137,8 @@ Cache::Manager::Manager(int events, int parameters,
                                   fParameterCache->GetParameters(),
                                   fParameterCache->GetLowerClamps(),
                                   fParameterCache->GetUpperClamps(),
-                                  generalSplines, generalPoints);
+                                  generalSplines, generalPoints,
+                                  spaceOption);
         fWeightsCache->AddWeightCalculator(fGeneralSplines.get());
         fTotalBytes += fGeneralSplines->GetResidentMemory();
 
@@ -136,12 +164,18 @@ bool Cache::Manager::HasCUDA() {
     return Cache::Parameters::UsingCUDA();
 }
 
-bool Cache::Manager::Build(FitSampleSet& sampleList) {
+#ifdef USE_NEW_DIALS
+bool Cache::Manager::Build(FitSampleSet& sampleList,
+                           EventDialCache& eventDials) {
     LogInfo << "Build the cache for Cache::Manager" << std::endl;
 
+    /// Zero everything before counting the amount of space needed for the
+    /// event dials
     int events = 0;
     int compactSplines = 0;
     int compactPoints = 0;
+    int monotonicSplines = 0;
+    int monotonicPoints = 0;
     int uniformSplines = 0;
     int uniformPoints = 0;
     int generalSplines = 0;
@@ -151,6 +185,243 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
     int norms = 0;
     Cache::Manager::ParameterMap.clear();
 
+    /// Find the amount of space needed for the cache.
+    std::set<const FitParameter*> usedParameters;
+
+    std::map<std::string, int> useCount;
+    for (EventDialCache::CacheElem_t& elem : eventDials.getCache()) {
+        if (elem.event->getSampleBinIndex() < 0) {
+            throw std::runtime_error("Caching event that isn't used");
+        }
+        for (EventDialCache::DialsElem_t& dialElem : elem.dials) {
+#ifdef USE_BREAKDOWN_CACHE
+            DialInterface* dialInterface = dialElem.dial;
+#else
+            DialInterface* dialInterface = dialElem;
+#endif
+            // This is depending behavior that is not guarranteed, but which
+            // is probably valid because of the particular usage.
+            // Specifically, it depends on the vector of FitParameter objects
+            // not being moved.  This happens after the vectors are "closed",
+            // so it is probably safe, but this isn't good.  The particular
+            // usage is forced do to an API change.
+            const FitParameter* fp = &(dialInterface->getInputBufferRef()->getFitParameter());
+            usedParameters.insert(fp);
+            ++useCount[fp->getFullTitle()];
+
+            DialBase* dial = dialInterface->getDialBaseRef();
+            std::string dialType = dial->getDialTypeName();
+            if (dialType.find("Norm") == 0) {
+                ++norms;
+            }
+            else if (dialType.find("GeneralSpline") == 0) {
+                ++generalSplines;
+                GeneralSpline* d = dynamic_cast<GeneralSpline*>(dial);
+                generalPoints += d->getSplineData().size();
+            }
+            else if (dialType.find("UniformSpline") == 0) {
+                ++uniformSplines;
+                UniformSpline* d = dynamic_cast<UniformSpline*>(dial);
+                uniformPoints += d->getSplineData().size();
+            }
+            else if (dialType.find("MonotonicSpline") == 0) {
+                ++monotonicSplines;
+                MonotonicSpline* d = dynamic_cast<MonotonicSpline*>(dial);
+                monotonicPoints += d->getSplineData().size();
+            }
+            else if (dialType.find("CompactSpline")) {
+                ++compactSplines;
+                CompactSpline* d = dynamic_cast<CompactSpline*>(dial);
+                compactPoints += d->getSplineData().size();
+            }
+            else {
+                LogThrow("Unsupported dial type in Cache::Manager -- "
+                         << dialType);
+            }
+        }
+    }
+
+    // Count the total number of histogram cells.
+    int histCells = 0;
+    for(const FitSample& sample : sampleList.getFitSampleList() ){
+        if (!sample.getMcContainer().histogram) continue;
+        int cells = sample.getMcContainer().histogram->GetNcells();
+        LogInfo << "Add histogram for " << sample.getName()
+                << " with " << cells
+                << " cells (includes under/over-flows)" << std::endl;
+        histCells += cells;
+    }
+
+    /// Summarize the space and get the cache memory.
+    int parameters = int(usedParameters.size());
+    LogInfo << "Cache for " << events << " events --"
+            << " using " << parameters << " parameters"
+            << std::endl;
+    LogInfo << "    Compact splines: " << compactSplines
+            << " (" << 1.0*compactSplines/events << " per event)"
+            << std::endl;
+    LogInfo << "    Monotonic splines: " << monotonicSplines
+            << " (" << 1.0*monotonicSplines/events << " per event)"
+            << std::endl;
+    LogInfo << "    Uniform Splines: " << uniformSplines
+            << " (" << 1.0*uniformSplines/events << " per event)"
+            << std::endl;
+    LogInfo << "    General Splines: " << generalSplines
+            << " (" << 1.0*generalSplines/events << " per event)"
+            << std::endl;
+    LogInfo << "    Graphs: " << graphs
+            << " (" << 1.0*graphs/events << " per event)"
+            << std::endl;
+    LogInfo << "    Normalizations: " << norms
+            <<" ("<< 1.0*norms/events <<" per event)"
+            << std::endl;
+    LogInfo << "    Histogram bins: " << histCells
+            << " (" << 1.0*events/histCells << " events per bin)"
+            << std::endl;
+
+    if (compactSplines > 0) {
+        LogInfo << "    Compact spline cache uses "
+                << compactPoints << " control points --"
+                << " (" << 1.0*compactPoints/compactSplines
+                << " points per spline)"
+                << " for " << compactSplines << " splines"
+                << std::endl;
+    }
+    if (monotonicSplines > 0) {
+        LogInfo << "    Monotonic spline cache uses "
+                << monotonicPoints << " control points --"
+                << " (" << 1.0*monotonicPoints/monotonicSplines
+                << " points per spline)"
+                << " for " << monotonicSplines << " splines"
+                << std::endl;
+    }
+    if (uniformSplines > 0) {
+        LogInfo << "    Uniform spline cache uses "
+                << uniformPoints << " control points --"
+                << " (" << 1.0*uniformPoints/uniformSplines
+                << " points per spline)"
+                << " for " << uniformSplines << " splines"
+                << std::endl;
+    }
+    if (generalSplines > 0) {
+        LogInfo << "    General spline cache uses "
+                << generalPoints << " control points --"
+                << " (" << 1.0*generalPoints/generalSplines
+                << " points per spline)"
+                << " for " << generalSplines << " splines"
+                << std::endl;
+    }
+    if (graphs > 0) {
+        LogInfo << "   Graph cache for " << graphPoints << " control points --"
+                << " (" << 1.0*graphPoints/graphs << " points per graph)"
+                << std::endl;
+    }
+
+    // Try to allocate the Cache::Manager memory (including for the GPU if
+    // it's being used).
+    if (!Cache::Manager::Get()
+        && GlobalVariables::getEnableCacheManager()) {
+        if (!Cache::Manager::HasCUDA()) {
+            LogWarning("Creating Cache::Manager without a GPU");
+        }
+
+        fSingleton = new Manager(events,parameters,
+                                 norms,
+                                 compactSplines,compactPoints,
+                                 monotonicSplines,monotonicPoints,
+                                 uniformSplines,uniformPoints,
+                                 generalSplines,generalPoints,
+                                 histCells,
+                                 "space");
+    }
+
+    // In case the cache isn't allocated (usually because it's turned off on
+    // the command line), but this is a safety check.
+    LogThrowIf(!Cache::Manager::Get(),
+               "Cache::Manager requested, but allocation failed");
+
+    // Add the dials to the cache.
+    LogDebug << "Add the dials to the cache." << std::endl;
+    int usedResults = 0;
+
+    /// MISSING IMPLEMENTATION
+
+
+
+    // Error checking adding the dials to the cache!
+    if (usedResults != Cache::Manager::Get()
+        ->GetWeightsCache().GetResultCount()) {
+        LogError << "Cache Manager -- used Results:     "
+                 << usedResults << std::endl;
+        LogError << "Cache Manager -- expected Results: "
+                 << Cache::Manager::Get()->GetWeightsCache().GetResultCount()
+                 << std::endl;
+        throw std::runtime_error("Probable problem putting dials in cache");
+    }
+
+    // Add the histogram cells to the cache.
+    LogDebug << "Add this histogram cells to the cache." << std::endl;
+    int nextHist = 0;
+    for(FitSample& sample : sampleList.getFitSampleList() ) {
+        LogInfo << "Fill cache for " << sample.getName()
+                << " with " << sample.getMcContainer().eventList.size()
+                << " events" << std::endl;
+        std::shared_ptr<TH1> hist(sample.getMcContainer().histogram);
+        if (!hist) {
+            throw std::runtime_error("missing sample histogram");
+        }
+        int thisHist = nextHist;
+        sample.getMcContainer().setCacheManagerIndex(thisHist);
+        sample.getMcContainer().setCacheManagerValuePointer(
+            Cache::Manager::Get()->GetHistogramsCache()
+            .GetSumsPointer());
+        sample.getMcContainer().setCacheManagerValidPointer(
+            Cache::Manager::Get()->GetHistogramsCache()
+            .GetSumsValidPointer());
+        sample.getMcContainer().setCacheManagerUpdatePointer(
+            [](){Cache::Manager::Get()->GetHistogramsCache().GetSum(0);});
+        int cells = hist->GetNcells();
+        nextHist += cells;
+        for (PhysicsEvent& event
+                 : sample.getMcContainer().eventList) {
+            int eventIndex = event.getCacheManagerIndex();
+            int cellIndex = event.getSampleBinIndex();
+            if (cellIndex < 0 || cells <= cellIndex) {
+                throw std::runtime_error("Histogram bin out of range");
+            }
+            int theEntry = thisHist + cellIndex;
+            Cache::Manager::Get()->GetHistogramsCache()
+                .SetEventIndex(eventIndex,theEntry);
+        }
+    }
+
+    if (histCells != nextHist) {
+        throw std::runtime_error("Histogram cells are missing");
+    }
+
+    return true;
+}
+#else
+bool Cache::Manager::Build(FitSampleSet& sampleList) {
+    LogInfo << "Build the cache for Cache::Manager" << std::endl;
+
+    /// Zero everything before counting the amount of space needed for the
+    /// event dials
+    int events = 0;
+    int compactSplines = 0;
+    int compactPoints = 0;
+    int monotonicSplines = 0;
+    int monotonicPoints = 0;
+    int uniformSplines = 0;
+    int uniformPoints = 0;
+    int generalSplines = 0;
+    int generalPoints = 0;
+    int graphs = 0;
+    int graphPoints = 0;
+    int norms = 0;
+    Cache::Manager::ParameterMap.clear();
+
+    /// Find the amount of space needed for the cache.
     std::set<const FitParameter*> usedParameters;
     for(const FitSample& sample : sampleList.getFitSampleList() ){
         LogInfo << "Sample " << sample.getName()
@@ -172,16 +443,16 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
                 if (sDial) {
                     std::string splineType = Cache::Manager::SplineType(sDial);
                     if (sDial->getSplineType() == SplineDial::Monotonic
-                        && splineType != "compactSpline") LogThrow("Bad mono");
+                        && splineType != "monotonicSpline") LogThrow("Bad mono");
                     if (sDial->getSplineType() == SplineDial::Uniform
                         && splineType != "uniformSpline") LogThrow("Bad unif");
                     if (sDial->getSplineType() == SplineDial::General
                         && splineType != "generalSpline") LogThrow("Bad gene");
                     const TSpline3* s = sDial->getSplinePtr();
                     if (!s) throw std::runtime_error("Null spline pointer");
-                    if (splineType == "compactSpline") {
-                        ++compactSplines;
-                        compactPoints
+                    if (splineType == "monotonicSpline") {
+                        ++monotonicSplines;
+                        monotonicPoints
                             += Cache::Weight::MonotonicSpline::FindPoints(s);
                     }
                     else if (splineType == "uniformSpline") {
@@ -238,8 +509,11 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
     LogInfo << "Cache for " << events << " events --"
             << " using " << parameters << " parameters"
             << std::endl;
-    LogInfo << "    Monotonic splines: " << compactSplines
+    LogInfo << "    Compact splines: " << compactSplines
             << " (" << 1.0*compactSplines/events << " per event)"
+            << std::endl;
+    LogInfo << "    Monotonic splines: " << monotonicSplines
+            << " (" << 1.0*monotonicSplines/events << " per event)"
             << std::endl;
     LogInfo << "    Uniform Splines: " << uniformSplines
             << " (" << 1.0*uniformSplines/events << " per event)"
@@ -258,11 +532,19 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
             << std::endl;
 
     if (compactSplines > 0) {
-        LogInfo << "    Monotonic spline cache uses "
+        LogInfo << "    Compact spline cache uses "
                 << compactPoints << " control points --"
                 << " (" << 1.0*compactPoints/compactSplines
                 << " points per spline)"
                 << " for " << compactSplines << " splines"
+                << std::endl;
+    }
+    if (monotonicSplines > 0) {
+        LogInfo << "    Monotonic spline cache uses "
+                << monotonicPoints << " control points --"
+                << " (" << 1.0*monotonicPoints/monotonicSplines
+                << " points per spline)"
+                << " for " << monotonicSplines << " splines"
                 << std::endl;
     }
     if (uniformSplines > 0) {
@@ -297,9 +579,11 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
         fSingleton = new Manager(events,parameters,
                                  norms,
                                  compactSplines,compactPoints,
+                                 monotonicSplines,monotonicPoints,
                                  uniformSplines,uniformPoints,
                                  generalSplines,generalPoints,
-                                 histCells);
+                                 histCells,
+                                 "points");
     }
 
     // In case the cache isn't allocated (usually because it's turned off on
@@ -384,20 +668,20 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
                 if (sDial) {
                     ++dialUsed;
                     std::string splineType = Cache::Manager::SplineType(sDial);
-                    if (splineType == "compactSpline") {
+                    if (splineType == "monotonicSpline") {
                         Cache::Manager::Get()
                             ->fMonotonicSplines
-                            ->AddSpline(resultIndex,parIndex,sDial);
+                            ->AddSpline(resultIndex,parIndex,sDial->getSplineData());
                     }
                     else if (splineType == "uniformSpline") {
                         Cache::Manager::Get()
                             ->fUniformSplines
-                            ->AddSpline(resultIndex,parIndex,sDial);
+                            ->AddSpline(resultIndex,parIndex,sDial->getSplineData());
                     }
                     else if (splineType == "generalSpline") {
                         Cache::Manager::Get()
                             ->fGeneralSplines
-                            ->AddSpline(resultIndex,parIndex,sDial);
+                            ->AddSpline(resultIndex,parIndex,sDial->getSplineData());
                     }
                     else {
                         LogError << "Not a valid spline type: " << splineType
@@ -463,6 +747,7 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
 
     return true;
 }
+#endif
 
 bool Cache::Manager::Fill() {
     Cache::Manager* cache = Cache::Manager::Get();

--- a/src/CacheManager/src/WeightCompactSpline.cpp
+++ b/src/CacheManager/src/WeightCompactSpline.cpp
@@ -1,0 +1,420 @@
+#include "CacheWeights.h"
+#include "WeightBase.h"
+#include "WeightCompactSpline.h"
+
+#include <algorithm>
+#include <iostream>
+#include <exception>
+#include <limits>
+#include <cmath>
+
+#include <hemi/hemi_error.h>
+#include <hemi/launch.h>
+#include <hemi/grid_stride_range.h>
+
+#include "Logger.h"
+LoggerInit([]{
+  Logger::setUserHeaderStr("[Cache::Weight::CompactSpline]");
+});
+
+// The constructor
+Cache::Weight::CompactSpline::CompactSpline(
+    Cache::Weights::Results& weights,
+    Cache::Parameters::Values& parameters,
+    Cache::Parameters::Clamps& lowerClamps,
+    Cache::Parameters::Clamps& upperClamps,
+    std::size_t splines, std::size_t knots,
+    std::string spaceOption)
+    : Cache::Weight::Base("compactSpline",weights,parameters),
+      fLowerClamp(lowerClamps), fUpperClamp(upperClamps),
+      fSplinesReserved(splines), fSplinesUsed(0),
+      fSplineKnotsReserved(knots), fSplineKnotsUsed(0) {
+
+    LogInfo << "Reserved " << GetName() << " Splines: "
+           << GetSplinesReserved() << std::endl;
+    if (GetSplinesReserved() < 1) return;
+
+    fTotalBytes += GetSplinesReserved()*sizeof(int);      // fSplineResult
+    fTotalBytes += GetSplinesReserved()*sizeof(short);    // fSplineParameter
+    fTotalBytes += (1+GetSplinesReserved())*sizeof(int);  // fSplineIndex
+
+    if (spaceOption == "points") {
+        fSplineKnotsReserved = 2*fSplinesReserved + fSplineKnotsReserved;
+    }
+    else {
+        LogThrowIf(spaceOption != "space",
+                   "Invalid space option for compact splines");
+    }
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::CompactSpline
+        // Add validation code for the spline calculation.  This can be rather
+        // slow, so do not use if it is not required.
+    fTotalBytes += GetSplinesReserved()*sizeof(double);
+#endif
+
+    LogInfo << "Reserved " << GetName()
+            << " Spline Knots: " << GetSplineKnotsReserved()
+            << std::endl;
+    fTotalBytes += GetSplineKnotsReserved()*sizeof(WEIGHT_BUFFER_FLOAT);  // fSpineKnots
+
+
+    LogInfo << "Approximate Memory Size for " << GetName()
+            << ": " << fTotalBytes/1E+9
+            << " GB" << std::endl;
+
+    try {
+        // Get the CPU/GPU memory for the spline index tables.  These are
+        // copied once during initialization so do not pin the CPU memory into
+        // the page set.
+        fSplineResult.reset(new hemi::Array<int>(GetSplinesReserved(),false));
+        fSplineParameter.reset(
+            new hemi::Array<short>(GetSplinesReserved(),false));
+        fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::CompactSpline
+        // Add validation code for the spline calculation.  This can be rather
+        // slow, so do not use if it is not required.
+        fSplineValue.reset(new hemi::Array<double>(GetSplinesReserved(),true));
+#endif
+
+        // Get the CPU/GPU memory for the spline knots.  This is copied once
+        // during initialization so do not pin the CPU memory into the page
+        // set.
+        fSplineKnots.reset(
+            new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSplineKnotsReserved(),false));
+    }
+    catch (std::bad_alloc&) {
+        LogError << "Failed to allocate memory, so stopping" << std::endl;
+        throw std::runtime_error("Not enough memory available");
+    }
+
+    // Initialize the caches.  Don't try to zero everything since the
+    // caches can be huge.
+    fSplineIndex->hostPtr()[0] = 0;
+}
+
+// The destructor
+Cache::Weight::CompactSpline::~CompactSpline() {}
+
+int Cache::Weight::CompactSpline::FindPoints(const TSpline3* s) {
+    return s->GetNp();
+}
+
+void Cache::Weight::CompactSpline::AddSpline(int resIndex,
+                                             int parIndex,
+                                             const std::vector<double>& splineData) {
+    if (resIndex < 0) {
+        LogError << "Invalid result index"
+               << std::endl;
+        throw std::runtime_error("Negative result index");
+    }
+    if (fWeights.size() <= resIndex) {
+        LogError << "Invalid result index"
+               << std::endl;
+        throw std::runtime_error("Result index out of bounds");
+    }
+    if (parIndex < 0) {
+        LogError << "Invalid parameter index"
+               << std::endl;
+        throw std::runtime_error("Negative parameter index");
+    }
+    if (fParameters.size() <= parIndex) {
+        LogError << "Invalid parameter index"
+               << std::endl;
+        throw std::runtime_error("Parameter index out of bounds");
+    }
+    if (splineData.size() < 5) {
+        LogError << "Insufficient points in spline"
+               << std::endl;
+        throw std::runtime_error("Invalid number of spline points");
+    }
+    int newIndex = fSplinesUsed++;
+    if (fSplinesUsed > fSplinesReserved) {
+        LogError << "Not enough space reserved for splines"
+                  << std::endl;
+        throw std::runtime_error("Not enough space reserved for splines");
+    }
+    fSplineResult->hostPtr()[newIndex] = resIndex;
+    fSplineParameter->hostPtr()[newIndex] = parIndex;
+    if (fSplineIndex->hostPtr()[newIndex] != fSplineKnotsUsed) {
+        LogError << "Last spline knot index should be at old end of splines"
+                  << std::endl;
+        throw std::runtime_error("Problem with control indices");
+    }
+    int knotIndex = fSplineKnotsUsed;
+    fSplineKnotsUsed += splineData.size();
+    if (fSplineKnotsUsed > fSplineKnotsReserved) {
+        LogError << "Not enough space reserved for spline knots"
+               << std::endl;
+        throw std::runtime_error("Not enough space reserved for spline knots");
+    }
+    fSplineIndex->hostPtr()[newIndex+1] = fSplineKnotsUsed;
+    for (std::size_t i = 0; i<splineData.size(); ++i) {
+        fSplineKnots->hostPtr()[knotIndex+i] = splineData.at(i);
+    }
+
+}
+
+void Cache::Weight::CompactSpline::SetSplineKnot(
+    int sIndex, int kIndex, double value) {
+    if (sIndex < 0) {
+        LogError << "Requested spline index is negative"
+                  << std::endl;
+        std::runtime_error("Invalid control point being set");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        LogError << "Requested spline index is to large"
+                  << std::endl;
+        std::runtime_error("Invalid control point being set");
+    }
+    if (kIndex < 0) {
+        LogError << "Requested control point index is negative"
+                  << std::endl;
+        std::runtime_error("Invalid control point being set");
+    }
+    int knotIndex = fSplineIndex->hostPtr()[sIndex] + 2 + kIndex;
+    if (fSplineIndex->hostPtr()[sIndex+1] <= knotIndex) {
+        LogError << "Requested control point index is two large"
+                  << std::endl;
+        std::runtime_error("Invalid control point being set");
+    }
+    fSplineKnots->hostPtr()[knotIndex] = value;
+}
+
+int Cache::Weight::CompactSpline::GetSplineParameterIndex(int sIndex) {
+    if (sIndex < 0) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    return fSplineParameter->hostPtr()[sIndex];
+}
+
+double Cache::Weight::CompactSpline::GetSplineParameter(int sIndex) {
+    int i = GetSplineParameterIndex(sIndex);
+    if (i<0) {
+        throw std::runtime_error("Spine parameter index out of bounds");
+    }
+    if (fParameters.size() <= i) {
+        throw std::runtime_error("Spine parameter index out of bounds");
+    }
+    return fParameters.hostPtr()[i];
+}
+
+int Cache::Weight::CompactSpline::GetSplineKnotCount(int sIndex) {
+    if (sIndex < 0) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    return fSplineIndex->hostPtr()[sIndex+1]-fSplineIndex->hostPtr()[sIndex]-2;
+}
+
+double Cache::Weight::CompactSpline::GetSplineLowerBound(int sIndex) {
+    if (sIndex < 0) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    int knotsIndex = fSplineIndex->hostPtr()[sIndex];
+    return fSplineKnots->hostPtr()[knotsIndex];
+}
+
+double Cache::Weight::CompactSpline::GetSplineUpperBound(int sIndex) {
+    if (sIndex < 0) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    int knotCount = GetSplineKnotCount(sIndex);
+    double lower = GetSplineLowerBound(sIndex);
+    int knotsIndex = fSplineIndex->hostPtr()[sIndex];
+    double step = fSplineKnots->hostPtr()[knotsIndex+1];
+    return lower + (knotCount-1)/step;
+}
+
+double Cache::Weight::CompactSpline::GetSplineLowerClamp(int sIndex) {
+    int i = GetSplineParameterIndex(sIndex);
+    if (i<0) {
+        throw std::runtime_error("Spine lower clamp index out of bounds");
+    }
+    if (fLowerClamp.size() <= i) {
+        throw std::runtime_error("Spine lower clamp index out of bounds");
+    }
+    return fLowerClamp.hostPtr()[i];
+}
+
+double Cache::Weight::CompactSpline::GetSplineUpperClamp(int sIndex) {
+    int i = GetSplineParameterIndex(sIndex);
+    if (i<0) {
+        throw std::runtime_error("Spine upper clamp index out of bounds");
+    }
+    if (fUpperClamp.size() <= i) {
+        throw std::runtime_error("Spine upper clamp index out of bounds");
+    }
+    return fUpperClamp.hostPtr()[i];
+}
+
+double Cache::Weight::CompactSpline::GetSplineKnot(int sIndex, int knot) {
+    if (sIndex < 0) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("Spline index invalid");
+    }
+    int knotsIndex = fSplineIndex->hostPtr()[sIndex];
+    int count = GetSplineKnotCount(sIndex);
+    if (knot < 0) {
+        throw std::runtime_error("Knot index invalid");
+    }
+    if (count <= knot) {
+        throw std::runtime_error("Knot index invalid");
+    }
+    return fSplineKnots->hostPtr()[knotsIndex+2+knot];
+}
+
+////////////////////////////////////////////////////////////////////
+// This section is for the validation methods.  They should mostly be
+// NOOPs and should mostly not be called.
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::GetSplineValue
+// Get the intermediate spline result that is used to calculate an event
+// weight.  This can trigger a copy from the GPU to CPU, and must only be
+// enabled during validation.  Using this validation code also significantly
+// increases the amount of GPU memory required.  In a short sentence, "Do not
+// use this method."
+double* Cache::Weight::CompactSpline::GetCachePointer(int sIndex) {
+    if (sIndex < 0) {
+        throw std::runtime_error("GetSplineValue: Spline index invalid");
+    }
+    if (GetSplinesUsed() <= sIndex) {
+        throw std::runtime_error("GetSplineValue: Spline index invalid");
+    }
+    // This can trigger a *slow* copy of the spline values from the GPU to the
+    // CPU.
+    return fSplineValue->hostPtr() + sIndex;
+}
+#endif
+
+#include "CacheAtomicMult.h"
+#include "CalculateCompactSpline.h"
+
+// Define CACHE_DEBUG to get lots of output from the host
+#undef CACHE_DEBUG
+#define PRINT_STEP 3
+
+namespace {
+    // A function to be used as the kernel on either the CPU or GPU.  This
+    // must be valid CUDA coda.
+    HEMI_KERNEL_FUNCTION(HEMISplinesKernel,
+                         double* results,
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::HEMISplinesKernel
+                         // inputs/output for validation
+                         double* splineValues,
+#endif
+                         const double* params,
+                         const double* lowerClamp,
+                         const double* upperClamp,
+                         const WEIGHT_BUFFER_FLOAT* knots,
+                         const int* rIndex,
+                         const short* pIndex,
+                         const int* sIndex,
+                         const int NP) {
+        for (int i : hemi::grid_stride_range(0,NP)) {
+            const int id0 = sIndex[i];
+            const int id1 = sIndex[i+1];
+            const int dim = id1-id0-2;
+            const double x = params[pIndex[i]];
+            const double lowBound = knots[id0];
+            const double step = 1.0/knots[id0+1];
+            const double lClamp = lowerClamp[pIndex[i]];
+            const double uClamp = upperClamp[pIndex[i]];
+
+            double v = CalculateCompactSpline(x, lClamp,uClamp,
+                                                &knots[id0],dim);
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::HEMISplinesKernel
+            splineValues[i] = v;
+#endif
+            CacheAtomicMult(&results[rIndex[i]], v);
+#ifndef HEMI_DEV_CODE
+#ifdef CACHE_DEBUG
+            if (rIndex[i] < PRINT_STEP) {
+                std::cout << "Splines kernel " << i
+                       << " iEvt " << rIndex[i]
+                       << " iPar " << pIndex[i]
+                       << " = " << params[pIndex[i]]
+                       << " --> " << x
+                       << std::endl;
+            }
+#endif
+#endif
+        }
+    }
+}
+
+bool Cache::Weight::CompactSpline::Apply() {
+    if (GetSplinesUsed() < 1) return false;
+
+    HEMISplinesKernel splinesKernel;
+    hemi::launch(splinesKernel,
+                 fWeights.writeOnlyPtr(),
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::Apply
+                 fSplineValue->writeOnlyPtr(),
+#endif
+                 fParameters.readOnlyPtr(),
+                 fLowerClamp.readOnlyPtr(),
+                 fUpperClamp.readOnlyPtr(),
+                 fSplineKnots->readOnlyPtr(),
+                 fSplineResult->readOnlyPtr(),
+                 fSplineParameter->readOnlyPtr(),
+                 fSplineIndex->readOnlyPtr(),
+                 GetSplinesUsed()
+        );
+
+#ifdef CACHE_MANAGER_SLOW_VALIDATION
+    // This MUST be done for slow validation.
+#warning Using SLOW VALIDATION and copying spine values
+    fSplineValue->hostPtr();
+#endif
+
+    return true;
+}
+
+// An MIT Style License
+
+// Copyright (c) 2022 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/CacheManager/src/WeightCompactSpline.cu
+++ b/src/CacheManager/src/WeightCompactSpline.cu
@@ -1,0 +1,1 @@
+#include "WeightCompactSpline.cpp"

--- a/src/CacheManager/src/WeightGeneralSpline.cpp
+++ b/src/CacheManager/src/WeightGeneralSpline.cpp
@@ -2,8 +2,6 @@
 #include "WeightBase.h"
 #include "WeightGeneralSpline.h"
 
-#include "SplineDial.h"
-
 #include <algorithm>
 #include <iostream>
 #include <exception>
@@ -25,7 +23,8 @@ Cache::Weight::GeneralSpline::GeneralSpline(
     Cache::Parameters::Values& parameters,
     Cache::Parameters::Clamps& lowerClamps,
     Cache::Parameters::Clamps& upperClamps,
-    std::size_t splines, std::size_t knots)
+    std::size_t splines, std::size_t knots,
+    std::string spaceOption)
     : Cache::Weight::Base("generalSpline",weights,parameters),
       fLowerClamp(lowerClamps), fUpperClamp(upperClamps),
       fSplinesReserved(splines), fSplinesUsed(0),
@@ -41,7 +40,14 @@ Cache::Weight::GeneralSpline::GeneralSpline(
 
     // Calculate the space needed to store the spline data.  This needs
     // to know how the spline data is packed for CalculateGeneralSpline.
-    fSplineKnotsReserved = 2*fSplinesReserved + 3*fSplineKnotsReserved;
+    if (spaceOption == "points") {
+        fSplineKnotsReserved = 2*fSplinesReserved + 3*fSplineKnotsReserved;
+    }
+    else {
+        LogThrowIf(spaceOption != "space",
+                   "Invalid space option for compact splines");
+    }
+
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
@@ -99,7 +105,7 @@ int Cache::Weight::GeneralSpline::FindPoints(const TSpline3* s) {
 }
 
 void Cache::Weight::GeneralSpline::AddSpline(int resIndex, int parIndex,
-                                             SplineDial* sDial) {
+                                             const std::vector<double>& splineData) {
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
@@ -120,7 +126,7 @@ void Cache::Weight::GeneralSpline::AddSpline(int resIndex, int parIndex,
                << std::endl;
         throw std::runtime_error("Parameter index out of bounds");
     }
-    if (sDial->getSplineData().size() < 11) {
+    if (splineData.size() < 11) {
         LogError << "Insufficient points in spline"
                << std::endl;
         throw std::runtime_error("Invalid number of spline points");
@@ -139,22 +145,17 @@ void Cache::Weight::GeneralSpline::AddSpline(int resIndex, int parIndex,
         throw std::runtime_error("Problem with control indices");
     }
     int knotIndex = fSplineKnotsUsed;
-    fSplineKnotsUsed += sDial->getSplineData().size();
+    fSplineKnotsUsed += splineData.size();
     if (fSplineKnotsUsed > fSplineKnotsReserved) {
         LogError << "Not enough space reserved for spline knots"
                << std::endl;
         throw std::runtime_error("Not enough space reserved for spline knots");
     }
     fSplineIndex->hostPtr()[newIndex+1] = fSplineKnotsUsed;
-    for (std::size_t i = 0; i<sDial->getSplineData().size(); ++i) {
-        fSplineKnots->hostPtr()[knotIndex+i] = sDial->getSplineData().at(i);
+    for (std::size_t i = 0; i<splineData.size(); ++i) {
+        fSplineKnots->hostPtr()[knotIndex+i] = splineData.at(i);
     }
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::AddSpline
-    sDial->setCacheManagerName(GetName());
-    sDial->setCacheManagerValuePointer(GetCachePointer(newIndex));
-#endif
 }
 
 int Cache::Weight::GeneralSpline::GetSplineParameterIndex(int sIndex) {

--- a/src/CacheManager/src/WeightMonotonicSpline.cpp
+++ b/src/CacheManager/src/WeightMonotonicSpline.cpp
@@ -2,8 +2,6 @@
 #include "WeightBase.h"
 #include "WeightMonotonicSpline.h"
 
-#include "SplineDial.h"
-
 #include <algorithm>
 #include <iostream>
 #include <exception>
@@ -25,7 +23,8 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
     Cache::Parameters::Values& parameters,
     Cache::Parameters::Clamps& lowerClamps,
     Cache::Parameters::Clamps& upperClamps,
-    std::size_t splines, std::size_t knots)
+    std::size_t splines, std::size_t knots,
+    std::string spaceOption)
     : Cache::Weight::Base("compactSpline",weights,parameters),
       fLowerClamp(lowerClamps), fUpperClamp(upperClamps),
       fSplinesReserved(splines), fSplinesUsed(0),
@@ -39,7 +38,13 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
     fTotalBytes += GetSplinesReserved()*sizeof(short);    // fSplineParameter
     fTotalBytes += (1+GetSplinesReserved())*sizeof(int);  // fSplineIndex
 
-    fSplineKnotsReserved = 2*fSplinesReserved + fSplineKnotsReserved;
+    if (spaceOption == "points") {
+        fSplineKnotsReserved = 2*fSplinesReserved + fSplineKnotsReserved;
+    }
+    else {
+        LogThrowIf(spaceOption != "space",
+                   "Invalid space option for compact splines");
+    }
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::MonotonicSpline::MonotonicSpline
@@ -99,7 +104,7 @@ int Cache::Weight::MonotonicSpline::FindPoints(const TSpline3* s) {
 
 void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
                                                int parIndex,
-                                               SplineDial* sDial) {
+                                               const std::vector<double>& splineData) {
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
@@ -120,7 +125,7 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
                << std::endl;
         throw std::runtime_error("Parameter index out of bounds");
     }
-    if (sDial->getSplineData().size() < 5) {
+    if (splineData.size() < 5) {
         LogError << "Insufficient points in spline"
                << std::endl;
         throw std::runtime_error("Invalid number of spline points");
@@ -139,22 +144,17 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
         throw std::runtime_error("Problem with control indices");
     }
     int knotIndex = fSplineKnotsUsed;
-    fSplineKnotsUsed += sDial->getSplineData().size();
+    fSplineKnotsUsed += splineData.size();
     if (fSplineKnotsUsed > fSplineKnotsReserved) {
         LogError << "Not enough space reserved for spline knots"
                << std::endl;
         throw std::runtime_error("Not enough space reserved for spline knots");
     }
     fSplineIndex->hostPtr()[newIndex+1] = fSplineKnotsUsed;
-    for (std::size_t i = 0; i<sDial->getSplineData().size(); ++i) {
-        fSplineKnots->hostPtr()[knotIndex+i] = sDial->getSplineData().at(i);
+    for (std::size_t i = 0; i<splineData.size(); ++i) {
+        fSplineKnots->hostPtr()[knotIndex+i] = splineData.at(i);
     }
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::MonotonicSpline::AddSpline
-    sDial->setCacheManagerName(GetName());
-    sDial->setCacheManagerValuePointer(GetCachePointer(newIndex));
-#endif
 }
 
 void Cache::Weight::MonotonicSpline::SetSplineKnot(

--- a/src/CacheManager/src/WeightUniformSpline.cpp
+++ b/src/CacheManager/src/WeightUniformSpline.cpp
@@ -2,8 +2,6 @@
 #include "WeightBase.h"
 #include "WeightUniformSpline.h"
 
-#include "SplineDial.h"
-
 #include <algorithm>
 #include <iostream>
 #include <exception>
@@ -25,7 +23,8 @@ Cache::Weight::UniformSpline::UniformSpline(
     Cache::Parameters::Values& parameters,
     Cache::Parameters::Clamps& lowerClamps,
     Cache::Parameters::Clamps& upperClamps,
-    std::size_t splines, std::size_t knots)
+    std::size_t splines, std::size_t knots,
+    std::string spaceOption)
     : Cache::Weight::Base("uniformSpline",weights,parameters),
       fLowerClamp(lowerClamps), fUpperClamp(upperClamps),
       fSplinesReserved(splines), fSplinesUsed(0),
@@ -41,7 +40,13 @@ Cache::Weight::UniformSpline::UniformSpline(
 
     // Calculate the space needed to store the spline data.  This needs
     // to know how the spline data is packed for CalculateUniformSpline.
-    fSplineKnotsReserved = 2*fSplinesReserved + 2*fSplineKnotsReserved;
+    if (spaceOption == "points") {
+        fSplineKnotsReserved = 2*fSplinesReserved + 2*fSplineKnotsReserved;
+    }
+    else {
+        LogThrowIf(spaceOption != "space",
+                   "Invalid space option for compact splines");
+    }
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::UniformSpline::UniformSpline
@@ -99,7 +104,7 @@ int Cache::Weight::UniformSpline::FindPoints(const TSpline3* s) {
 }
 
 void Cache::Weight::UniformSpline::AddSpline(int resIndex, int parIndex,
-                                            SplineDial* sDial) {
+                                             const std::vector<double>& splineData) {
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
@@ -120,7 +125,7 @@ void Cache::Weight::UniformSpline::AddSpline(int resIndex, int parIndex,
                << std::endl;
         throw std::runtime_error("Parameter index out of bounds");
     }
-    int points = sDial->getSplineData().size();
+    int points = splineData.size();
     if (points < 8) {
         LogError << "Insufficient points in spline"
                << std::endl;
@@ -143,21 +148,16 @@ void Cache::Weight::UniformSpline::AddSpline(int resIndex, int parIndex,
     fSplineKnotsUsed += points;
     if (fSplineKnotsUsed > fSplineKnotsReserved) {
         LogError << "Not enough space reserved for spline knots"
-        << " -> " << GET_VAR_NAME_VALUE(fSplineKnotsReserved)
-        << " / " << GET_VAR_NAME_VALUE(fSplineKnotsUsed)
-        << std::endl;
+                 << " -> SplineKnotsReserved = " << fSplineKnotsReserved
+                 << " / SplineKnotsUsed = " << fSplineKnotsUsed
+                 << std::endl;
         throw std::runtime_error("Not enough space reserved for spline knots");
     }
     fSplineIndex->hostPtr()[newIndex+1] = fSplineKnotsUsed;
-    for (std::size_t i = 0; i<sDial->getSplineData().size(); ++i) {
-        fSplineKnots->hostPtr()[knotIndex+i] = sDial->getSplineData().at(i);
+    for (std::size_t i = 0; i<splineData.size(); ++i) {
+        fSplineKnots->hostPtr()[knotIndex+i] = splineData.at(i);
     }
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::UniformSpline::AddSpline
-    sDial->setCacheManagerName(GetName());
-    sDial->setCacheManagerValuePointer(GetCachePointer(newIndex));
-#endif
 }
 
 int Cache::Weight::UniformSpline::GetSplineParameterIndex(int sIndex) {

--- a/src/DialDictionary/CMakeLists.txt
+++ b/src/DialDictionary/CMakeLists.txt
@@ -11,8 +11,10 @@ set( SRCFILES
     src/EventDialCache.cpp
     src/GraphHandler.cpp
     src/LightGraphHandler.cpp
-    src/MonotonicSplineHandler.cpp
     src/GeneralSplineHandler.cpp
+    src/UniformSplineHandler.cpp
+    src/CompactSplineHandler.cpp
+    src/MonotonicSplineHandler.cpp
     src/SimpleSplineHandler.cpp
     include/LightGraphCache.h)
 
@@ -34,12 +36,17 @@ set( HEADERS
     include/LightGraphHandler.h
     include/Graph.h
     include/LightGraph.h
-    include/MonotonicSplineHandler.h
-    include/MonotonicSpline.h
-    include/MonotonicSplineCache.h
     include/GeneralSplineHandler.h
     include/GeneralSpline.h
     include/GeneralSplineCache.h
+    include/UniformSplineHandler.h
+    include/UniformSpline.h
+    include/CompactSplineHandler.h
+    include/CompactSpline.h
+    include/CompactSplineCache.h
+    include/MonotonicSplineHandler.h
+    include/MonotonicSpline.h
+    include/MonotonicSplineCache.h
     include/SimpleSplineHandler.h
     include/SimpleSpline.h
     include/SimpleSplineCache.h

--- a/src/DialDictionary/include/CompactSpline.h
+++ b/src/DialDictionary/include/CompactSpline.h
@@ -1,0 +1,23 @@
+//
+// Created by Adrien Blanchet on 22/01/2023.
+//
+
+#ifndef GUNDAM_COMPACTSPLINE_H
+#define GUNDAM_COMPACTSPLINE_H
+
+#include "DialBase.h"
+#include "CompactSplineHandler.h"
+
+class CompactSpline : public DialBase, public CompactSplineHandler {
+
+public:
+  CompactSpline() = default;
+
+  [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<CompactSpline>(*this); }
+  [[nodiscard]] std::string getDialTypeName() const override { return {"CompactSpline"}; }
+  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+
+};
+
+
+#endif //GUNDAM_COMPACTSPLINE_H

--- a/src/DialDictionary/include/CompactSplineHandler.h
+++ b/src/DialDictionary/include/CompactSplineHandler.h
@@ -1,0 +1,42 @@
+//
+// Created by Adrien Blanchet on 22/01/2023.
+//
+
+#ifndef GUNDAM_COMPACTSPLINEHANDLER_H
+#define GUNDAM_COMPACTSPLINEHANDLER_H
+
+#include "DialInputBuffer.h"
+
+#include "TGraph.h"
+
+#include "vector"
+#include "utility"
+
+
+class CompactSplineHandler {
+
+public:
+  CompactSplineHandler() = default;
+  virtual ~CompactSplineHandler() = default;
+
+  void setAllowExtrapolation(bool allowExtrapolation);
+
+  void buildSplineData(TGraph& graph_);
+  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+
+  bool getIsUniform() const {return true;}
+  const std::vector<double>& getSplineData() const {return _splineData_;}
+
+protected:
+  bool _allowExtrapolation_{false};
+
+  // A block of data to calculate the spline values.  This must be filled for
+  // the Cache::Manager to work, and provides the input for spline calculation
+  // functions that can be shared between the CPU and the GPU.
+  std::vector<double> _splineData_{};
+  std::pair<double, double> _splineBounds_{std::nan("unset"), std::nan("unset")};
+
+};
+
+
+#endif //GUNDAM_COMPACTSPLINEHANDLER_H

--- a/src/DialDictionary/include/DialInterface.h
+++ b/src/DialDictionary/include/DialInterface.h
@@ -19,6 +19,8 @@
 #include "vector"
 
 
+/// This class is size critical and should not be used as a base class (no
+/// virtual methods.
 class DialInterface {
 
 public:
@@ -29,9 +31,25 @@ public:
   void setResponseSupervisorRef(const DialResponseSupervisor *responseSupervisorRef);
   void setDialBinRef(const DataBin *dialBinRef);
 
-  [[nodiscard]] DialInputBuffer *getInputBufferRef() const;
+  /// Return the input buffer containing the connection to the FitParameter(s)
+  /// used by this dial.  The number of FitParameters contained in the input
+  /// buffer musts mach the number expected by the specialization of the
+  /// DialBase.
+  [[nodiscard]] inline DialInputBuffer *getInputBufferRef() const {return _inputBufferRef_;}
 
-  double evalResponse();
+  /// Get the dial calculation method.  The dial will need one or more
+  /// FitParameter inputs, and the number *must* match the number and order of
+  /// the FitParameters in the DialInputBuffer.
+  [[nodiscard]] inline DialBase* getDialBaseRef() const {return _dialBaseRef_;}
+
+  /// Get the DialResponseSupervisor. This conditions the return value of the
+  /// dial (normally truncates between zero and the maximum response).
+  [[nodiscard]] inline const DialResponseSupervisor* getResponseSupervisorRef() const {return _responseSupervisorRef_;}
+
+  /// Get the data bin definition for the dial.
+  [[nodiscard]] inline const DataBin* getDialBinRef() const {return _dialBinRef_;}
+
+  [[nodiscard]] double evalResponse();
   [[nodiscard]] std::string getSummary(bool shallow_=true);
 
 private:

--- a/src/DialDictionary/include/GeneralSplineHandler.h
+++ b/src/DialDictionary/include/GeneralSplineHandler.h
@@ -27,6 +27,9 @@ public:
   void buildSplineData(const TSpline3& sp_);
   [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
 
+  bool getIsUniform() const {return false;}
+  const std::vector<double>& getSplineData() const {return _splineData_;}
+
 protected:
   bool _allowExtrapolation_{false};
 

--- a/src/DialDictionary/include/MonotonicSplineHandler.h
+++ b/src/DialDictionary/include/MonotonicSplineHandler.h
@@ -24,6 +24,9 @@ public:
   void buildSplineData(TGraph& graph_);
   [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
 
+  bool getIsUniform() const {return true;}
+  const std::vector<double>& getSplineData() const {return _splineData_;}
+
 protected:
   bool _allowExtrapolation_{false};
 

--- a/src/DialDictionary/include/SimpleSplineHandler.h
+++ b/src/DialDictionary/include/SimpleSplineHandler.h
@@ -27,9 +27,12 @@ public:
   void buildSplineData(const TSpline3& sp_);
   [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
 
+  bool getIsUniform() const {return _isUniform_;}
+  const std::vector<double>& getSplineData() const {return _splineData_;}
+
 protected:
   bool _allowExtrapolation_{false};
-  bool _isMonotonic_{false};
+  bool _isUniform_{false};
 
   // A block of data to calculate the spline values.  This must be filled for
   // the Cache::Manager to work, and provides the input for spline calculation

--- a/src/DialDictionary/include/UniformSpline.h
+++ b/src/DialDictionary/include/UniformSpline.h
@@ -1,0 +1,23 @@
+//
+// Created by Adrien Blanchet on 23/01/2023.
+//
+
+#ifndef GUNDAM_UNIFORMSPLINE_H
+#define GUNDAM_UNIFORMSPLINE_H
+
+#include "DialBase.h"
+#include "UniformSplineHandler.h"
+
+class UniformSpline : public DialBase, public UniformSplineHandler {
+
+public:
+  UniformSpline() = default;
+
+  [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<UniformSpline>(*this); }
+  [[nodiscard]] std::string getDialTypeName() const override { return {"UniformSpline"}; }
+  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+
+};
+
+
+#endif //GUNDAM_UNIFORMSPLINE_H

--- a/src/DialDictionary/include/UniformSplineHandler.h
+++ b/src/DialDictionary/include/UniformSplineHandler.h
@@ -1,0 +1,45 @@
+//
+// Created by Adrien Blanchet on 23/01/2023.
+//
+
+#ifndef GUNDAM_UNIFORMSPLINEHANDLER_H
+#define GUNDAM_UNIFORMSPLINEHANDLER_H
+
+
+#include "DialInputBuffer.h"
+
+#include "TGraph.h"
+#include "TSpline.h"
+
+#include "vector"
+#include "utility"
+
+
+class UniformSplineHandler {
+
+public:
+  UniformSplineHandler() = default;
+  virtual ~UniformSplineHandler() = default;
+
+  void setAllowExtrapolation(bool allowExtrapolation);
+
+  void buildSplineData(TGraph& graph_);
+  void buildSplineData(const TSpline3& sp_);
+  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+
+  bool getIsUniform() const {return true;}
+  const std::vector<double>& getSplineData() const {return _splineData_;}
+
+protected:
+  bool _allowExtrapolation_{false};
+
+  // A block of data to calculate the spline values.  This must be filled for
+  // the Cache::Manager to work, and provides the input for spline calculation
+  // functions that can be shared between the CPU and the GPU.
+  std::vector<double> _splineData_{};
+  std::pair<double, double> _splineBounds_{std::nan("unset"), std::nan("unset")};
+
+};
+
+
+#endif //GUNDAM_UNIFORMSPLINEHANDLER_H

--- a/src/DialDictionary/src/CompactSplineHandler.cpp
+++ b/src/DialDictionary/src/CompactSplineHandler.cpp
@@ -1,0 +1,49 @@
+//
+// Created by Adrien Blanchet on 22/01/2023.
+//
+
+#include "CompactSplineHandler.h"
+#include "CalculateCompactSpline.h"
+
+#include "GenericToolbox.Root.h"
+#include "Logger.h"
+
+
+LoggerInit([]{
+  Logger::setUserHeaderStr("[CompactSplineHandler]");
+});
+
+void CompactSplineHandler::setAllowExtrapolation(bool allowExtrapolation) {
+  _allowExtrapolation_ = allowExtrapolation;
+}
+
+void CompactSplineHandler::buildSplineData(TGraph& graph_){
+  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+
+  // Copy the spline data into local storage.
+  graph_.Sort();
+
+  LogThrowIf(
+      not GenericToolbox::hasUniformlySpacedKnots(&graph_),
+      "Can't use compact spline with a input that doesn't have uniformly spaced knots"
+  );
+
+  _splineBounds_.first = graph_.GetX()[0];
+  _splineBounds_.second = graph_.GetX()[graph_.GetN()-1];
+
+  _splineData_.resize(2 + graph_.GetN());
+  _splineData_[0] = graph_.GetX()[0];
+  _splineData_[1] = (graph_.GetX()[graph_.GetN()-1] - graph_.GetX()[0])/(graph_.GetN()-1.0);
+
+  memcpy(&_splineData_[2], graph_.GetY(), graph_.GetN() * sizeof(double));
+}
+double CompactSplineHandler::evaluateSpline(const DialInputBuffer& input_) const{
+  double dialInput{input_.getBuffer()[0]};
+
+  if( not _allowExtrapolation_ ){
+    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+  }
+
+  return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+}

--- a/src/DialDictionary/src/DialInterface.cpp
+++ b/src/DialDictionary/src/DialInterface.cpp
@@ -49,8 +49,3 @@ std::string DialInterface::getSummary(bool shallow_) {
 
   return ss.str();
 }
-
-DialInputBuffer *DialInterface::getInputBufferRef() const {
-  return _inputBufferRef_;
-}
-

--- a/src/DialDictionary/src/MonotonicSplineHandler.cpp
+++ b/src/DialDictionary/src/MonotonicSplineHandler.cpp
@@ -25,7 +25,7 @@ void MonotonicSplineHandler::buildSplineData(TGraph& graph_){
 
   LogThrowIf(
       not GenericToolbox::hasUniformlySpacedKnots(&graph_),
-      "Can't use uniform spline with an input that doesn't have uniformly spaced knots"
+      "Can't use monotonic spline with a input that doesn't have uniformly spaced knots"
   );
 
   _splineBounds_.first = graph_.GetX()[0];
@@ -47,4 +47,3 @@ double MonotonicSplineHandler::evaluateSpline(const DialInputBuffer& input_) con
 
   return CalculateMonotonicSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
 }
-

--- a/src/DialDictionary/src/SimpleSplineHandler.cpp
+++ b/src/DialDictionary/src/SimpleSplineHandler.cpp
@@ -4,7 +4,9 @@
 
 #include "SimpleSplineHandler.h"
 #include "CalculateGeneralSpline.h"
+#include "CalculateUniformSpline.h"
 #include "CalculateMonotonicSpline.h"
+#include "CalculateCompactSpline.h"
 
 #include "Logger.h"
 #include "GenericToolbox.Root.h"
@@ -25,8 +27,32 @@ void SimpleSplineHandler::buildSplineData(TGraph& graph_){
   graph_.Sort();
 
   if( GenericToolbox::hasUniformlySpacedKnots(&graph_) ){
-    _isMonotonic_ = true;
+    _isUniform_ = true;
+    _splineBounds_.first = graph_.GetX()[0];
+    _splineBounds_.second = graph_.GetX()[graph_.GetN()-1];
 
+    // If FAKE_UNIFORM_SPLINE is undefined, then reproduce TSpline3 assuming
+    // uniform point spacing.
+#ifndef FAKE_UNIFORM_SPLINE
+    TSpline3 sp(Form("%p", &graph_), &graph_);
+    _splineBounds_.first = sp.GetXmin();
+    _splineBounds_.second = sp.GetXmax();
+
+    _splineData_.resize(2 + sp.GetNp() * 2);
+    _splineData_[0] = sp.GetXmin();
+    _splineData_[1] = ((sp.GetXmax() - sp.GetXmin() ) / (sp.GetNp() - 1.0 ) );
+
+    // Copy the spline data into local storage.
+    for (int i = 0; i < sp.GetNp(); ++i) {
+      double x;
+      double y;
+      sp.GetKnot(i, x, y);
+      _splineData_[2 + 2*i + 0] = y;
+      _splineData_[2 + 2*i + 1] = sp.Derivative(x);
+    }
+#else
+    // If FAKE_UNIFORM_SPLINE is defined, then use a compact spline
+    // representation.
     _splineBounds_.first = graph_.GetX()[0];
     _splineBounds_.second = graph_.GetX()[graph_.GetN()-1];
 
@@ -35,6 +61,7 @@ void SimpleSplineHandler::buildSplineData(TGraph& graph_){
     _splineData_[1] = (graph_.GetX()[graph_.GetN()-1] - graph_.GetX()[0])/(graph_.GetN()-1.0);
 
     memcpy(&_splineData_[2], graph_.GetY(), graph_.GetN() * sizeof(double));
+#endif
   }
   else{
     TSpline3 sp(Form("%p", &graph_), &graph_);
@@ -73,9 +100,20 @@ double SimpleSplineHandler::evaluateSpline(const DialInputBuffer& input_) const{
     else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
-  if( _isMonotonic_ ){
+  if( _isUniform_ ){
+#ifndef FAKE_UNIFORM_SPLINE
+    // Use the same knots and slopes as TSpline3.
+    return CalculateUniformSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+#else
+#ifndef FAKE_UNIFORM_SPLINE_WITH_COMPACT_SPLINE
+    // Fake the TSpline3 spline but impose a monotonic constraint.
     return CalculateMonotonicSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+#else
+    // Fake the TSpline3 spline.  This does a pretty good of reproducing
+    // TSpline3 as long as it uses the default boundary conditions.
+    return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+#endif
+#endif
   }
   return CalculateGeneralSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
 }
-

--- a/src/DialDictionary/src/UniformSplineHandler.cpp
+++ b/src/DialDictionary/src/UniformSplineHandler.cpp
@@ -1,0 +1,55 @@
+//
+// Created by Adrien Blanchet on 23/01/2023.
+//
+
+#include "UniformSplineHandler.h"
+#include "CalculateUniformSpline.h"
+
+#include "GenericToolbox.Root.h"
+#include "Logger.h"
+
+
+LoggerInit([]{
+  Logger::setUserHeaderStr("[MonotonicSplineHandler]");
+});
+
+void UniformSplineHandler::setAllowExtrapolation(bool allowExtrapolation) {
+  _allowExtrapolation_ = allowExtrapolation;
+}
+
+void UniformSplineHandler::buildSplineData(TGraph& graph_){
+  // Copy the spline data into local storage.
+  graph_.Sort();
+  buildSplineData(TSpline3(Form("%p", &graph_), &graph_));
+}
+void UniformSplineHandler::buildSplineData(const TSpline3& sp_){
+  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+
+  _splineBounds_.first = sp_.GetXmin();
+  _splineBounds_.second = sp_.GetXmax();
+
+  _splineData_.resize(2 + sp_.GetNp()*3);
+  _splineData_[0] = sp_.GetXmin();
+  _splineData_[1] = ( ( sp_.GetXmax() - sp_.GetXmin() ) / ( sp_.GetNp()-1.0 ) );
+
+  // Copy the spline data into local storage.
+  for (int i = 0; i < sp_.GetNp(); ++i) {
+    double x;
+    double y;
+    sp_.GetKnot(i,x,y);
+    _splineData_[2 + 2*i + 0] = y;
+    _splineData_[2 + 2*i + 1] = sp_.Derivative(x);
+  }
+
+//  LogThrow(GenericToolbox::parseVectorAsString(_splineData_));
+}
+double UniformSplineHandler::evaluateSpline(const DialInputBuffer& input_) const{
+  double dialInput{input_.getBuffer()[0]};
+
+  if( not _allowExtrapolation_ ){
+    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+  }
+
+  return CalculateUniformSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+}

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -323,7 +323,13 @@ void Propagator::initializeImpl() {
   // the MC has been copied for the Asimov fit, or the "data" use the MC
   // reweighting cache.  This must also be before the first use of
   // reweightMcEvents.
-  if(GlobalVariables::getEnableCacheManager()) Cache::Manager::Build(getFitSampleSet());
+  if(GlobalVariables::getEnableCacheManager()) {
+#ifdef USE_NEW_DIALS
+      Cache::Manager::Build(getFitSampleSet(), _eventDialCache_);
+#else
+      Cache::Manager::Build(getFitSampleSet());
+#endif
+  }
 #endif
 
   LogInfo << "Propagating prior parameters on events..." << std::endl;

--- a/src/Utils/include/CalculateCompactSpline.h
+++ b/src/Utils/include/CalculateCompactSpline.h
@@ -1,11 +1,12 @@
 #ifndef CALCULATE_COMPACT_SPLINE_H_SEEN
-// Calculate a spline with uniformly space knots.  This adds a function that
-// can be called from CPU (with c++), or a GPU (with CUDA).  This is much
-// faster than TSpline3.  This uses the constraint that the slope at the first
-// and last point is equal to the average slope between the first and last two
-// points [i.e. The slope at the first point, M0, is equal to the slope
-// between P0 and P1, so M0 is (P1-P0)/(dist)]. The slope at any point is
-// fixed to be the average slope between the preceding and following points.
+// Calculate a Catmull-Rom spline with uniformly space knots.  This adds a
+// function that can be called from CPU (with c++), or a GPU (with CUDA).
+// This is much faster than TSpline3.  This uses the constraint that the slope
+// at the first and last point is equal to the average slope between the first
+// and last two points [i.e. The slope at the first point, M0, is equal to the
+// slope between P0 and P1, so M0 is (P1-P0)/(dist)]. The slope at any point
+// is fixed to be the average slope between the preceding and following
+// points.
 
 // Wrap the CUDA compiler attributes into a definition.  When this is compiled
 // with a CUDA compiler __CUDACC__ will be defined.  In that case, the code

--- a/src/Utils/include/CalculateCompactSpline.h
+++ b/src/Utils/include/CalculateCompactSpline.h
@@ -1,12 +1,11 @@
-#ifndef CALCULATE_MONOTONIC_SPLINE_H_SEEN
-// Calculate a monotonic spline with uniformly space knots.  This adds a
-// function that can be called from CPU (with c++), or a GPU (with CUDA).
-// This is much faster than TSpline3.  This uses the constraint that the slope
-// at the first and last point is equal to the average slope between the first
-// and last two points [i.e. The slope at the first point, M0, is equal to the
-// slope between P0 and P1, so M0 is (P1-P0)/(dist)].  Before applying the
-// monotonic constraint, the slope at any point is set equal to the average
-// slope between the preceding and following points.
+#ifndef CALCULATE_COMPACT_SPLINE_H_SEEN
+// Calculate a spline with uniformly space knots.  This adds a function that
+// can be called from CPU (with c++), or a GPU (with CUDA).  This is much
+// faster than TSpline3.  This uses the constraint that the slope at the first
+// and last point is equal to the average slope between the first and last two
+// points [i.e. The slope at the first point, M0, is equal to the slope
+// between P0 and P1, so M0 is (P1-P0)/(dist)]. The slope at any point is
+// fixed to be the average slope between the preceding and following points.
 
 // Wrap the CUDA compiler attributes into a definition.  When this is compiled
 // with a CUDA compiler __CUDACC__ will be defined.  In that case, the code
@@ -31,7 +30,7 @@
 
 // Place in a private name space so it plays nicely with CUDA
 namespace {
-    // Interpolate one point using a monotonic spline.  This takes the "index"
+    // Interpolate one point using a compact spline.  This takes the "index"
     // of the point in the data, the parameter value (that made the index), a
     // minimum and maximum bound, the buffer of data for this spline, and the
     // number of data elements in the spline data.  The input data is arrange
@@ -41,10 +40,10 @@ namespace {
     // data[1] -- spline inverse step (not used)
     // data[2+2*n+0] -- The function value for knot n
     DEVICE_CALLABLE_INLINE
-    double CalculateMonotonicSpline(const double x,
-                                    const double lowerBound, double upperBound,
-                                    const DEVICE_FLOATING_POINT* data,
-                                    const int dim) {
+    double CalculateCompactSpline(const double x,
+                                  const double lowerBound, double upperBound,
+                                  const DEVICE_FLOATING_POINT* data,
+                                  const int dim) {
 
         // Interpolate between p2 and p3
         // ix-2 ix-1 ix   ix+1 ix+2 ix+3
@@ -106,50 +105,6 @@ namespace {
         // double m1 = 0.5*(d10+d21);
         double m2 = 0.5*(d21+d32);
         double m3 = 0.5*(d32+d43);
-
-#define COMPACT_SPLINE_MONOTONIC
-#ifdef COMPACT_SPLINE_MONOTONIC
-// #warning Using a MONOTONIC spline
-        const double d54 = data[2+d54_1] - data[2+d54_0];
-        double m4 = 0.5*(d43+d54);
-
-        // Deal with cusp points and flat areas.
-        // if (d21*d10 < 0.0) m1 = 0.0;
-        if (d32*d21 <= 0.0) m2 = 0.0;
-        if (d43*d32 <= 0.0) m3 = 0.0;
-        if (d54*d43 <= 0.0) m4 = 0.0;
-
-        // Find the alphas and betas
-        // double a0 = (d10>0) ? m0/d21: 0;
-        // double b0 = (d10>0) ? m1/d21: 0;
-        // double a1 = (d21>0) ? m1/d21: 0;
-        const double b1 = (d21>0) ? m2/d21: 0;
-        const double a2 = (d32>0) ? m2/d32: 0;
-        const double b2 = (d32>0) ? m3/d32: 0;
-        const double a3 = (d43>0) ? m3/d43: 0;
-        const double b3 = (d43>0) ? m4/d43: 0;
-        // double a4 = (d54>0) ? m4/d54: 0;
-        // double b4 = (d54>0) ? m5/d54: 0;
-
-        // Find places where can only be piecewise monotonic.
-        // if (b0 <= 0) m1 = 0.0;
-        if (b1 <= 0) m2 = 0.0;
-        if (b2 <= 0) m3 = 0.0;
-        // if (b3 <= 0) m4 = 0.0;
-        // if (b4 <= 0) m5 = 0.0;
-        // if (a0 <= 0) m0 = 0.0;
-        // if (a1 <= 0) m1 = 0.0;
-        if (a2 <= 0) m2 = 0.0;
-        if (a3 <= 0) m3 = 0.0;
-        // if (a4 <= 0) m4 = 0.0;
-
-        // Limit the slopes so there isn't overshoot.  It might be
-        // possible to handle the zero slope sections here without an
-        // extra conditional.  if (a1 > 3 || b1 > 3) m1 = 3.0*d21;
-        if (a2 > 3 || b2 > 3) m2 = 3.0*d32;
-        if (a3 > 3 || b3 > 3) m3 = 3.0*d43;
-        // if (a4 > 3 || b4 > 3) m4 = 3.0*d54;
-#endif
 
         // Cubic spline with the points and slopes.
         // double v = p2*(2.0*fxxx-3.0*fxx+1.0) + m2*(fxxx-2.0*fxx+fx)

--- a/src/Utils/include/CalculateUniformSpline.h
+++ b/src/Utils/include/CalculateUniformSpline.h
@@ -28,7 +28,7 @@
 namespace {
     // Interpolate one point using a spline with uniformly spaced knots.  This
     // is much faster than TSpline3 (about fifty times faster, but careful,
-    // controlled, benchmarking was not done).  This takes the "index" of the
+    // controlled benchmarking was not done).  This takes the "index" of the
     // point in the data, the parameter value (that made the index), a minimum
     // and maximum output value, the buffer of data for this spline, and the
     // number of data elements in the spline data.  The input data is arrange


### PR DESCRIPTION
Update Cache::Manager::Build() to work with the new dial implementation.  This also separates the implemenation of the compact and monotonic Catmull-Rom splines (compact and monotonic in GUNDAM jargon).  