### PR TITLE
Feature/event dial cache documentation

### DIFF
--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -584,6 +584,7 @@ void DataDispenser::fetchRequestedLeaves(){
 //  t.printTable();
 
 }
+
 void DataDispenser::preAllocateMemory(){
   LogInfo << "Pre-allocating memory..." << std::endl;
   /// \brief The following lines are necessary since the events might get
@@ -789,6 +790,7 @@ void DataDispenser::preAllocateMemory(){
 #endif
 
 }
+
 void DataDispenser::readAndFill(){
   LogWarning << "Reading dataset and loading..." << std::endl;
 
@@ -815,6 +817,7 @@ void DataDispenser::readAndFill(){
     container->shrinkEventList(_cache_.sampleIndexOffsetList[iSample]);
   }
 }
+
 void DataDispenser::fillFunction(int iThread_){
 
   int nThreads = GlobalVariables::getNbThreads();
@@ -981,7 +984,7 @@ void DataDispenser::fillFunction(int iThread_){
 #if USE_NEW_DIALS
   size_t freeSlotDial{0};
   size_t iCollection(-1);
-  std::pair<std::pair<size_t, size_t>, std::vector<std::pair<size_t, size_t>>>* eventDialCacheEntry;
+  EventDialCache::IndexedEntry_t* eventDialCacheEntry;
   std::vector<DataBin>::iterator dial2FoundItr;
   auto isDial2Valid = [&](const DataBin& d_){
     nBinEdges = d_.getEdgesList().size();
@@ -1117,7 +1120,6 @@ void DataDispenser::fillFunction(int iThread_){
           if( eventBuffer.evalFormula( varSelectionFormulaList[iSample].get() ) == 0 ) break;
         }
 
-
         // Has valid bin?
         binsListPtr = &_cache_.samplesToFillList[iSample]->getBinning().getBinsList();
         binFoundItr = std::find_if(
@@ -1130,10 +1132,9 @@ void DataDispenser::fillFunction(int iThread_){
           // Invalid bin -> next sample
           break;
         }
-        else {
-          // found bin
-          eventBuffer.setSampleBinIndex(int(std::distance(binsListPtr->begin(), binFoundItr)));
-        }
+
+        // found the bin
+        eventBuffer.setSampleBinIndex(int(std::distance(binsListPtr->begin(), binFoundItr)));
 
         // OK, now we have a valid fit bin. Let's claim an index.
         sampleEventIndex = _cache_.sampleIndexOffsetList[iSample]++;
@@ -1155,7 +1156,6 @@ void DataDispenser::fillFunction(int iThread_){
 
         // Now the event is ready. Let's index the dials:
         eventDialOffset = 0;
-
 
 #if USE_NEW_DIALS
         if( _eventDialCacheRef_ != nullptr ) {

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1160,10 +1160,9 @@ void DataDispenser::fillFunction(int iThread_){
 #if USE_NEW_DIALS
         if( _eventDialCacheRef_ != nullptr ) {
           eventDialCacheEntry = _eventDialCacheRef_->fetchNextCacheEntry();
-          eventDialCacheEntry->first = {
-              _cache_.samplesToFillList[iSample]->getIndex(),
-              sampleEventIndex
-          };
+          eventDialCacheEntry->event.sampleIndex
+              = std::size_t(_cache_.samplesToFillList[iSample]->getIndex());
+          eventDialCacheEntry->event.eventIndex = sampleEventIndex;
 
           iCollection = -1;
           for( auto* dialCollectionRef : _cache_.dialCollectionsRefList ){
@@ -1185,8 +1184,8 @@ void DataDispenser::fillFunction(int iThread_){
                 // if is it NOT a DialBinned -> this is the one we are
                 // supposed to use
                 if( dialCollectionRef->getDialBinSet().isEmpty() ){
-                  eventDialCacheEntry->second[eventDialOffset].first = iCollection;
-                  eventDialCacheEntry->second[eventDialOffset].second = 0;
+                  eventDialCacheEntry->dials[eventDialOffset].collectionIndex = iCollection;
+                  eventDialCacheEntry->dials[eventDialOffset].interfaceIndex = 0;
                   eventDialOffset++;
                 }
               }
@@ -1201,8 +1200,8 @@ void DataDispenser::fillFunction(int iThread_){
 
                 if (dial2FoundItr !=  dialCollectionRef->getDialBinSet().getBinsList().end()) {
                   // found DIAL -> get index
-                  eventDialCacheEntry->second[eventDialOffset].first = iCollection;
-                  eventDialCacheEntry->second[eventDialOffset].second = std::distance(
+                  eventDialCacheEntry->dials[eventDialOffset].collectionIndex = iCollection;
+                  eventDialCacheEntry->dials[eventDialOffset].interfaceIndex = std::distance(
                       dialCollectionRef->getDialBinSet().getBinsList().begin(), dial2FoundItr
                   );
                   eventDialOffset++;
@@ -1236,8 +1235,8 @@ void DataDispenser::fillFunction(int iThread_){
                 else {
                     LogThrow( "Unsupported event-by-event dial: " << dialCollectionRef->getGlobalDialType() );
                 }
-                eventDialCacheEntry->second[eventDialOffset].first = iCollection;
-                eventDialCacheEntry->second[eventDialOffset].second = freeSlotDial;
+                eventDialCacheEntry->dials[eventDialOffset].collectionIndex = iCollection;
+                eventDialCacheEntry->dials[eventDialOffset].interfaceIndex = freeSlotDial;
                 eventDialOffset++;
               }
 

--- a/src/DialDictionary/include/EventDialCache.h
+++ b/src/DialDictionary/include/EventDialCache.h
@@ -40,13 +40,43 @@ public:
   /// The cache element associating a PhysicsEvent to the appropriate
   /// DialInterface.
   struct CacheElem_t {
-     PhysicsEvent* event;
-     std::vector<DialsElem_t> dials;
+    PhysicsEvent* event;
+    std::vector<DialsElem_t> dials;
   };
 
-  typedef std::pair<size_t, size_t> EventIndexEntry_t;
-  typedef std::pair<size_t, size_t> DialIndexEntry_t;
-  typedef std::pair<EventIndexEntry_t, std::vector<DialIndexEntry_t>> IndexedEntry_t;
+  /// A pair of indices into the vector of dial collections, and then the
+  /// index of the dial interfaces in the dial collection vector of dial
+  /// interfaces.
+  struct DialIndexEntry_t {
+    /// The index in the dial collection being associated with the event.
+    std::size_t first {std::size_t(-1)};
+    /// The index of the actual dial interface in the dial collection being
+    /// associated with the event.
+    std::size_t second {std::size_t(-1)};
+  };
+
+  /// A pair of indices into the the vector of FitSamples in the FitSampleSet
+  /// vector of fit samples, and the index of the event eventList in the
+  /// SampleElement returned by getMcContainer().
+  struct EventIndexEntry_t {
+    /// The index of the fit sample being referenced by this indexed cache
+    /// entry in the FitSampleSet vector of FitSample objects (returned by
+    /// getFitSampleList().
+    std::size_t first {std::size_t(-1)};
+    /// The index of the MC event being reference by this indexed cache entry
+    /// in the SampleElement eveltList vector for the SampleElement returned
+    /// by FitSample::getMcContainer()
+    std::size_t second {std::size_t(-1)};
+  };
+
+  /// A mapping between the event (in the FitSampleSet, and the dial in the
+  /// DialCollectionVector.  This will be used to build a fast lookup table
+  /// between the PhysicsEvent* and the DialInterface* (i.e. a CacheElem_t
+  /// returned by getCache().
+  struct IndexedEntry_t{
+    EventIndexEntry_t first;
+    std::vector<DialIndexEntry_t> second;
+  };
 
   /// Provide the event dial cache.  The event dial cache containes a
   /// CacheElem_t object for every dial applied to a physics event.  The
@@ -64,7 +94,8 @@ public:
 
   /// This gets the next available indexed cache entry.  WARNING: This is a
   /// bare pointer but it is referencing an element of a vector and can be
-  /// invalidated if the values get added to the indexed cache.
+  /// invalidated if the values get added to the indexed cache.  The ownership
+  /// of the pointer is not passed to the caller.
   IndexedEntry_t* fetchNextCacheEntry();
 
   /// Build the association between pointers to PhysicsEvent objects and the
@@ -92,10 +123,9 @@ private:
   /// associations for efficient use when reweighting the MC events.
   std::vector<CacheElem_t> _cache_;
 
-  /// Flag that all events should have dials (or not).
+  /// Flag that all events should have dials (or not).  At the end to have
+  /// better packed alignment.
   bool _warnForDialLessEvent_{false};
-
-
 };
 
 

--- a/src/DialDictionary/include/EventDialCache.h
+++ b/src/DialDictionary/include/EventDialCache.h
@@ -37,29 +37,93 @@ public:
   };
 #endif
 
-  /// The cache element associating a PhysicsEvent to the dials.
+  /// The cache element associating a PhysicsEvent to the appropriate
+  /// DialInterface.
   struct CacheElem_t {
      PhysicsEvent* event;
      std::vector<DialsElem_t> dials;
   };
 
-  /// Provide the event dial cache.
+  typedef std::pair<size_t, size_t> EventIndexEntry_t;
+  typedef std::pair<size_t, size_t> DialIndexEntry_t;
+  typedef std::pair<EventIndexEntry_t, std::vector<DialIndexEntry_t>> IndexedEntry_t;
+
+  /// Provide the event dial cache.  The event dial cache containes a
+  /// CacheElem_t object for every dial applied to a physics event.  The
+  /// CacheElem_t is a pointer to the PhysicsEvent that will be reweighted and
+  /// a pointer to the DialInterface that will do the reweighting.  Note: Each
+  /// PhysicsEvent will probably be in the cache multiple times (for different
+  /// DialInterface objects), and each DialInterface object could be in the
+  /// cache multiple times (but for different Physics event objects).
   std::vector<CacheElem_t> &getCache();
 
+  /// Allocate entries for events in the indexed cache.  The first parameter
+  /// arethe number of events to allocate space for, and the second number is
+  /// the total number of dials that might exist for each event.
   void allocateCacheEntries(size_t nEvent_, size_t nDialsMaxPerEvent_);
-  std::pair<std::pair<size_t, size_t>, std::vector<std::pair<size_t, size_t>>>* fetchNextCacheEntry();
-  void buildReferenceCache(FitSampleSet& sampleSet_, std::vector<DialCollection>& dialCollectionList_);
+
+  /// This gets the next available indexed cache entry.  WARNING: This is a
+  /// bare pointer but it is referencing an element of a vector and can be
+  /// invalidated if the values get added to the indexed cache.
+  IndexedEntry_t* fetchNextCacheEntry();
+
+  /// Build the association between pointers to PhysicsEvent objects and the
+  /// pointers to DialInterface objects.  This must be done before the event
+  /// dial cache can be used, but after the index cache has been filled.
+  void buildReferenceCache(FitSampleSet& sampleSet_,
+                           std::vector<DialCollection>& dialCollectionList_);
 
   static void reweightEntry(CacheElem_t& entry_);
 
 private:
-  bool _warnForDialLessEvent_{false};
+  // The next available entry in the indexed cache.
   size_t _fillIndex_{0};
+
   GenericToolbox::NoCopyWrapper<std::mutex> _mutex_;
-  std::vector<std::pair<std::pair<size_t, size_t>, std::vector<std::pair<size_t, size_t>>>> _indexedCache_{};
+
+  // A cache mapping events to dials.  This is built while the dials are
+  // allocated, and might contain "empty" or invalid entries since some events
+  // can have dials that get skipped.  The indexedCache will be used to build
+  // the main vector of CacheElem_t which will only have valid pairs of events
+  // and dials.
+  std::vector<IndexedEntry_t> _indexedCache_{};
+
+  /// A cache of all of the valid PhysicsEvent* and DialInterface*
+  /// associations for efficient use when reweighting the MC events.
   std::vector<CacheElem_t> _cache_;
+
+  /// Flag that all events should have dials (or not).
+  bool _warnForDialLessEvent_{false};
+
 
 };
 
 
 #endif //GUNDAM_EVENTDIALCACHE_H
+
+//  A Lesser GNU Public License
+
+//  Copyright (C) 2023 GUNDAM DEVELOPERS
+
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the
+//
+//  Free Software Foundation, Inc.
+//  51 Franklin Street, Fifth Floor,
+//  Boston, MA  02110-1301  USA
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:2
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/DialDictionary/include/EventDialCache.h
+++ b/src/DialDictionary/include/EventDialCache.h
@@ -49,10 +49,10 @@ public:
   /// interfaces.
   struct DialIndexEntry_t {
     /// The index in the dial collection being associated with the event.
-    std::size_t first {std::size_t(-1)};
+    std::size_t collectionIndex {std::size_t(-1)};
     /// The index of the actual dial interface in the dial collection being
     /// associated with the event.
-    std::size_t second {std::size_t(-1)};
+    std::size_t interfaceIndex {std::size_t(-1)};
   };
 
   /// A pair of indices into the the vector of FitSamples in the FitSampleSet
@@ -62,20 +62,20 @@ public:
     /// The index of the fit sample being referenced by this indexed cache
     /// entry in the FitSampleSet vector of FitSample objects (returned by
     /// getFitSampleList().
-    std::size_t first {std::size_t(-1)};
+    std::size_t sampleIndex {std::size_t(-1)};
     /// The index of the MC event being reference by this indexed cache entry
     /// in the SampleElement eveltList vector for the SampleElement returned
     /// by FitSample::getMcContainer()
-    std::size_t second {std::size_t(-1)};
+    std::size_t eventIndex {std::size_t(-1)};
   };
 
-  /// A mapping between the event (in the FitSampleSet, and the dial in the
-  /// DialCollectionVector.  This will be used to build a fast lookup table
+  /// A mapping between the event (in the FitSampleSet, and the dial (in the
+  /// DialCollectionVector).  This will be used to build a fast lookup table
   /// between the PhysicsEvent* and the DialInterface* (i.e. a CacheElem_t
   /// returned by getCache().
   struct IndexedEntry_t{
-    EventIndexEntry_t first;
-    std::vector<DialIndexEntry_t> second;
+    EventIndexEntry_t event;
+    std::vector<DialIndexEntry_t> dials;
   };
 
   /// Provide the event dial cache.  The event dial cache containes a

--- a/src/FitSamples/include/FitSampleSet.h
+++ b/src/FitSamples/include/FitSampleSet.h
@@ -18,6 +18,9 @@
 #include "vector"
 
 
+/// Hold a description of all of the event samples (both "data" and the
+/// matching "MC") that are going to be managed by the Propagator.  The
+/// samples in the set can be referred to by their sample set index.
 class FitSampleSet : public JsonBaseClass {
 
 public:

--- a/src/Propagator/include/Propagator.h
+++ b/src/Propagator/include/Propagator.h
@@ -132,6 +132,9 @@ private:
 
   // DEV
 #if USE_NEW_DIALS
+  // A vector of all the dial collections used by all of the fit samples.
+  // Once a dial collection has been added to this vector, it's index becomes
+  // the immutable tag for that specific group of dials.
   std::vector<DialCollection> _dialCollections_{};
   EventDialCache _eventDialCache_{};
 #endif


### PR DESCRIPTION
This adds comments to the EventDialCache code and methods explaining how it works.  It also removes the use of std::pair<> as a building block for the cache and makes sure that the field names are specific to the usage.  There were a couple of places where a particular memory mapping was assumed, and those are now more explicitly matching the field to the data.