### PR TITLE
Feature/extended dial base

### DIFF
--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -217,22 +217,22 @@ bool Cache::Manager::Build(FitSampleSet& sampleList,
             else if (dialType.find("GeneralSpline") == 0) {
                 ++generalSplines;
                 GeneralSpline* d = dynamic_cast<GeneralSpline*>(dial);
-                generalPoints += d->getSplineData().size();
+                generalPoints += d->getDialData().size();
             }
             else if (dialType.find("UniformSpline") == 0) {
                 ++uniformSplines;
                 UniformSpline* d = dynamic_cast<UniformSpline*>(dial);
-                uniformPoints += d->getSplineData().size();
+                uniformPoints += d->getDialData().size();
             }
             else if (dialType.find("MonotonicSpline") == 0) {
                 ++monotonicSplines;
                 MonotonicSpline* d = dynamic_cast<MonotonicSpline*>(dial);
-                monotonicPoints += d->getSplineData().size();
+                monotonicPoints += d->getDialData().size();
             }
             else if (dialType.find("CompactSpline")) {
                 ++compactSplines;
                 CompactSpline* d = dynamic_cast<CompactSpline*>(dial);
-                compactPoints += d->getSplineData().size();
+                compactPoints += d->getDialData().size();
             }
             else {
                 LogThrow("Unsupported dial type in Cache::Manager -- "

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1258,57 +1258,57 @@ void DataDispenser::fillFunction(int iThread_){
                 freeSlotDial = dialCollectionRef->getNextDialFreeSlot();
                 if      ( dialCollectionRef->getGlobalDialType() == "Spline" ){
                   if(dialCollectionRef->useCachedDials() ) {
-                    ( (SplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->createSpline( grPtr );
-                    ( (SplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                   else {
-                    ( (Spline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->createSpline( grPtr );
-                    ( (Spline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                 }
                 else if ( dialCollectionRef->getGlobalDialType() == "MonotonicSpline" ){
                   if(dialCollectionRef->useCachedDials() ) {
-                    ( (MonotonicSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (MonotonicSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                   else {
-                    ( (MonotonicSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (MonotonicSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                 }
                 else if ( dialCollectionRef->getGlobalDialType() == "GeneralSpline" ){
                   if(dialCollectionRef->useCachedDials() ) {
-                    ( (GeneralSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (GeneralSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                   else {
-                    ( (GeneralSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (GeneralSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                 }
                 else if ( dialCollectionRef->getGlobalDialType() == "SimpleSpline" ){
                   if(dialCollectionRef->useCachedDials() ) {
-                    ( (SimpleSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (SimpleSplineCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                   else {
-                    ( (SimpleSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->buildSplineData( *grPtr );
-                    ( (SimpleSpline*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                 }
                 else if ( dialCollectionRef->getGlobalDialType() == "Graph" ){
                   if(dialCollectionRef->useCachedDials() ) {
-                    ( (GraphCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setGraph( *grPtr );
-                    ( (GraphCache*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                   else{
-                    ( (Graph*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setGraph( *grPtr );
-                    ( (Graph*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                   }
                 }
                 else if ( dialCollectionRef->getGlobalDialType() == "LightGraph" ){
-                  ( (LightGraph*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setGraph( *grPtr );
-                  ( (LightGraph*) dialCollectionRef->getDialBaseList()[freeSlotDial].get() )->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
+                  dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
+                  dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
                 }
                 else{
                   LogThrow( "Unsupported event-by-event dial: " << dialCollectionRef->getGlobalDialType() );

--- a/src/DialDictionary/include/CompactSpline.h
+++ b/src/DialDictionary/include/CompactSpline.h
@@ -21,15 +21,26 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<CompactSpline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"CompactSpline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
   void buildSplineData(TGraph& graph_);
   [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
 
-  bool getIsUniform() const {return true;}
-  const std::vector<double>& getSplineData() const {return _splineData_;}
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") override;
+
+  const std::vector<double>& getDialData() const override {return _splineData_;}
 
 protected:
   bool _allowExtrapolation_{false};

--- a/src/DialDictionary/include/DialBase.h
+++ b/src/DialDictionary/include/DialBase.h
@@ -28,16 +28,49 @@ public:
 
   // virtual layer + 8 bytes
 
-  // to override
-  [[nodiscard]] virtual std::unique_ptr<DialBase> clone() const = 0; // can't allocate pure virtual class
-  [[nodiscard]] virtual std::string getDialTypeName() const { return {"DialBase"}; }
-  virtual double evalResponseImpl(const DialInputBuffer& input_) = 0;
-  virtual bool isBinned(){ return false; }
+  // Construct a copy of this dial.  Needed for PolymorphicObject.
+  [[nodiscard]] virtual std::unique_ptr<DialBase> clone() const = 0;
 
-  // other virtual
-  virtual double evalResponse(const DialInputBuffer& input_) {return this->evalResponseImpl(input_); }
+  // Return the name of the dial type (simple local RTTI).
+  [[nodiscard]] virtual std::string getDialTypeName() const = 0;
 
-  //! class size = 8 bytes (no padding!)
+  // virtual bool isBinned(){ return false; }
+
+  /// Evaluate the the dial response at the set of parameter values in
+  /// DialInputBuffer.
+  [[nodiscard]] virtual double evalResponse(const DialInputBuffer& input_) const = 0;
+
+  /// Allow extrapolation of the data.  The default is to
+  /// forbid extrapolation.
+  virtual void setAllowExtrapolation(bool allow=false) {}
+  virtual bool getAllowExtrapolation() const {return false;}
+
+  /////////////////////////////////////////////////////////////////////////
+  // Pass information to the dial so that it can build it's internal
+  // information.  New overloads should be added as we have classes of dials
+  // (e.g. multi-dimensional dials).
+  /////////////////////////////////////////////////////////////////////////
+
+  /// Build the dial with no input arguments.  Mostly here for completeness!
+  virtual void buildDial(std::string option="") {throw std::runtime_error("Not implemented");}
+
+  /// Build the dial using up to up to three vectors of doubles.  Mostly
+  /// an internal tool to make spline and graph builders work the same.
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") {throw std::runtime_error("Not implemented");}
+
+  /// Build the dial using a graph (usually a leaf in the input file
+  virtual void buildDial(const TGraph& grf, std::string option="") {throw std::runtime_error("Not implemented");}
+
+  /// Build the dial using a spline (usually a leaf in the input file.
+  virtual void buildDial(const TSpline3& spl, std::string option="") {throw std::runtime_error("Not implemented");}
+
+  /// Return the data used by the dial to calculate the output values. The
+  /// specific data contained in the vector depends on the derived class.
+  virtual const std::vector<double>& getDialData() const;
+
 };
 
 /// This is a template to add caching to a DialBase derived class.
@@ -45,24 +78,24 @@ template <typename T>
 class CachedDial: public T {
 public:
   CachedDial() = default;
-  double evalResponse(const DialInputBuffer& input_) override;
+  double evalResponse(const DialInputBuffer& input_) const override;
   bool isCacheValid(const DialInputBuffer& input_) const;
-  void updateInputCache(const DialInputBuffer& input_);
+  void updateInputCache(const DialInputBuffer& input_) const;
 
 protected:
-  double _cachedResponse_{std::nan("unset")}; // + 8 bytes
-  GenericToolbox::NoCopyWrapper<std::mutex> _evalLock_{}; // + 64 bytes
+  mutable double _cachedResponse_{std::nan("unset")}; // + 8 bytes
+  mutable GenericToolbox::NoCopyWrapper<std::mutex> _evalLock_{}; // + 64 bytes
 #if USE_ZLIB
   // + 4 bytes (keeping a vector empty is already 24...)
-  uint32_t _cachedInputHash_{0};
+  mutable uint32_t _cachedInputHash_{0};
 #else
-  std::vector<double> _cachedInputs_{}; // + 24 bytes
+  mutable std::vector<double> _cachedInputs_{}; // + 24 bytes
 #endif
 };
 
 /// This is a template to add caching to a DialBase derived class.
 template <typename T>
-double CachedDial<T>::evalResponse(const DialInputBuffer& input_) {
+double CachedDial<T>::evalResponse(const DialInputBuffer& input_) const {
   if (isCacheValid(input_)) {return _cachedResponse_;}
 #if HAS_CPP_17
   std::scoped_lock<std::mutex> g(_evalLock_);
@@ -88,7 +121,7 @@ bool CachedDial<T>::isCacheValid(const DialInputBuffer& input_) const {
 }
 
 template <typename T>
-void CachedDial<T>::updateInputCache(const DialInputBuffer& input_) {
+void CachedDial<T>::updateInputCache(const DialInputBuffer& input_) const {
 #if USE_ZLIB
   _cachedInputHash_ = input_.getCurrentHash();
 #else

--- a/src/DialDictionary/include/GeneralSpline.h
+++ b/src/DialDictionary/include/GeneralSpline.h
@@ -22,16 +22,23 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<GeneralSpline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"GeneralSpline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
-  void buildSplineData(TGraph& graph_);
-  void buildSplineData(const TSpline3& sp_);
-  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") override;
 
-  bool getIsUniform() const {return false;}
-  const std::vector<double>& getSplineData() const {return _splineData_;}
+   const std::vector<double>& getDialData() const override {return _splineData_;}
 
 protected:
   bool _allowExtrapolation_{false};

--- a/src/DialDictionary/include/Graph.h
+++ b/src/DialDictionary/include/Graph.h
@@ -16,14 +16,16 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Graph>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"Graph"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateGraph(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
-  void setGraph(const TGraph &graph);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
-  [[nodiscard]] double evaluateGraph(const DialInputBuffer& input_) const;
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
 
 protected:
+  [[nodiscard]] double evaluateGraph(const DialInputBuffer& input_) const;
+
   bool _allowExtrapolation_{false};
   TGraph _graph_{};
 };

--- a/src/DialDictionary/include/LightGraph.h
+++ b/src/DialDictionary/include/LightGraph.h
@@ -13,18 +13,19 @@
 class LightGraph : public DialBase {
 
 public:
-    LightGraph() = default;
-     
-    [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<LightGraph>(*this); }
-    [[nodiscard]] std::string getDialTypeName() const override { return {"LightGraph"}; }
-    double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateGraph(input_); }
+  LightGraph() = default;
 
-    void setAllowExtrapolation(bool allowExtrapolation);
-  void setGraph(TGraph &graph);
+  [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<LightGraph>(*this); }
+  [[nodiscard]] std::string getDialTypeName() const override { return {"LightGraph"}; }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  [[nodiscard]] double evaluateGraph(const DialInputBuffer& input_) const;
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
+
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
 
 protected:
+  [[nodiscard]] double evaluateGraph(const DialInputBuffer& input_) const;
   bool _allowExtrapolation_{false};
   Int_t nPoints{0};   ///< Number of points <= fMaxSize
   std::vector<Double_t> xPoints; ///<[fNpoints] array of X points

--- a/src/DialDictionary/include/MonotonicSpline.h
+++ b/src/DialDictionary/include/MonotonicSpline.h
@@ -21,15 +21,23 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<MonotonicSpline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"MonotonicSpline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
-  void buildSplineData(TGraph& graph_);
-  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") override;
 
-  bool getIsUniform() const {return true;}
-  const std::vector<double>& getSplineData() const {return _splineData_;}
+  const std::vector<double>& getDialData() const override {return _splineData_;}
 
 protected:
   bool _allowExtrapolation_{false};

--- a/src/DialDictionary/include/Norm.h
+++ b/src/DialDictionary/include/Norm.h
@@ -17,7 +17,7 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Norm>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"Norm"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return input_.getBuffer()[0]; }
+  double evalResponse(const DialInputBuffer& input_) const override { return input_.getBuffer()[0]; }
 
 };
 

--- a/src/DialDictionary/include/SimpleSpline.h
+++ b/src/DialDictionary/include/SimpleSpline.h
@@ -22,20 +22,23 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<SimpleSpline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"SimpleSpline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
-  void buildSplineData(TGraph& graph_);
-  void buildSplineData(const TSpline3& sp_);
-  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
 
-  bool getIsUniform() const {return _isUniform_;}
-  const std::vector<double>& getSplineData() const {return _splineData_;}
+  const std::vector<double>& getDialData() const override {return _splineData_;}
 
 protected:
-  bool _allowExtrapolation_{false};
   bool _isUniform_{false};
+  bool _allowExtrapolation_{false};
 
   // A block of data to calculate the spline values.  This must be filled for
   // the Cache::Manager to work, and provides the input for spline calculation

--- a/src/DialDictionary/include/Spline.h
+++ b/src/DialDictionary/include/Spline.h
@@ -16,18 +16,28 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Spline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"Spline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") override;
+
+protected:
   void setSpline(const TSpline3 &spline);
   [[nodiscard]] const TSpline3 &getSpline() const;
 
   void copySpline(const TSpline3* splinePtr_);
   void createSpline(TGraph* grPtr_);
 
-  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
-
-protected:
   bool _allowExtrapolation_{false};
   TSpline3 _spline_{};
 

--- a/src/DialDictionary/include/UniformSpline.h
+++ b/src/DialDictionary/include/UniformSpline.h
@@ -22,16 +22,23 @@ public:
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<UniformSpline>(*this); }
   [[nodiscard]] std::string getDialTypeName() const override { return {"UniformSpline"}; }
-  double evalResponseImpl(const DialInputBuffer& input_) override { return this->evaluateSpline(input_); }
+  double evalResponse(const DialInputBuffer& input_) const override;
 
-  void setAllowExtrapolation(bool allowExtrapolation);
+  void setAllowExtrapolation(bool allowExtrapolation) override;
+  bool getAllowExtrapolation() const override;
 
-  void buildSplineData(TGraph& graph_);
-  void buildSplineData(const TSpline3& sp_);
-  [[nodiscard]] double evaluateSpline(const DialInputBuffer& input_) const;
+  /// Pass information to the dial so that it can build it's
+  /// internal information.  New build overloads should be
+  /// added as we have classes of dials
+  /// (e.g. multi-dimensional dials).
+  virtual void buildDial(const TGraph& grf, std::string option="") override;
+  virtual void buildDial(const TSpline3& spl, std::string option="") override;
+  virtual void buildDial(const std::vector<double>& v1,
+                         const std::vector<double>& v2,
+                         const std::vector<double>& v3,
+                         std::string option="") override;
 
-  bool getIsUniform() const {return true;}
-  const std::vector<double>& getSplineData() const {return _splineData_;}
+   const std::vector<double>& getDialData() const override {return _splineData_;}
 
 protected:
   bool _allowExtrapolation_{false};

--- a/src/DialDictionary/src/CompactSpline.cpp
+++ b/src/DialDictionary/src/CompactSpline.cpp
@@ -17,27 +17,62 @@ void CompactSpline::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
 
-void CompactSpline::buildSplineData(TGraph& graph_){
+bool CompactSpline::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
+}
+
+void CompactSpline::buildDial(const TSpline3& spline, std::string option) {
+  std::vector<double> xPoint(spline.GetNp());
+  std::vector<double> yPoint(spline.GetNp());
+  std::vector<double> dummy;
+  xPoint.clear(); yPoint.clear();
+  for (int i = 0; i<spline.GetNp(); ++i) {
+    double x; double y;
+    spline.GetKnot(i,x,y);
+    xPoint.push_back(x);
+    yPoint.push_back(y);
+  }
+  buildDial(xPoint,yPoint,dummy,option);
+}
+
+void CompactSpline::buildDial(const TGraph& grf, std::string option) {
+  std::vector<double> xPoint(grf.GetN());
+  std::vector<double> yPoint(grf.GetN());
+  std::vector<double> dummy;
+  xPoint.clear(); yPoint.clear();
+  for (int i = 0; i<grf.GetN(); ++i) {
+      double x; double y;
+      grf.GetPoint(i,x,y);
+      xPoint.push_back(x);
+      yPoint.push_back(y);
+  }
+  buildDial(xPoint,yPoint,dummy,option);
+}
+
+
+void CompactSpline::buildDial(const std::vector<double>& v1,
+                              const std::vector<double>& v2,
+                              const std::vector<double>& v3,
+                              std::string option) {
   LogThrowIf(not _splineData_.empty(), "Spline data already set.");
 
-  // Copy the spline data into local storage.
-  graph_.Sort();
+  _splineBounds_.first = v1.front();
+  _splineBounds_.second = v1.back();
 
-  LogThrowIf(
-      not GenericToolbox::hasUniformlySpacedKnots(&graph_),
-      "Can't use compact spline with a input that doesn't have uniformly spaced knots"
-  );
+  _splineData_.resize(2 + v1.size());
+  _splineData_[0] = v1.front();
+  _splineData_[1] = (v1.back() - v1.front())/(v1.size()-1.0);
 
-  _splineBounds_.first = graph_.GetX()[0];
-  _splineBounds_.second = graph_.GetX()[graph_.GetN()-1];
+  for (int i=0; i<v1.size()-1; ++i) {
+      double d = std::abs(v1[i] - _splineData_[0] - i*_splineData_[1]);
+      LogThrowIf(d>1E-8, "CompactSplines require uniform knots");
+  }
 
-  _splineData_.resize(2 + graph_.GetN());
-  _splineData_[0] = graph_.GetX()[0];
-  _splineData_[1] = (graph_.GetX()[graph_.GetN()-1] - graph_.GetX()[0])/(graph_.GetN()-1.0);
+  for(int i=0; i<v2.size(); ++i) _splineData_[2+i] = v2[i];
 
-  memcpy(&_splineData_[2], graph_.GetY(), graph_.GetN() * sizeof(double));
 }
-double CompactSpline::evaluateSpline(const DialInputBuffer& input_) const{
+
+double CompactSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/src/DialBase.cpp
+++ b/src/DialDictionary/src/DialBase.cpp
@@ -10,3 +10,11 @@ LoggerInit([]{
   Logger::setUserHeaderStr("[DialBase]");
 });
 
+const std::vector<double>& DialBase::getDialData() const {
+    throw std::runtime_error("getDialData not implemented for "
+                             + this->getDialTypeName());
+    static const std::vector<double> dummy;
+    return dummy;
+}
+
+std::string DialBase::getDialTypeName() const { return {"DialBase"}; }

--- a/src/DialDictionary/src/DialCollection.cpp
+++ b/src/DialDictionary/src/DialCollection.cpp
@@ -365,14 +365,14 @@ bool DialCollection::initializeDialsWithDefinition() {
 
             if( useCachedDials() ){
               SplineCache s;
-              s.copySpline(binnedSpline);
+              s.buildDial(*binnedSpline);
               s.setAllowExtrapolation(_allowDialExtrapolation_);
               _dialBaseList_.emplace_back( std::make_unique<SplineCache>(s) );
             }
             else{
               Spline s;
               s.setAllowExtrapolation(_allowDialExtrapolation_);
-              s.copySpline(binnedSpline);
+              s.buildDial(*binnedSpline);
               _dialBaseList_.emplace_back( std::make_unique<Spline>(s) );
             }
           }
@@ -389,13 +389,13 @@ bool DialCollection::initializeDialsWithDefinition() {
             if( useCachedDials() ){
               GraphCache g;
               g.setAllowExtrapolation(_allowDialExtrapolation_);
-              g.setGraph( *(binnedGraph) );
+              g.buildDial( *(binnedGraph) );
               _dialBaseList_.emplace_back( std::make_unique<GraphCache>(g) );
             }
             else{
               Graph g;
               g.setAllowExtrapolation(_allowDialExtrapolation_);
-              g.setGraph( *(binnedGraph) );
+              g.buildDial( *(binnedGraph) );
               _dialBaseList_.emplace_back( std::make_unique<Graph>(g) );
             }
           }
@@ -412,13 +412,13 @@ bool DialCollection::initializeDialsWithDefinition() {
             if( this->useCachedDials() ){
               LightGraphCache g;
               g.setAllowExtrapolation(_allowDialExtrapolation_);
-              g.setGraph( *(binnedGraph) );
+              g.buildDial( *(binnedGraph) );
               _dialBaseList_.emplace_back( std::make_unique<LightGraphCache>(g) );
             }
             else{
               LightGraph g;
               g.setAllowExtrapolation(_allowDialExtrapolation_);
-              g.setGraph( *(binnedGraph) );
+              g.buildDial( *(binnedGraph) );
               _dialBaseList_.emplace_back( std::make_unique<LightGraph>(g) );
             }
           }
@@ -491,13 +491,13 @@ bool DialCollection::initializeDialsWithDefinition() {
             if( this->useCachedDials() ){
               SplineCache s;
               s.setAllowExtrapolation(_allowDialExtrapolation_);
-              s.copySpline(splinePtr);
+              s.buildDial(*splinePtr);
               _dialBaseList_.emplace_back( std::make_unique<SplineCache>(s) );
             }
             else{
               Spline s;
               s.setAllowExtrapolation(_allowDialExtrapolation_);
-              s.copySpline(splinePtr);
+              s.buildDial(*splinePtr);
               _dialBaseList_.emplace_back( std::make_unique<Spline>(s) );
             }
           }

--- a/src/DialDictionary/src/DialInterface.cpp
+++ b/src/DialDictionary/src/DialInterface.cpp
@@ -24,7 +24,7 @@ void DialInterface::setDialBinRef(const DataBin *dialBinRef) {
   _dialBinRef_ = dialBinRef;
 }
 
-double DialInterface::evalResponse(){
+double DialInterface::evalResponse() {
   if( _inputBufferRef_->isMasked() ){ return 1; }
   return _responseSupervisorRef_->process( _dialBaseRef_->evalResponse( *_inputBufferRef_ ) );
 }

--- a/src/DialDictionary/src/GeneralSpline.cpp
+++ b/src/DialDictionary/src/GeneralSpline.cpp
@@ -17,34 +17,62 @@ void GeneralSpline::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
 
-void GeneralSpline::buildSplineData(TGraph& graph_){
-  // Copy the spline data into local storage.
-  graph_.Sort();
-  buildSplineData(TSpline3(Form("%p", &graph_), &graph_));
+bool GeneralSpline::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
 }
-void GeneralSpline::buildSplineData(const TSpline3& sp_){
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
 
-  _splineBounds_.first = sp_.GetXmin();
-  _splineBounds_.second = sp_.GetXmax();
+void GeneralSpline::buildDial(const TGraph& graph_, std::string option_){
+  // Copy the spline data into local storage.
+  TGraph grf(graph_);
+  grf.Sort();
+  buildDial(TSpline3(Form("%p", &graph_), &graph_), option_);
+}
 
-  _splineData_.resize(2 + sp_.GetNp()*3);
-  _splineData_[0] = sp_.GetXmin();
-  _splineData_[1] = ( ( sp_.GetXmax() - sp_.GetXmin() ) / ( sp_.GetNp()-1.0 ) );
+void GeneralSpline::buildDial(const TSpline3& sp_, std::string option_){
+  std::vector<double> xPoints;
+  std::vector<double> yPoints;
+  std::vector<double> deriv;
 
   // Copy the spline data into local storage.
   for (int i = 0; i < sp_.GetNp(); ++i) {
     double x;
     double y;
     sp_.GetKnot(i,x,y);
+    double d = sp_.Derivative(x);
+    xPoints.push_back(x);
+    yPoints.push_back(y);
+    deriv.push_back(d);
+  }
+  buildDial(xPoints, yPoints, deriv);
+}
+
+void GeneralSpline::buildDial(const std::vector<double>& xPoints,
+                              const std::vector<double>& yPoints,
+                              const std::vector<double>& deriv,
+                              std::string option_){
+  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+
+  _splineBounds_.first = xPoints.front();
+  _splineBounds_.second = xPoints.back();
+
+  _splineData_.resize(2 + xPoints.size()*3);
+  _splineData_[0] = xPoints.front();
+  _splineData_[1] = (xPoints.back()-xPoints.front())/(xPoints.size()-1.0);
+
+  // Copy the spline data into local storage.
+  for (int i = 0; i < xPoints.size(); ++i) {
+    double x = xPoints[i];
+    double y = yPoints[i];
+    double d = deriv[i];
     _splineData_[2 + 3*i + 0] = y;
-    _splineData_[2 + 3*i + 1] = sp_.Derivative(x);
+    _splineData_[2 + 3*i + 1] = d;
     _splineData_[2 + 3*i + 2] = x;
   }
 
 //  LogThrow(GenericToolbox::parseVectorAsString(_splineData_));
 }
-double GeneralSpline::evaluateSpline(const DialInputBuffer& input_) const{
+
+double GeneralSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/src/Graph.cpp
+++ b/src/DialDictionary/src/Graph.cpp
@@ -7,14 +7,19 @@
 void Graph::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
-void Graph::setGraph(const TGraph &graph) {
-  LogThrowIf(_graph_.GetN() != 0, "Graph already set.");
+
+bool Graph::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
+}
+
+void Graph::buildDial(const TGraph &graph, std::string option) {
+    LogThrowIf(_graph_.GetN() != 0, "Graph already set.");
   LogThrowIf(graph.GetN() == 0, "Invalid input graph");
   _graph_ = graph;
   _graph_.Sort();
 }
 
-double Graph::evaluateGraph(const DialInputBuffer& input_) const{
+double Graph::evalResponse(const DialInputBuffer& input_) const {
   if( not _allowExtrapolation_ ){
     if     (input_.getBuffer()[0] <= _graph_.GetX()[0])                { return _graph_.GetY()[0]; }
     else if(input_.getBuffer()[0] >= _graph_.GetX()[_graph_.GetN()-1]) { return _graph_.GetY()[_graph_.GetN() - 1]; }

--- a/src/DialDictionary/src/LightGraph.cpp
+++ b/src/DialDictionary/src/LightGraph.cpp
@@ -8,8 +8,14 @@
 void LightGraph::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
-void LightGraph::setGraph(TGraph &graph) {
-  LogThrowIf(graph.GetN() == 0, "Invalid input graph");
+
+bool LightGraph::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
+}
+
+void LightGraph::buildDial(const TGraph &grf, std::string option) {
+  LogThrowIf(grf.GetN() == 0, "Invalid input graph");
+  TGraph graph(grf);
   graph.Sort();
 
   nPoints = graph.GetN();
@@ -21,7 +27,7 @@ void LightGraph::setGraph(TGraph &graph) {
   memcpy(&yPoints[0], graph.GetY(), nPoints * sizeof(double));
 }
 
-double LightGraph::evaluateGraph(const DialInputBuffer& input_) const{
+double LightGraph::evalResponse(const DialInputBuffer& input_) const {
   LogThrowIf(xPoints.empty(), "No graph point defined.");
   if (nPoints == 1) return yPoints[0];
 

--- a/src/DialDictionary/src/SimpleSpline.cpp
+++ b/src/DialDictionary/src/SimpleSpline.cpp
@@ -20,8 +20,13 @@ void SimpleSpline::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
 
-void SimpleSpline::buildSplineData(TGraph& graph_){
+bool SimpleSpline::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
+}
+
+void SimpleSpline::buildDial(const TGraph& grf, std::string option){
   LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  TGraph graph_ = grf;
 
   // Copy the spline data into local storage.
   graph_.Sort();
@@ -84,7 +89,8 @@ void SimpleSpline::buildSplineData(TGraph& graph_){
   }
 
 }
-void SimpleSpline::buildSplineData(const TSpline3& sp_){
+
+void SimpleSpline::buildDial(const TSpline3& sp_, std::string option) {
   LogThrow("NOT IMPLEMENTED");
 
 
@@ -92,7 +98,8 @@ void SimpleSpline::buildSplineData(const TSpline3& sp_){
 
 
 }
-double SimpleSpline::evaluateSpline(const DialInputBuffer& input_) const{
+
+double SimpleSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/src/UniformSpline.cpp
+++ b/src/DialDictionary/src/UniformSpline.cpp
@@ -17,33 +17,65 @@ void UniformSpline::setAllowExtrapolation(bool allowExtrapolation) {
   _allowExtrapolation_ = allowExtrapolation;
 }
 
-void UniformSpline::buildSplineData(TGraph& graph_){
-  // Copy the spline data into local storage.
-  graph_.Sort();
-  buildSplineData(TSpline3(Form("%p", &graph_), &graph_));
+bool UniformSpline::getAllowExtrapolation() const {
+  return _allowExtrapolation_;
 }
-void UniformSpline::buildSplineData(const TSpline3& sp_){
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
 
-  _splineBounds_.first = sp_.GetXmin();
-  _splineBounds_.second = sp_.GetXmax();
+void UniformSpline::buildDial(const TGraph& graph_, std::string option_){
+  // Copy the spline data into local storage.
+  TGraph grf(graph_);
+  grf.Sort();
+  buildDial(TSpline3(Form("%p", &graph_), &graph_), option_);
+}
 
-  _splineData_.resize(2 + sp_.GetNp()*3);
-  _splineData_[0] = sp_.GetXmin();
-  _splineData_[1] = ( ( sp_.GetXmax() - sp_.GetXmin() ) / ( sp_.GetNp()-1.0 ) );
+void UniformSpline::buildDial(const TSpline3& sp_, std::string option_){
+  std::vector<double> xPoints;
+  std::vector<double> yPoints;
+  std::vector<double> deriv;
 
   // Copy the spline data into local storage.
   for (int i = 0; i < sp_.GetNp(); ++i) {
     double x;
     double y;
     sp_.GetKnot(i,x,y);
-    _splineData_[2 + 2*i + 0] = y;
-    _splineData_[2 + 2*i + 1] = sp_.Derivative(x);
+    double d = sp_.Derivative(x);
+    xPoints.push_back(x);
+    yPoints.push_back(y);
+    deriv.push_back(d);
+  }
+  buildDial(xPoints, yPoints, deriv);
+}
+
+void UniformSpline::buildDial(const std::vector<double>& xPoints,
+                              const std::vector<double>& yPoints,
+                              const std::vector<double>& deriv,
+                              std::string option_){
+  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+
+  _splineBounds_.first = xPoints.front();
+  _splineBounds_.second = xPoints.back();
+
+  _splineData_.resize(2 + xPoints.size()*2);
+  _splineData_[0] = xPoints.front();
+  _splineData_[1] = (xPoints.back()-xPoints.front())/(xPoints.size()-1.0);
+
+  for (int i=0; i<xPoints.size()-1; ++i) {
+      double d = std::abs(xPoints[i] - _splineData_[0] - i*_splineData_[1]);
+      LogThrowIf(d>1E-8, "UniformSplines require uniform knots");
   }
 
-//  LogThrow(GenericToolbox::parseVectorAsString(_splineData_));
+  // Copy the spline data into local storage.
+  for (int i = 0; i < xPoints.size(); ++i) {
+    double x = xPoints[i];
+    double y = yPoints[i];
+    double d = deriv[i];
+    _splineData_[2 + 2*i + 0] = y;
+    _splineData_[2 + 2*i + 1] = d;
+  }
+
 }
-double UniformSpline::evaluateSpline(const DialInputBuffer& input_) const{
+
+double UniformSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
   if( not _allowExtrapolation_ ){


### PR DESCRIPTION
Extend the DialBase class with the methods needed to initialize all of the current dial types.  All of our dials have pretty similar initialization requirements, so this only adds a small set of methods.  It does simplify the overall initialization since down-casts are no longer necessary.  