### PR TITLE
Feature/dial base factories

### DIFF
--- a/documentation/configuration/DialSet.md
+++ b/documentation/configuration/DialSet.md
@@ -14,7 +14,8 @@
 | printDialsSummary      | bool         | extra verbose                                                   | false   |
 | parametersBinningPath  | string       | create a dedicated norm dial according to the parameter binning |         |
 | dialsDefinitions       | json         | dials config                                                    |         |
-| dialsType              | string       | {Norm, Spline, Graph}                                           |         |
+| dialsType              | string       | {Norm, Normalization, Spline, Graph}                            |         |
+| dialSubType            | string       | {not-a-knot, natural, catmull-rom, light, monotonic} [1]        | empty   |
 | applyCondition         | string       | formula condition that applies on every dial of the set         |         |
 | applyConditions        | json         | config gathering multiple formulas                              |         |
 | minDialResponse        | double       | cap dial response                                               |         |
@@ -24,6 +25,30 @@
 | mirrorHighEdge         | double       | upper edge where mirroring applies                              |         |
 | allowDialExtrapolation | bool         | evaluate dials even out of boundaries                           | false   |
 
+[1] The values for the dialSubType depend on the value of dialsType.  Specifically:
+
+* Norm: This is a normalization parameter, and the subtype is currently ignored
+* Graph: This does linear interpolation between points.  The subtype
+      values are ROOT, or light.
+  - ROOT: A ROOT TGraph object is used
+  - light: A gundam LightGraph object is used.
+* Spline: Implement a spline controled by input knots provided as a
+      graph.  In several cases a GeneralSpline, or UniformSpline
+      object may be used.  The choice depends on the spacing of the
+      input points.  UniformSpline assumes regular point spacing, and
+      GeneralSpline does not require that.  The subtype meanings are:
+  - ROOT: A ROOT TSpline3 without constraints is used.  This results
+      the slopes being estimated using the Not-A-Knot criteria.
+  - not-a-knot: Use a GeneralSpline, or UniformSpline with the slopes
+      calculated using the not-a-knot criteria.
+  - natural: Use a GeneralSpline with the slopes calculated using the
+      natural spline criteria
+  - catmull-rom: Estimate the slopes using the Catmull-Rom criteria.
+      This uses the average slopes for the points before and after.
+  - monotonic: Apply the monotonic critera to the slopes before they
+      are used.  This applies to "not-a-knot", "natural" and
+      "catmull-rom" splines.  The monotonic criteria cannot be applied
+      the "ROOT" TSpline3.
 
 ### applyConditions options
 
@@ -34,6 +59,8 @@
 | excludedRanges                    | list(pair(double)) | list of ranges (min, max) where the dials of the set don't apply |         |
 | allowedValues                     | list(double)       | list of values where the dials of the set apply                  |         |
 | excludedValues                    | list(double)       | list of values where the dials of the set apply                  |         |
+
+
 
 
 ### dialsDefinitions options
@@ -48,4 +75,3 @@
 | dialsList           | string | path within root file to the list of dials                         |         |
 | dialsTreePath (old) | string | tree name where the dials are stored                               |         |
 | dialSubType         | string | cache manager spline type (dev)                                    |         |
-

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -663,11 +663,11 @@ void DataDispenser::preAllocateMemory(){
             double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(SplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(SplineCache()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(Spline);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(Spline()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(Spline()));
             }
 
             eventByEventDialSize += dialsSizeInRam;
@@ -679,11 +679,11 @@ void DataDispenser::preAllocateMemory(){
             double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(MonotonicSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(MonotonicSplineCache()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(MonotonicSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(MonotonicSpline);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(MonotonicSpline()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(MonotonicSpline()));
             }
 
             eventByEventDialSize += dialsSizeInRam;
@@ -695,11 +695,11 @@ void DataDispenser::preAllocateMemory(){
             double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(GeneralSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(GeneralSplineCache()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GeneralSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(GeneralSpline);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(GeneralSpline()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GeneralSpline()));
             }
 
             eventByEventDialSize += dialsSizeInRam;
@@ -711,11 +711,11 @@ void DataDispenser::preAllocateMemory(){
             double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(SimpleSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(SimpleSplineCache()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SimpleSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(SimpleSpline);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(SimpleSpline()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SimpleSpline()));
             }
 
             eventByEventDialSize += dialsSizeInRam;
@@ -727,11 +727,11 @@ void DataDispenser::preAllocateMemory(){
             double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(GraphCache);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(GraphCache()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GraphCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(Graph);
-              dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(Graph()));
+              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(Graph()));
             }
 
             eventByEventDialSize += dialsSizeInRam;
@@ -742,7 +742,7 @@ void DataDispenser::preAllocateMemory(){
             dialCollection->getDialBaseList().clear();
             double dialsSizeInRam{0};
             dialsSizeInRam = double(nEvents) * sizeof(LightGraph);
-            dialCollection->getDialBaseList().resize(nEvents, GenericToolbox::PolymorphicObjectWrapper<DialBase>(LightGraph()));
+            dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(LightGraph()));
 
             eventByEventDialSize += dialsSizeInRam;
             LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -12,6 +12,7 @@
 #if USE_NEW_DIALS
 #include "DialCollection.h"
 #include "DialTypes.h"
+#include "DialBaseFactory.h"
 #else
 #include "SplineDial.h"
 #include "GraphDial.h"
@@ -585,10 +586,11 @@ void DataDispenser::fetchRequestedLeaves(){
 }
 void DataDispenser::preAllocateMemory(){
   LogInfo << "Pre-allocating memory..." << std::endl;
-  /// \brief The following lines are necessary since the events might get resized while being in multithread
-  /// Because std::vector is insuring continuous memory allocation, a resize sometimes
-  /// lead to the full moving of a vector memory. This is not thread safe, so better ensure
-  /// the vector won't have to do this by allocating the right event size.
+  /// \brief The following lines are necessary since the events might get
+  /// resized while being in multithread Because std::vector is insuring
+  /// continuous memory allocation, a resize sometimes lead to the full moving
+  /// of a vector memory. This is not thread safe, so better ensure the vector
+  /// won't have to do this by allocating the right event size.
 
   // MEMORY CLAIM?
   TChain treeChain(_parameters_.treePath.c_str());
@@ -647,7 +649,9 @@ void DataDispenser::preAllocateMemory(){
           for( auto& bin : dialCollection->getDialBinSet().getBinsList() ){
             std::vector<int> varIndexes;
             for( auto& var : bin.getVariableNameList() ){
-              varIndexes.emplace_back(GenericToolbox::findElementIndex(var, _cache_.varsRequestedForIndexing));
+              varIndexes.emplace_back(
+                  GenericToolbox::findElementIndex(
+                      var, _cache_.varsRequestedForIndexing));
             }
             bin.setEventVarIndexCache(varIndexes);
           }
@@ -658,99 +662,60 @@ void DataDispenser::preAllocateMemory(){
           LogInfo << dialCollection->getTitle() << ": creating " << nEvents;
           LogInfo << " " << dialType;
 
+          double dialsSizeInRam{0};
+          dialCollection->getDialBaseList().clear();
+          dialCollection->getDialBaseList().resize(nEvents);
           if     ( dialType == "Spline" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(SplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(Spline);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(Spline()));
             }
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
-
           }
           else if( dialType == "MonotonicSpline" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(MonotonicSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(MonotonicSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(MonotonicSpline);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(MonotonicSpline()));
             }
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
-
           }
           else if( dialType == "GeneralSpline" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(GeneralSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GeneralSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(GeneralSpline);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GeneralSpline()));
             }
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
-
           }
           else if( dialType == "SimpleSpline" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(SimpleSplineCache);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SimpleSplineCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(SimpleSpline);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(SimpleSpline()));
             }
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
-
           }
           else if( dialType == "Graph" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             if(dialCollection->useCachedDials() ){
               dialsSizeInRam = double(nEvents) * sizeof(GraphCache);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(GraphCache()));
             }
             else{
               dialsSizeInRam = double(nEvents) * sizeof(Graph);
-              dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(Graph()));
             }
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
-
           }
           else if( dialType == "LightGraph" ){
-            dialCollection->getDialBaseList().clear();
-            double dialsSizeInRam{0};
             dialsSizeInRam = double(nEvents) * sizeof(LightGraph);
-            dialCollection->getDialBaseList().resize(nEvents, DialCollection::DialBaseObject(LightGraph()));
-
-            eventByEventDialSize += dialsSizeInRam;
-            LogInfo << " dials (" << GenericToolbox::parseSizeUnits( dialsSizeInRam ) << ")" << std::endl;
           }
           else{
             LogInfo << std::endl;
             LogThrow("Invalid dial type for event-by-event dial: " << dialType);
           }
+          eventByEventDialSize += dialsSizeInRam;
+          LogInfo << " dials ("
+                  << GenericToolbox::parseSizeUnits( dialsSizeInRam )
+                  << ")" << std::endl;
 
         }
         else{
@@ -758,7 +723,9 @@ void DataDispenser::preAllocateMemory(){
         }
       }
       _eventDialCacheRef_->allocateCacheEntries(nEvents, nDialsMaxPerEvent);
-      LogInfo << "Event-by-event dials take " << GenericToolbox::parseSizeUnits(eventByEventDialSize) << " in RAM." << std::endl;
+      LogInfo << "Event-by-event dials take "
+              << GenericToolbox::parseSizeUnits(eventByEventDialSize)
+              << " in RAM." << std::endl;
     }
   }
 #else
@@ -1215,7 +1182,8 @@ void DataDispenser::fillFunction(int iThread_){
 
               // is only one bin with no condition:
               if( dialCollectionRef->getDialBaseList().size() == 1 ){
-                // if is it NOT a DialBinned -> this is the one we are supposed to use
+                // if is it NOT a DialBinned -> this is the one we are
+                // supposed to use
                 if( dialCollectionRef->getDialBinSet().isEmpty() ){
                   eventDialCacheEntry->second[eventDialOffset].first = iCollection;
                   eventDialCacheEntry->second[eventDialOffset].second = 0;
@@ -1255,63 +1223,18 @@ void DataDispenser::fillFunction(int iThread_){
 
               // loaded graph is valid?
               if( Misc::isGraphValid(grPtr) ){
-                freeSlotDial = dialCollectionRef->getNextDialFreeSlot();
-                if      ( dialCollectionRef->getGlobalDialType() == "Spline" ){
-                  if(dialCollectionRef->useCachedDials() ) {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                  else {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
+                DialBaseFactory factory;
+                DialBase* dialBase
+                    = factory(dialCollectionRef->getGlobalDialType(),
+                              dialCollectionRef->getGlobalDialSubType(),
+                              grPtr, dialCollectionRef->useCachedDials());
+                if (dialBase) {
+                    freeSlotDial = dialCollectionRef->getNextDialFreeSlot();
+                    dialBase->setAllowExtrapolation(dialCollectionRef->isAllowDialExtrapolation());
+                    dialCollectionRef->getDialBaseList()[freeSlotDial] = DialCollection::DialBaseObject(dialBase);
                 }
-                else if ( dialCollectionRef->getGlobalDialType() == "MonotonicSpline" ){
-                  if(dialCollectionRef->useCachedDials() ) {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                  else {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                }
-                else if ( dialCollectionRef->getGlobalDialType() == "GeneralSpline" ){
-                  if(dialCollectionRef->useCachedDials() ) {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                  else {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                }
-                else if ( dialCollectionRef->getGlobalDialType() == "SimpleSpline" ){
-                  if(dialCollectionRef->useCachedDials() ) {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                  else {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                }
-                else if ( dialCollectionRef->getGlobalDialType() == "Graph" ){
-                  if(dialCollectionRef->useCachedDials() ) {
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                  else{
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                    dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                  }
-                }
-                else if ( dialCollectionRef->getGlobalDialType() == "LightGraph" ){
-                  dialCollectionRef->getDialBaseList()[freeSlotDial]->buildDial( *grPtr );
-                  dialCollectionRef->getDialBaseList()[freeSlotDial]->setAllowExtrapolation( dialCollectionRef->isAllowDialExtrapolation() );
-                }
-                else{
-                  LogThrow( "Unsupported event-by-event dial: " << dialCollectionRef->getGlobalDialType() );
+                else {
+                    LogThrow( "Unsupported event-by-event dial: " << dialCollectionRef->getGlobalDialType() );
                 }
                 eventDialCacheEntry->second[eventDialOffset].first = iCollection;
                 eventDialCacheEntry->second[eventDialOffset].second = freeSlotDial;

--- a/src/DialDictionary/CMakeLists.txt
+++ b/src/DialDictionary/CMakeLists.txt
@@ -2,6 +2,10 @@ set( LIB_NAME GundamDialDictionary )
 
 set( SRCFILES
     src/DialBase.cpp
+    src/DialBaseFactory.cpp
+    src/NormDialBaseFactory.cpp
+    src/GraphDialBaseFactory.cpp
+    src/SplineDialBaseFactory.cpp
     src/DialInputBuffer.cpp
     src/DialInterface.cpp
     src/DialResponseSupervisor.cpp
@@ -19,6 +23,10 @@ set( SRCFILES
 
 set( HEADERS
     include/DialTypes.h
+    include/DialBaseFactory.h
+    include/NormDialBaseFactory.h
+    include/GraphDialBaseFactory.h
+    include/SplineDialBaseFactory.h
     include/DialBase.h
     include/DialInputBuffer.h
     include/DialInterface.h
@@ -30,10 +38,13 @@ set( HEADERS
     include/Spline.h
     include/SplineCache.h
     include/Graph.h
+    include/GraphCache.h
     include/LightGraph.h
+    include/LightGraphCache.h
     include/GeneralSpline.h
     include/GeneralSplineCache.h
     include/UniformSpline.h
+    include/UniformSplineCache.h
     include/CompactSpline.h
     include/CompactSplineCache.h
     include/MonotonicSpline.h

--- a/src/DialDictionary/include/CompactSplineCache.h
+++ b/src/DialDictionary/include/CompactSplineCache.h
@@ -1,0 +1,11 @@
+//
+// Created by Adrien Blanchet on 22/01/2023.
+//
+
+#ifndef GUNDAM_COMPACTSPLINECACHE_H
+#define GUNDAM_COMPACTSPLINECACHE_H
+
+#include "CompactSpline.h"
+typedef CachedDial<CompactSpline> CompactSplineCache;
+
+#endif //GUNDAM_COMPACTSPLINECACHE_H

--- a/src/DialDictionary/include/DialBaseFactory.h
+++ b/src/DialDictionary/include/DialBaseFactory.h
@@ -1,0 +1,53 @@
+#ifndef DialBaseFactory_h_Seen
+#define DialBaseFactory_h_Seen
+
+#include <DialBase.h>
+#include <TObject.h>
+#include <string>
+
+// A functor class that will build DialBase objects and return the pointer to
+// the object.  The ownership of the object is passed to the caller.
+class DialBaseFactory {
+public:
+  DialBaseFactory();
+  ~DialBaseFactory();
+
+  // Construct a pointer to the correct DialBase.  This uses the dialType and
+  // dialSubType to figure out the correct class, and then uses the object
+  // pointed to by the dialInitializer to fill the dial.  The ownership of the
+  // pointer is passed to the caller, so it should be put in a managed
+  // variable (e.g. a unique_ptr, or shared_ptr).
+  DialBase* operator () (std::string dialType,
+                         std::string dialSubType,
+                         TObject* dialInitializer,
+                         bool cached);
+};
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+
+#endif

--- a/src/DialDictionary/include/DialCollection.h
+++ b/src/DialDictionary/include/DialCollection.h
@@ -25,6 +25,8 @@ class DialCollection : public JsonBaseClass {
 public:
   explicit DialCollection(std::vector<FitParameterSet> *targetParameterSetListPtr);
 
+  typedef GenericToolbox::PolymorphicObjectWrapper<DialBase> DialBaseObject;
+  
   void setIndex(int index);
   void setSupervisedParameterIndex(int supervisedParameterIndex);
   void setSupervisedParameterSetIndex(int supervisedParameterSetIndex);
@@ -38,7 +40,7 @@ public:
   [[nodiscard]] const std::shared_ptr<TFormula> &getApplyConditionFormula() const;
   [[nodiscard]] const DataBinSet &getDialBinSet() const;
   const std::vector<std::string> &getDataSetNameList() const;
-  std::vector<GenericToolbox::PolymorphicObjectWrapper<DialBase>> &getDialBaseList();
+  std::vector<DialBaseObject> &getDialBaseList();
   std::vector<DialInterface> &getDialInterfaceList();
   DataBinSet &getDialBinSet();
 
@@ -89,7 +91,7 @@ private:
   std::vector<DialInterface> _dialInterfaceList_{};
   std::vector<DialInputBuffer> _dialInputBufferList_{};
   std::vector<DialResponseSupervisor> _dialResponseSupervisorList_{};
-  std::vector<GenericToolbox::PolymorphicObjectWrapper<DialBase>> _dialBaseList_{};
+  std::vector<DialBaseObject> _dialBaseList_{};
   std::shared_ptr<TFormula> _applyConditionFormula_{nullptr};
   GenericToolbox::CopiableAtomic<size_t> _dialFreeSlot_{0};
 

--- a/src/DialDictionary/include/DialCollection.h
+++ b/src/DialDictionary/include/DialCollection.h
@@ -19,14 +19,22 @@
 #include "string"
 #include "memory"
 
-
 class DialCollection : public JsonBaseClass {
 
 public:
   explicit DialCollection(std::vector<FitParameterSet> *targetParameterSetListPtr);
 
-  typedef GenericToolbox::PolymorphicObjectWrapper<DialBase> DialBaseObject;
-  
+  //  The PolymorphicObjectWrapper doesn't have the correct semantics since it
+  // clones the payload when it's copied.  We want to leave the pointee alone
+  // and just move the pointers around.
+  //
+  // Temporarily replace specialty class with shared_ptr.  The shared_ptr
+  // class has the correct semantics (copyable, and deletes the object), but
+  // we don't need the reference counting since we can only have one of each
+  // object.  Also shared_ptr is a bit to memory hungry.
+  typedef std::shared_ptr<DialBase> DialBaseObject;
+  // typedef GenericToolbox::PolymorphicObjectWrapper<DialBase> DialBaseObject;
+
   void setIndex(int index);
   void setSupervisedParameterIndex(int supervisedParameterIndex);
   void setSupervisedParameterSetIndex(int supervisedParameterSetIndex);
@@ -37,6 +45,7 @@ public:
   [[nodiscard]] int getIndex() const{ return _index_; }
   [[nodiscard]] const std::string &getGlobalDialLeafName() const;
   [[nodiscard]] const std::string &getGlobalDialType() const;
+  [[nodiscard]] const std::string &getGlobalDialSubType() const;
   [[nodiscard]] const std::shared_ptr<TFormula> &getApplyConditionFormula() const;
   [[nodiscard]] const DataBinSet &getDialBinSet() const;
   const std::vector<std::string> &getDataSetNameList() const;
@@ -79,9 +88,9 @@ private:
   double _mirrorHighEdge_{std::nan("unset")};
   double _mirrorRange_{std::nan("unset")};
   std::string _applyConditionStr_{};
-  std::string _globalDialSubType_{};
   std::string _globalDialLeafName_{};
   std::string _globalDialType_{};
+  std::string _globalDialSubType_{};
   std::vector<std::string> _dataSetNameList_{};
 
   // internal

--- a/src/DialDictionary/include/GraphDialBaseFactory.h
+++ b/src/DialDictionary/include/GraphDialBaseFactory.h
@@ -1,0 +1,53 @@
+#ifndef GraphDialBaseFactory_h_Seen
+#define GraphDialBaseFactory_h_Seen
+
+#include <DialBase.h>
+#include <TObject.h>
+#include <string>
+
+// A functor class that will build DialBase objects and return the pointer to
+// the object.  The ownership of the object is passed to the caller.
+class GraphDialBaseFactory {
+public:
+  GraphDialBaseFactory();
+  ~GraphDialBaseFactory();
+
+  // Construct a pointer to the correct DialBase.  This uses the dialType and
+  // dialSubType to figure out the correct class, and then uses the object
+  // pointed to by the dialInitializer to fill the dial.  The ownership of the
+  // pointer is passed to the caller, so it should be put in a managed
+  // variable (e.g. a unique_ptr, or shared_ptr).
+  DialBase* operator () (std::string dialType,
+                         std::string dialSubType,
+                         TObject* dialInitializer,
+                         bool cached);
+};
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+
+#endif

--- a/src/DialDictionary/include/Norm.h
+++ b/src/DialDictionary/include/Norm.h
@@ -19,6 +19,10 @@ public:
   [[nodiscard]] std::string getDialTypeName() const override { return {"Norm"}; }
   double evalResponse(const DialInputBuffer& input_) const override { return input_.getBuffer()[0]; }
 
+  /// Build the dial with no input arguments.  This is here for completeness,
+  /// but could eventually do... something.
+  virtual void buildDial(std::string option="") override {}
+
 };
 
 

--- a/src/DialDictionary/include/NormDialBaseFactory.h
+++ b/src/DialDictionary/include/NormDialBaseFactory.h
@@ -1,0 +1,53 @@
+#ifndef NormDialBaseFactory_h_Seen
+#define NormDialBaseFactory_h_Seen
+
+#include <DialBase.h>
+#include <TObject.h>
+#include <string>
+
+// A functor class that will build DialBase objects and return the pointer to
+// the object.  The ownership of the object is passed to the caller.
+class NormDialBaseFactory {
+public:
+  NormDialBaseFactory();
+  ~NormDialBaseFactory();
+
+  // Construct a pointer to the correct DialBase.  This uses the dialType and
+  // dialSubType to figure out the correct class, and then uses the object
+  // pointed to by the dialInitializer to fill the dial.  The ownership of the
+  // pointer is passed to the caller, so it should be put in a managed
+  // variable (e.g. a unique_ptr, or shared_ptr).
+  DialBase* operator () (std::string dialType,
+                         std::string dialSubType,
+                         TObject* dialInitializer,
+                         bool cached);
+};
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+
+#endif

--- a/src/DialDictionary/include/SplineDialBaseFactory.h
+++ b/src/DialDictionary/include/SplineDialBaseFactory.h
@@ -12,11 +12,32 @@ public:
   SplineDialBaseFactory();
   ~SplineDialBaseFactory();
 
-  // Construct a pointer to the correct DialBase.  This uses the dialType and
-  // dialSubType to figure out the correct class, and then uses the object
-  // pointed to by the dialInitializer to fill the dial.  The ownership of the
-  // pointer is passed to the caller, so it should be put in a managed
-  // variable (e.g. a unique_ptr, or shared_ptr).
+  /// Fill the points starting from a TObject that needs to be pointing to a
+  /// graph.  This returns false if it can't get the points.
+  bool FillFromGraph(std::vector<double>& xPoint,
+                     std::vector<double>& yPoint,
+                     std::vector<double>& slope,
+                     TObject* dialInitializer,
+                     const std::string& splType);
+
+  /// Fill the points starting from a TObject that needs to be pointing to a
+  /// spline.  This returns false if it can't get the points.
+  bool FillFromSpline(std::vector<double>& xPoint,
+                      std::vector<double>& yPoint,
+                      std::vector<double>& slope,
+                      TObject* dialInitializer,
+                      const std::string& splType);
+
+  /// Apply the monotonic constraint to the slopes.
+  void MakeMonotonic(const std::vector<double>& xPoint,
+                     const std::vector<double>& yPoint,
+                     std::vector<double>& slope);
+
+  /// Construct a pointer to the correct DialBase.  This uses the dialType and
+  /// dialSubType to figure out the correct class, and then uses the object
+  /// pointed to by the dialInitializer to fill the dial.  The ownership of
+  /// the pointer is passed to the caller, so it should be put in a managed
+  /// variable (e.g. a unique_ptr, or shared_ptr).
   DialBase* operator () (std::string dialType,
                          std::string dialSubType,
                          TObject* dialInitializer,

--- a/src/DialDictionary/include/SplineDialBaseFactory.h
+++ b/src/DialDictionary/include/SplineDialBaseFactory.h
@@ -1,0 +1,53 @@
+#ifndef SplineDialBaseFactory_h_Seen
+#define SplineDialBaseFactory_h_Seen
+
+#include <DialBase.h>
+#include <TObject.h>
+#include <string>
+
+// A functor class that will build DialBase objects and return the pointer to
+// the object.  The ownership of the object is passed to the caller.
+class SplineDialBaseFactory {
+public:
+  SplineDialBaseFactory();
+  ~SplineDialBaseFactory();
+
+  // Construct a pointer to the correct DialBase.  This uses the dialType and
+  // dialSubType to figure out the correct class, and then uses the object
+  // pointed to by the dialInitializer to fill the dial.  The ownership of the
+  // pointer is passed to the caller, so it should be put in a managed
+  // variable (e.g. a unique_ptr, or shared_ptr).
+  DialBase* operator () (std::string dialType,
+                         std::string dialSubType,
+                         TObject* dialInitializer,
+                         bool cached);
+};
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+
+#endif

--- a/src/DialDictionary/include/UniformSplineCache.h
+++ b/src/DialDictionary/include/UniformSplineCache.h
@@ -1,0 +1,11 @@
+//
+// Created by Adrien Blanchet on 23/01/2023.
+//
+
+#ifndef GUNDAM_UNIFORMSPLINECACHE_H
+#define GUNDAM_UNIFORMSPLINECACHE_H
+
+#include "UniformSpline.h"
+typedef CachedDial<UniformSpline> UniformSplineCache;
+
+#endif //GUNDAM_UNIFORMSPLINECACHE_H

--- a/src/DialDictionary/src/DialBaseFactory.cpp
+++ b/src/DialDictionary/src/DialBaseFactory.cpp
@@ -3,6 +3,8 @@
 #include "GraphDialBaseFactory.h"
 #include "SplineDialBaseFactory.h"
 
+#include "Logger.h"
+
 DialBaseFactory::DialBaseFactory() {}
 DialBaseFactory::~DialBaseFactory() {}
 
@@ -27,6 +29,34 @@ DialBase* DialBaseFactory::operator () (std::string dialType,
     SplineDialBaseFactory factory;
     dialBase.reset(factory(dialType, dialSubType, dialInitializer,cached));
   }
+#define INCLUDE_DEPRECATED_DIAL_TYPES
+#ifdef INCLUDE_DEPRECATED_DIAL_TYPES
+  else if (dialType == "MonotonicSpline") {
+    LogWarning << "DEPRECATED DIAL-TYPE USED: MonotonicSpline will be removed"
+            << std::endl;
+    SplineDialBaseFactory factory;
+    dialBase.reset(factory("Spline", "catmull-rom, monotonic",
+                           dialInitializer,cached));
+  }
+  else if (dialType == "GeneralSpline") {
+    LogWarning << "DEPRECATED DIAL-TYPE USED: GeneralSpline will be removed"
+            << std::endl;
+    SplineDialBaseFactory factory;
+    dialBase.reset(factory("Spline", "not-a-knot", dialInitializer,cached));
+  }
+  else if (dialType == "SimpleSpline") {
+    LogWarning << "DEPRECATED DIAL-TYPE USED: SimpleSpline will be removed"
+            << std::endl;
+    SplineDialBaseFactory factory;
+    dialBase.reset(factory("Spline", "knot-a-knot", dialInitializer,cached));
+  }
+  else if (dialType == "LightGraph") {
+    LogWarning << "DEPRECATED DIAL-TYPE USED: LightGraph will be removed"
+            << std::endl;
+    GraphDialBaseFactory factory;
+    dialBase.reset(factory("Graph", "light", dialInitializer,cached));
+  }
+#endif
 
   // Pass the ownership without any constraints!
   return dialBase.release();

--- a/src/DialDictionary/src/DialBaseFactory.cpp
+++ b/src/DialDictionary/src/DialBaseFactory.cpp
@@ -1,0 +1,60 @@
+#include "DialBaseFactory.h"
+#include "NormDialBaseFactory.h"
+#include "GraphDialBaseFactory.h"
+#include "SplineDialBaseFactory.h"
+
+DialBaseFactory::DialBaseFactory() {}
+DialBaseFactory::~DialBaseFactory() {}
+
+DialBase* DialBaseFactory::operator () (std::string dialType,
+                                        std::string dialSubType,
+                                        TObject* dialInitializer,
+                                        bool cached) {
+
+  // Stuff the created dial into a unique_ptr, so it will be properly deleted
+  // in the event of an exception.
+  std::unique_ptr<DialBase> dialBase;
+
+  if (dialType == "Norm" || dialType == "Normalization") {
+    NormDialBaseFactory factory;
+    dialBase.reset(factory(dialType, dialSubType, dialInitializer,cached));
+  }
+  else if (dialType == "Graph") {
+    GraphDialBaseFactory factory;
+    dialBase.reset(factory(dialType, dialSubType, dialInitializer,cached));
+  }
+  else if (dialType == "Spline") {
+    SplineDialBaseFactory factory;
+    dialBase.reset(factory(dialType, dialSubType, dialInitializer,cached));
+  }
+
+  // Pass the ownership without any constraints!
+  return dialBase.release();
+}
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/DialDictionary/src/DialCollection.cpp
+++ b/src/DialDictionary/src/DialCollection.cpp
@@ -82,7 +82,7 @@ const DataBinSet &DialCollection::getDialBinSet() const {
 const std::vector<std::string> &DialCollection::getDataSetNameList() const {
   return _dataSetNameList_;
 }
-std::vector<GenericToolbox::PolymorphicObjectWrapper<DialBase>> &DialCollection::getDialBaseList() {
+std::vector<DialCollection::DialBaseObject> &DialCollection::getDialBaseList() {
   return _dialBaseList_;
 }
 std::vector<DialInterface> &DialCollection::getDialInterfaceList() {

--- a/src/DialDictionary/src/GraphDialBaseFactory.cpp
+++ b/src/DialDictionary/src/GraphDialBaseFactory.cpp
@@ -1,0 +1,64 @@
+#include "GraphDialBaseFactory.h"
+
+#include "Graph.h"
+#include "LightGraph.h"
+
+#include "GraphCache.h"
+#include "LightGraphCache.h"
+
+#include <TGraph.h>
+
+GraphDialBaseFactory::GraphDialBaseFactory() {}
+GraphDialBaseFactory::~GraphDialBaseFactory() {}
+
+DialBase* GraphDialBaseFactory::operator () (std::string dialType,
+                                             std::string dialSubType,
+                                             TObject* dialInitializer,
+                                             bool cached) {
+
+  TGraph* graph = dynamic_cast<TGraph*>(dialInitializer);
+  LogThrowIf(!graph, "Graph dial initializer must be a TGraph");
+
+  // Stuff the created dial into a unique_ptr, so it will be properly deleted
+  // in the event of an exception.
+  std::unique_ptr<DialBase> dialBase;
+
+  if (dialSubType == "TGraph") {
+    dialBase.reset((not cached) ? new Graph: new GraphCache);
+  }
+  else {
+    dialBase.reset((not cached) ? new LightGraph: new LightGraphCache);
+  }
+
+  dialBase->buildDial(*graph);
+
+  // Pass the ownership without any constraints!
+  return dialBase.release();
+}
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/DialDictionary/src/GraphDialBaseFactory.cpp
+++ b/src/DialDictionary/src/GraphDialBaseFactory.cpp
@@ -23,7 +23,7 @@ DialBase* GraphDialBaseFactory::operator () (std::string dialType,
   // in the event of an exception.
   std::unique_ptr<DialBase> dialBase;
 
-  if (dialSubType == "TGraph") {
+  if (dialSubType == "ROOT") {
     dialBase.reset((not cached) ? new Graph: new GraphCache);
   }
   else {

--- a/src/DialDictionary/src/NormDialBaseFactory.cpp
+++ b/src/DialDictionary/src/NormDialBaseFactory.cpp
@@ -1,0 +1,48 @@
+#include "NormDialBaseFactory.h"
+#include "Norm.h"
+
+NormDialBaseFactory::NormDialBaseFactory() {}
+NormDialBaseFactory::~NormDialBaseFactory() {}
+
+DialBase* NormDialBaseFactory::operator () (std::string dialType,
+                                            std::string dialSubType,
+                                            TObject* dialInitializer,
+                                            bool cached) {
+  // Stuff the created dial into a unique_ptr, so it will be properly deleted
+  // in the event of an exception.
+  std::unique_ptr<DialBase> dialBase;
+
+  // Nothing much to do for a normalization dial!
+  dialBase.reset(new Norm);
+  dialBase->buildDial();
+
+  // Pass the ownership without any constraints!
+  return dialBase.release();
+}
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/DialDictionary/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/src/SplineDialBaseFactory.cpp
@@ -126,7 +126,8 @@ DialBase* SplineDialBaseFactory::operator () (std::string dialType,
   // might be implemented with at TSpline3).  The "ROOT" spline will use an
   // actual TSpline3 (and is slow).  The natural and catmull-rom splines are
   // just as expected.
-  std::string splType = "not-a-knot";
+  std::string splType = "not-a-knot";  // The default.
+  if (dialSubType.find("not-a-knot")!=std::string::npos) splType = "not-a-knot";
   if (dialSubType.find("catmull")!=std::string::npos) splType = "catmull-rom";
   if (dialSubType.find("natural") != std::string:: npos) splType = "natural";
   if (dialSubType.find("ROOT") != std::string:: npos) splType = "ROOT";
@@ -145,6 +146,11 @@ DialBase* SplineDialBaseFactory::operator () (std::string dialType,
   if (xPoint.size() < 2) {
     LogWarning << "Splines must have at least two points." << std::endl;
     return nullptr;
+  }
+
+  // If there are only two points, then force catmull-rom
+  if (xPoint.size()<3) {
+    splType = "catmull-rom";
   }
 
   // Check that there are equal numbers of X and Y

--- a/src/DialDictionary/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/src/SplineDialBaseFactory.cpp
@@ -1,0 +1,176 @@
+#include "SplineDialBaseFactory.h"
+
+#include "Spline.h"
+#include "GeneralSpline.h"
+#include "UniformSpline.h"
+#include "CompactSpline.h"
+#include "MonotonicSpline.h"
+
+#include "SplineCache.h"
+#include "GeneralSplineCache.h"
+#include "UniformSplineCache.h"
+#include "CompactSplineCache.h"
+#include "MonotonicSplineCache.h"
+
+#include "TGraph.h"
+#include "TSpline.h"
+
+SplineDialBaseFactory::SplineDialBaseFactory() {}
+SplineDialBaseFactory::~SplineDialBaseFactory() {}
+
+DialBase* SplineDialBaseFactory::operator () (std::string dialType,
+                                              std::string dialSubType,
+                                              TObject* dialInitializer,
+                                              bool cached) {
+
+  // The types of splines are "not-a-knot", "natural", "catmull-rom", and
+  // "ROOT".  The "not-a-knot" spline will give the same curve as ROOT (and
+  // might be implemented with at TSpline3).  The "ROOT" spline will use an
+  // actual TSpline3 (and is slow).  The natural and catmull-rom splines are
+  // just as expected.
+  std::string splType = "not-a-knot";
+  if (dialSubType.find("catmull")!=std::string::npos) splType = "catmull-rom";
+  if (dialSubType.find("natural") != std::string:: npos) splType = "natural";
+  if (dialSubType.find("ROOT") != std::string:: npos) splType = "ROOT";
+
+  std::vector<double> xPoint;
+  std::vector<double> yPoint;
+  std::vector<double> slope;
+
+  do {
+    // Get the spline knots and slopes (starting from a graph).
+    TGraph* graph = dynamic_cast<TGraph*>(dialInitializer);
+    if (graph) {
+      std::string opt;
+      double valBeg = 0;
+      double valEnd = 0;
+      if (splType == "natural") opt = "b2,e2";
+      TSpline3 spline(Form("%p", graph), graph, opt.c_str(), valBeg, valEnd);
+      xPoint.reserve(spline.GetNp());
+      yPoint.reserve(spline.GetNp());
+      slope.reserve(spline.GetNp());
+      for (int i = 0; i<graph->GetN(); ++i) {
+        double x; double y;
+        spline.GetKnot(i,x,y);
+        double d = spline.Derivative(x);
+        xPoint.push_back(x);
+        yPoint.push_back(y);
+        slope.push_back(d);
+      }
+      break;
+    }
+
+    // Get the spline knots and slopes (starting from a spline).
+    TSpline3* spline = dynamic_cast<TSpline3*>(dialInitializer);
+    if (spline) {
+      xPoint.reserve(spline->GetNp());
+      yPoint.reserve(spline->GetNp());
+      slope.reserve(spline->GetNp());
+      for (int i = 0; i<spline->GetNp(); ++i) {
+        double x; double y;
+        spline->GetKnot(i,x,y);
+        double d = spline->Derivative(x);
+        xPoint.push_back(x);
+        yPoint.push_back(y);
+        slope.push_back(d);
+      }
+      break;
+    }
+
+    LogThrow("dialInitialize must be a TGraph or a TSpline3");
+  } while (false);
+
+  LogThrowIf(xPoint.size() < 2,
+             "Splines must have at least two points.");
+  LogThrowIf(xPoint.size() != yPoint.size(),
+             "Splines must have the same number of X and Y points");
+
+  ////////////////////////////////////////////////////////////////
+  // Condition the slopes as necessary (only matters if the dial sub-type
+  // includes "monotonic"
+  ////////////////////////////////////////////////////////////////
+  bool monotonic = false;
+  if (dialSubType.find("monotonic") != std::string::npos) {
+    monotonic = true;
+    // Apply the monotonic condition to the slopes.  This always adjusts the
+    // slopes, however, with Catmull-Rom the modified slopes will be ignored
+    // and the monotonic criteria is applied as the spline is evaluated.
+
+    /// DUMMY FOR NOW!!!!!
+  }
+
+  ////////////////////////////////////////////////////////////////
+  // Check if the spline can be treated as having uniformly spaced knots.
+  ////////////////////////////////////////////////////////////////
+  double s = (xPoint.back() - xPoint.front())/(xPoint.size()-1);
+  bool uniform = true;
+  for (int i=1; i<xPoint.size(); ++i) {
+    if (std::abs(xPoint[i]-xPoint[i-1]-s) > 1E-6) {
+      uniform = false;
+      break;
+    }
+  }
+
+  // Stuff the created dial into a unique_ptr, so it will be properly deleted
+  // in the event of an exception.
+  std::unique_ptr<DialBase> dialBase;
+
+  // Create the right low level spline.
+  if (splType == "catmull-rom") {
+    LogThrowIf(not uniform,
+               "Catmull-rom splines need a uniformly spaced points");
+    if (monotonic) {
+      dialBase.reset(
+        (not cached) ? new MonotonicSpline: new MonotonicSplineCache);
+    }
+    else {
+      dialBase.reset(
+        (not cached) ? new CompactSpline: new CompactSplineCache);
+    }
+  }
+  else if (splType == "ROOT") {
+    dialBase.reset(new Spline);
+  }
+  else {
+    if (not uniform) {
+      dialBase.reset(
+        (not cached) ? new GeneralSpline: new GeneralSplineCache);
+    }
+    else {
+      dialBase.reset(
+        (not cached) ? new UniformSpline: new UniformSplineCache);
+    }
+  }
+
+  dialBase->buildDial(xPoint,yPoint,slope);
+
+  // Pass the ownership without any constraints!
+  return dialBase.release();
+}
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:


### PR DESCRIPTION
Change the DialBase construction into a factory pattern.  This makes sure that DialBase objects are created the same way everyplace, and removes bit-rot between DialCollection and DataDispenser.

The factories will supports the 1.6.1 dial declaration behavior, added subtype behavior, and the deprecated set of dialsType options in master.  The factories also make features like "monotonic" spline behavior available to all the spline implementations, and makes sure that the features are available everyplace splines are used (the same comment applies to graphs).