### PR TITLE
Adding histogram loading as a data set

### DIFF
--- a/src/DatasetManager/include/DataDispenser.h
+++ b/src/DatasetManager/include/DataDispenser.h
@@ -17,6 +17,7 @@
 #include "EventDialCache.h"
 
 #include "TChain.h"
+#include "nlohmann/json.hpp"
 
 #include "string"
 #include "vector"
@@ -36,6 +37,8 @@ struct DataDispenserParameters{
   std::vector<std::string> additionalVarsStorage{};
   std::vector<std::string> dummyVariablesList;
   int iThrow{-1};
+
+  nlohmann::json fromHistContent{};
 
   [[nodiscard]] std::string getSummary() const{
     std::stringstream ss;
@@ -121,12 +124,15 @@ protected:
   void initializeImpl() override;
 
   void buildSampleToFillList();
+  void parseStringParameters();
   void doEventSelection();
   void fetchRequestedLeaves();
   void preAllocateMemory();
   void readAndFill();
+  void loadFromHistContent();
 
   void fillFunction(int iThread_);
+
 
 private:
   // Parameters

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -935,19 +935,8 @@ void DataDispenser::loadFromHistContent(){
       auto target = sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList );
       auto histBinIndex = hist->GetBin( target.data() ); // bad fetch..?
 
-//      // manual fetch??
-//      histBinIndex = 1;
-//      std::vector<int> axisIdxList{};
-//      for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
-//        LogTrace << axisNameList[iDim] << " => " << GET_VAR_NAME_VALUE(target[iDim]) << std::endl;
-//        axisIdxList.emplace_back(hist->GetAxis(iDim)->FindBin( target[iDim] ));
-//      }
-//      LogTrace << "bins: " << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
-//      histBinIndex = hist->GetBin( axisIdxList.data() );
-
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );
       container->eventList[iBin].resetEventWeight();
-//      LogDebug << "Bin #" << iBin << " (" << histBinIndex << ") " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
     }
 
   }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -867,6 +867,7 @@ void DataDispenser::loadFromHistContent(){
 
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());
+  eventPlaceholder.setEventWeight(0); // default.
 
   // claiming event memory
   for( size_t iSample = 0 ; iSample < _cache_.samplesToFillList.size() ; iSample++ ){

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -937,6 +937,9 @@ void DataDispenser::loadFromHistContent(){
       auto target = sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList );
       auto histBinIndex = hist->GetBin( target.data() ); // bad fetch..?
 
+      for( size_t iVar = 0 ; iVar < target.size() ; iVar++ ){
+        container->eventList[iBin].setVariable( target[iVar], axisNameList[iVar] );
+      }
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );
       container->eventList[iBin].resetEventWeight();
     }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -938,6 +938,7 @@ void DataDispenser::loadFromHistContent(){
       // manual fetch??
       histBinIndex = 1;
       for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
+        LogTrace << GET_VAR_NAME_VALUE(hist->GetAxis(iDim)->FindBin( target[iDim] )) << std::endl;
         histBinIndex *= hist->GetAxis(iDim)->FindBin( target[iDim] );
       }
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -864,12 +864,16 @@ void DataDispenser::loadFromHistContent(){
   _cache_.sampleIndexOffsetList.resize(_cache_.samplesToFillList.size());
   _cache_.sampleEventListPtrToFill.resize(_cache_.samplesToFillList.size());
 
+
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());
 
   // claiming event memory
   for( size_t iSample = 0 ; iSample < _cache_.samplesToFillList.size() ; iSample++ ){
-    LogScopeIndent;
+
+    eventPlaceholder.setCommonLeafNameListPtr(
+      std::make_shared<std::vector<std::string>>(_cache_.samplesToFillList[iSample]->getBinning().getBinVariables())
+    );
 
     // one event per bin
     _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();
@@ -917,7 +921,6 @@ void DataDispenser::loadFromHistContent(){
 
     auto* hist = fHist->Get<THnD>( histName.c_str() );
     LogThrowIf( hist == nullptr, "Could not find THnD \"" << histName << "\" within " << fHist->GetPath() );
-
 
     int nBins = 1;
     for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -862,6 +862,8 @@ void DataDispenser::loadFromHistContent(){
 
   // counting events
   _cache_.sampleNbOfEvents.resize(_cache_.samplesToFillList.size());
+  _cache_.sampleIndexOffsetList.resize(_cache_.samplesToFillList.size());
+  _cache_.sampleEventListPtrToFill.resize(_cache_.samplesToFillList.size());
 
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -860,31 +860,35 @@ void DataDispenser::loadFromHistContent(){
   // non-trivial as we need to propagate systematics. Need to merge with the original data loader, but not straight forward?
   LogThrowIf( _parameters_.useMcContainer, "Hist loader not implemented for MC containers" );
 
-  LogDebug << __LINE__ << std::endl;
   // counting events
   _cache_.sampleNbOfEvents.resize(_cache_.samplesToFillList.size());
 
-  LogDebug << __LINE__ << std::endl;
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());
 
-  LogDebug << __LINE__ << std::endl;
   // claiming event memory
-  for( size_t iSample = 0 ; iSample < _cache_.sampleNbOfEvents.size() ; iSample++ ){
+  for( size_t iSample = 0 ; iSample < _cache_.samplesToFillList.size() ; iSample++ ){
 
     LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     // one event per bin
     _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();
 
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
+
     auto* container = &_cache_.samplesToFillList[iSample]->getDataContainer();
+
+
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     _cache_.sampleEventListPtrToFill[iSample] = &container->eventList;
     _cache_.sampleIndexOffsetList[iSample] = _cache_.sampleEventListPtrToFill[iSample]->size();
     container->reserveEventMemory( _owner_->getDataSetIndex(), _cache_.sampleNbOfEvents[iSample], eventPlaceholder );
 
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     // indexing according to the binning
     for( size_t iEvent=_cache_.sampleIndexOffsetList[iSample] ; iEvent < container->eventList.size() ; iEvent++ ){
       container->eventList[iEvent].setSampleBinIndex( int( iEvent ) );
     }
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
   }
 
   // read hist content from file

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -114,15 +114,15 @@ void DataDispenser::load(){
     return;
   }
 
+  if( not _parameters_.fromHistContent.empty() ){
+    this->loadFromHistContent();
+    return;
+  }
+
   LogInfo << "Data will be extracted from: " << GenericToolbox::parseVectorAsString(_parameters_.filePathList, true) << std::endl;
   for( const auto& file: _parameters_.filePathList){
     std::string path = GenericToolbox::expandEnvironmentVariables(file);
     LogThrowIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.treePath}), "Invalid file: " << path);
-  }
-
-  if( not _parameters_.fromHistContent.empty() ){
-    this->loadFromHistContent();
-    return;
   }
 
   this->parseStringParameters();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -939,10 +939,10 @@ void DataDispenser::loadFromHistContent(){
       histBinIndex = 1;
       std::vector<int> axisIdxList{};
       for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
-        LogTrace << GET_VAR_NAME_VALUE(hist->GetAxis(iDim)->FindBin( target[iDim] )) << std::endl;
+        LogTrace << axisNameList[iDim] << " => " << GET_VAR_NAME_VALUE(target[iDim]) << std::endl;
         axisIdxList.emplace_back(hist->GetAxis(iDim)->FindBin( target[iDim] ));
       }
-      LogTrace << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
+      LogTrace << "bins: " << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
       histBinIndex = hist->GetBin( axisIdxList.data() );
 
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -8,6 +8,7 @@
 #include "DatasetLoader.h"
 #include "GenericToolbox.Json.h"
 #include "Misc.h"
+#include "ConfigUtils.h"
 
 #if USE_NEW_DIALS
 #include "DialCollection.h"
@@ -49,7 +50,7 @@ void DataDispenser::readConfigImpl(){
     LogWarning << "Dataset \"" << _parameters_.name << "\" will be defined with histogram data." << std::endl;
 
     _parameters_.fromHistContent = GenericToolbox::Json::fetchValue<nlohmann::json>( _config_, "fromHistContent" );
-    GenericToolbox::Json::forwardConfig( _parameters_.fromHistContent );
+    ConfigUtils::forwardConfig( _parameters_.fromHistContent );
     return;
   }
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -913,19 +913,28 @@ void DataDispenser::loadFromHistContent(){
     auto histName = GenericToolbox::Json::fetchValue<std::string>( entry, "hist" );
     LogInfo << "Filling sample \"" << sample->getName() << "\" using hist with name: " << histName << std::endl;
 
+    LogThrowIf( not GenericToolbox::Json::doKeyExist( entry, "axis" ), "No axis names provided for " << sample->getName() );
+    auto axisNameList = GenericToolbox::Json::fetchValue<std::vector<std::string>>(entry, "axis");
+
     auto* hist = fHist->Get<THnD>( histName.c_str() );
     LogThrowIf( hist == nullptr, "Could not find THnD \"" << histName << "\" within " << fHist->GetPath() );
 
-    LogWarningIf( hist->GetNbins() != int( sample->getBinning().getBinsList().size() ) ) <<
-      "Mismatching bin number for " << sample->getName() << std::endl
-      << GET_VAR_NAME_VALUE(hist->GetNbins()) << std::endl
+
+    int nBins = 0;
+    for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
+      nBins += hist->GetAxis(iDim)->GetNbins();
+    }
+
+    LogAlertIf( nBins != int( sample->getBinning().getBinsList().size() ) ) <<
+      "Mismatching bin number for " << sample->getName() << ":" << std::endl
+      << GET_VAR_NAME_VALUE(nBins) << std::endl
       << GET_VAR_NAME_VALUE(sample->getBinning().getBinsList().size()) << std::endl;
 
     auto* container = &sample->getDataContainer();
     for( size_t iBin = 0 ; iBin < sample->getBinning().getBinsList().size() ; iBin++ ){
       container->eventList[iBin].setTreeWeight(
           hist->GetBinContent(
-              hist->GetBin( sample->getBinning().getBinsList()[iBin].generateBinTarget().data() )
+              hist->GetBin( sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList ).data() )
           )
       );
       container->eventList[iBin].resetEventWeight();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -874,6 +874,10 @@ void DataDispenser::loadFromHistContent(){
     eventPlaceholder.setCommonLeafNameListPtr(
       std::make_shared<std::vector<std::string>>(_cache_.samplesToFillList[iSample]->getBinning().getBinVariables())
     );
+    for( size_t iVar = 0 ; iVar < _cache_.samplesToFillList[iSample]->getBinning().getBinVariables().size() ; iVar++ ){
+      eventPlaceholder.getLeafContentList()[iVar].emplace_back( double(0.) );
+    }
+    eventPlaceholder.resizeVarToDoubleCache();
 
     // one event per bin
     _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -932,13 +932,14 @@ void DataDispenser::loadFromHistContent(){
 
     auto* container = &sample->getDataContainer();
     for( size_t iBin = 0 ; iBin < sample->getBinning().getBinsList().size() ; iBin++ ){
+      auto target = sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList );
       container->eventList[iBin].setTreeWeight(
           hist->GetBinContent(
-              hist->GetBin( sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList ).data() )
+              hist->GetBin( target.data() )
           )
       );
       container->eventList[iBin].resetEventWeight();
-      LogDebug << "Bin #" << iBin << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
+      LogDebug << "Bin #" << iBin << " " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
     }
 
   }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -903,16 +903,17 @@ void DataDispenser::loadFromHistContent(){
     LogThrowIf( hist == nullptr, "Could not find hist \"" << histName << "\" within " << fHist->GetPath() );
 
     LogThrowIf( hist->GetNbins() != int( sample->getBinning().getBinsList().size() ),
-                "Mismatching bin number for " << sample->getName() << std::endl
-                << GET_VAR_NAME_VALUE(hist->GetNbins()) << std::endl
-                << GET_VAR_NAME_VALUE(sample->getBinning().getBinsList().size()) << std::endl
-                );
+      "Mismatching bin number for " << sample->getName() << std::endl
+      << GET_VAR_NAME_VALUE(hist->GetNbins()) << std::endl
+      << GET_VAR_NAME_VALUE(sample->getBinning().getBinsList().size()) << std::endl
+    );
 
     auto* container = &sample->getDataContainer();
     for( size_t iBin = 0 ; iBin < sample->getBinning().getBinsList().size() ; iBin++ ){
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( int(iBin) + 1 ) );
       container->eventList[iBin].resetEventWeight();
     }
+
   }
 
   fHist->Close();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -935,19 +935,19 @@ void DataDispenser::loadFromHistContent(){
       auto target = sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList );
       auto histBinIndex = hist->GetBin( target.data() ); // bad fetch..?
 
-      // manual fetch??
-      histBinIndex = 1;
-      std::vector<int> axisIdxList{};
-      for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
-        LogTrace << axisNameList[iDim] << " => " << GET_VAR_NAME_VALUE(target[iDim]) << std::endl;
-        axisIdxList.emplace_back(hist->GetAxis(iDim)->FindBin( target[iDim] ));
-      }
-      LogTrace << "bins: " << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
-      histBinIndex = hist->GetBin( axisIdxList.data() );
+//      // manual fetch??
+//      histBinIndex = 1;
+//      std::vector<int> axisIdxList{};
+//      for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
+//        LogTrace << axisNameList[iDim] << " => " << GET_VAR_NAME_VALUE(target[iDim]) << std::endl;
+//        axisIdxList.emplace_back(hist->GetAxis(iDim)->FindBin( target[iDim] ));
+//      }
+//      LogTrace << "bins: " << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
+//      histBinIndex = hist->GetBin( axisIdxList.data() );
 
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );
       container->eventList[iBin].resetEventWeight();
-      LogDebug << "Bin #" << iBin << " (" << histBinIndex << ") " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
+//      LogDebug << "Bin #" << iBin << " (" << histBinIndex << ") " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
     }
 
   }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -387,7 +387,6 @@ void DataDispenser::doEventSelection(){
     if( iThread_ == 0 ){ GenericToolbox::displayProgressBar(nEvents, nEvents, ssProgressTitle.str()); }
   };
 
-  LogInfo << "Event selection..." << std::endl;
   if( not _owner_->isDevSingleThreadEventSelection() ) {
     GlobalVariables::getParallelWorker().addJob(__METHOD_NAME__, selectionFct);
     GlobalVariables::getParallelWorker().runJob(__METHOD_NAME__);

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -937,10 +937,13 @@ void DataDispenser::loadFromHistContent(){
 
       // manual fetch??
       histBinIndex = 1;
+      std::vector<int> axisIdxList{};
       for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
         LogTrace << GET_VAR_NAME_VALUE(hist->GetAxis(iDim)->FindBin( target[iDim] )) << std::endl;
-        histBinIndex *= hist->GetAxis(iDim)->FindBin( target[iDim] );
+        axisIdxList.emplace_back(hist->GetAxis(iDim)->FindBin( target[iDim] ));
       }
+      LogTrace << GenericToolbox::parseVectorAsString(axisIdxList) << std::endl;
+      histBinIndex = hist->GetBin( axisIdxList.data() );
 
       container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );
       container->eventList[iBin].resetEventWeight();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -869,18 +869,17 @@ void DataDispenser::loadFromHistContent(){
   // claiming event memory
   for( size_t iSample = 0 ; iSample < _cache_.samplesToFillList.size() ; iSample++ ){
 
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     // one event per bin
     _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();
 
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
-
+    // fetch event container
     auto* container = &_cache_.samplesToFillList[iSample]->getDataContainer();
 
-
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     _cache_.sampleEventListPtrToFill[iSample] = &container->eventList;
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     _cache_.sampleIndexOffsetList[iSample] = _cache_.sampleEventListPtrToFill[iSample]->size();
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     container->reserveEventMemory( _owner_->getDataSetIndex(), _cache_.sampleNbOfEvents[iSample], eventPlaceholder );
 
     LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -860,14 +860,19 @@ void DataDispenser::loadFromHistContent(){
   // non-trivial as we need to propagate systematics. Need to merge with the original data loader, but not straight forward?
   LogThrowIf( _parameters_.useMcContainer, "Hist loader not implemented for MC containers" );
 
+  LogDebug << __LINE__ << std::endl;
   // counting events
   _cache_.sampleNbOfEvents.resize(_cache_.samplesToFillList.size());
 
+  LogDebug << __LINE__ << std::endl;
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());
 
+  LogDebug << __LINE__ << std::endl;
   // claiming event memory
   for( size_t iSample = 0 ; iSample < _cache_.sampleNbOfEvents.size() ; iSample++ ){
+
+    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     // one event per bin
     _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -892,7 +892,8 @@ void DataDispenser::loadFromHistContent(){
   LogThrowIf( not GenericToolbox::Json::doKeyExist(_parameters_.fromHistContent, "fromRootFile"), "No root file provided." );
   auto filePath = GenericToolbox::Json::fetchValue<std::string>(_parameters_.fromHistContent, "fromRootFile");
 
-  fHist = GenericToolbox::openExistingTFile(filePath);
+  LogThrowIf( GenericToolbox::doesTFileIsValid(filePath), "Could not open file: " << filePath );
+  fHist = TFile::Open(filePath.c_str());
   LogThrowIf(fHist == nullptr, "Could not open file: " << filePath);
 
   LogThrowIf( not GenericToolbox::Json::doKeyExist(_parameters_.fromHistContent, "sampleList"), "Could not find samplesList." );

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -914,18 +914,22 @@ void DataDispenser::loadFromHistContent(){
     LogInfo << "Filling sample \"" << sample->getName() << "\" using hist with name: " << histName << std::endl;
 
     auto* hist = fHist->Get<THnD>( histName.c_str() );
-    LogThrowIf( hist == nullptr, "Could not find hist \"" << histName << "\" within " << fHist->GetPath() );
+    LogThrowIf( hist == nullptr, "Could not find THnD \"" << histName << "\" within " << fHist->GetPath() );
 
-    LogThrowIf( hist->GetNbins() != int( sample->getBinning().getBinsList().size() ),
+    LogWarningIf( hist->GetNbins() != int( sample->getBinning().getBinsList().size() ) ) <<
       "Mismatching bin number for " << sample->getName() << std::endl
       << GET_VAR_NAME_VALUE(hist->GetNbins()) << std::endl
-      << GET_VAR_NAME_VALUE(sample->getBinning().getBinsList().size()) << std::endl
-    );
+      << GET_VAR_NAME_VALUE(sample->getBinning().getBinsList().size()) << std::endl;
 
     auto* container = &sample->getDataContainer();
     for( size_t iBin = 0 ; iBin < sample->getBinning().getBinsList().size() ; iBin++ ){
-      container->eventList[iBin].setTreeWeight( hist->GetBinContent( int(iBin) + 1 ) );
+      container->eventList[iBin].setTreeWeight(
+          hist->GetBinContent(
+              hist->GetBin( sample->getBinning().getBinsList()[iBin].generateBinTarget().data() )
+          )
+      );
       container->eventList[iBin].resetEventWeight();
+      LogDebug << "Bin #" << iBin << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
     }
 
   }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -933,13 +933,10 @@ void DataDispenser::loadFromHistContent(){
     auto* container = &sample->getDataContainer();
     for( size_t iBin = 0 ; iBin < sample->getBinning().getBinsList().size() ; iBin++ ){
       auto target = sample->getBinning().getBinsList()[iBin].generateBinTarget( axisNameList );
-      container->eventList[iBin].setTreeWeight(
-          hist->GetBinContent(
-              hist->GetBin( target.data() )
-          )
-      );
+      auto histBinIndex = hist->GetBin( target.data() );
+      container->eventList[iBin].setTreeWeight( hist->GetBinContent( histBinIndex ) );
       container->eventList[iBin].resetEventWeight();
-      LogDebug << "Bin #" << iBin << " " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
+      LogDebug << "Bin #" << iBin << " (" << histBinIndex << ") " << GenericToolbox::parseVectorAsString(target) << " -> weight = " << container->eventList[iBin].getEventWeight() << std::endl;
     }
 
   }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -861,16 +861,16 @@ void DataDispenser::loadFromHistContent(){
   LogThrowIf( _parameters_.useMcContainer, "Hist loader not implemented for MC containers" );
 
   // counting events
-  for( auto& sample : _cache_.samplesToFillList ){
-    // one event per bin
-    _cache_.sampleNbOfEvents.resize( sample->getBinning().getBinsList().size(), 0);
-  }
+  _cache_.sampleNbOfEvents.resize(_cache_.samplesToFillList.size());
 
   PhysicsEvent eventPlaceholder;
   eventPlaceholder.setDataSetIndex(_owner_->getDataSetIndex());
 
   // claiming event memory
   for( size_t iSample = 0 ; iSample < _cache_.sampleNbOfEvents.size() ; iSample++ ){
+    // one event per bin
+    _cache_.sampleNbOfEvents[iSample] = _cache_.samplesToFillList[iSample]->getBinning().getBinsList().size();
+
     auto* container = &_cache_.samplesToFillList[iSample]->getDataContainer();
     _cache_.sampleEventListPtrToFill[iSample] = &container->eventList;
     _cache_.sampleIndexOffsetList[iSample] = _cache_.sampleEventListPtrToFill[iSample]->size();

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -877,19 +877,14 @@ void DataDispenser::loadFromHistContent(){
     // fetch event container
     auto* container = &_cache_.samplesToFillList[iSample]->getDataContainer();
 
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     _cache_.sampleEventListPtrToFill[iSample] = &container->eventList;
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     _cache_.sampleIndexOffsetList[iSample] = _cache_.sampleEventListPtrToFill[iSample]->size();
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(container) << std::endl;
     container->reserveEventMemory( _owner_->getDataSetIndex(), _cache_.sampleNbOfEvents[iSample], eventPlaceholder );
 
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
     // indexing according to the binning
     for( size_t iEvent=_cache_.sampleIndexOffsetList[iSample] ; iEvent < container->eventList.size() ; iEvent++ ){
       container->eventList[iEvent].setSampleBinIndex( int( iEvent ) );
     }
-    LogDebug << __LINE__ << GET_VAR_NAME_VALUE(iSample) << std::endl;
   }
 
   // read hist content from file

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -40,10 +40,13 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
   LogThrowIf(saveDir_ == nullptr, "Save TDirectory is not set.");
   LogThrowIf(treeName_.empty(), "TTree name no set.");
 
+  LogInfo << "Writing " << eventList_.size() << " events in TTree: " << saveDir_->GetPath() << "/" << treeName_ << std::endl;
+
   auto* oldDir = GenericToolbox::getCurrentTDirectory();
 
   auto* tree = new TTree(treeName_.c_str(), treeName_.c_str());
 
+  LogDebug << __LINE__ << std::endl;
   GenericToolbox::RawDataArray privateMemberArr;
   std::map<std::string, std::function<void(GenericToolbox::RawDataArray&, const PhysicsEvent&)>> leafDictionary;
   leafDictionary["eventWeight/D"] =   [](GenericToolbox::RawDataArray& arr_, const PhysicsEvent& ev_){ arr_.writeRawData(ev_.getEventWeight()); };
@@ -61,6 +64,7 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
   privateMemberArr.lockArraySize();
   tree->Branch("Event", &privateMemberArr.getRawDataArray()[0], leavesDefStr.c_str());
 
+  LogDebug << __LINE__ << std::endl;
   GenericToolbox::RawDataArray loadedLeavesArr;
   auto loadedLeavesDict = eventList_[0].generateLeavesDictionary(true);
   std::vector<std::string> leafNamesList;
@@ -74,6 +78,7 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
   loadedLeavesArr.lockArraySize();
   tree->Branch("Leaves", &loadedLeavesArr.getRawDataArray()[0], leavesDefStr.c_str());
 
+  LogDebug << __LINE__ << std::endl;
   std::vector<void*> parReferences;
   std::vector<TSpline3*> responseSplineList;
   std::vector<TSpline3> flatSplinesList; // flat splines for event not affected by parameter (1 spline per parameter)
@@ -114,6 +119,7 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
   }
 
 
+  LogDebug << __LINE__ << std::endl;
   int iLeaf;
   int iPar{0};
   std::string progressTitle = LogInfo.getPrefixString() + "Writing " + treeName_;
@@ -139,6 +145,7 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
     tree->Fill();
   }
 
+  LogDebug << __LINE__ << std::endl;
   GenericToolbox::writeInTFile( saveDir_, tree );
   delete tree;
 

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -145,7 +145,6 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
     tree->Fill();
   }
 
-  LogDebug << __LINE__ << std::endl;
   GenericToolbox::writeInTFile( saveDir_, tree );
   delete tree;
 

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -41,6 +41,7 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
   LogThrowIf(treeName_.empty(), "TTree name no set.");
 
   LogInfo << "Writing " << eventList_.size() << " events in TTree: " << saveDir_->GetPath() << "/" << treeName_ << std::endl;
+  LogReturnIf(eventList_.empty(), "No event to be writen. Leaving...");
 
   auto* oldDir = GenericToolbox::getCurrentTDirectory();
 

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -66,8 +66,8 @@ void EventTreeWriter::writeEvents(TDirectory *saveDir_, const std::string& treeN
 
   GenericToolbox::RawDataArray loadedLeavesArr;
   auto loadedLeavesDict = eventList_[0].generateLeavesDictionary(true);
+  std::vector<std::string> leafNamesList;
   if( not loadedLeavesDict.empty() ){
-    std::vector<std::string> leafNamesList;
     leavesDefStr = "";
     for( auto& leafDef : loadedLeavesDict ){
       if( not leavesDefStr.empty() ) leavesDefStr += ":";

--- a/src/DialDictionary/DialDefinitions/include/CompactSpline.h
+++ b/src/DialDictionary/DialDefinitions/include/CompactSpline.h
@@ -23,6 +23,8 @@ public:
   [[nodiscard]] std::string getDialTypeName() const override { return {"CompactSpline"}; }
   [[nodiscard]] double evalResponse(const DialInputBuffer& input_) const override;
 
+  [[nodiscard]] std::string getSummary() const override;
+
   void setAllowExtrapolation(bool allowExtrapolation) override;
   [[nodiscard]] bool getAllowExtrapolation() const override;
 

--- a/src/DialDictionary/DialDefinitions/include/DialBase.h
+++ b/src/DialDictionary/DialDefinitions/include/DialBase.h
@@ -43,6 +43,9 @@ public:
   virtual void setAllowExtrapolation(bool allow_) {}
   [[nodiscard]] virtual bool getAllowExtrapolation() const {return false;}
 
+  /// Dial summary describing its content
+  [[nodiscard]] virtual std::string getSummary() const { return {}; };
+
   /////////////////////////////////////////////////////////////////////////
   // Pass information to the dial so that it can build it's internal
   // information.  New overloads should be added as we have classes of dials
@@ -76,6 +79,7 @@ public:
   /// Return the data used by the dial to calculate the output values. The
   /// specific data contained in the vector depends on the derived class.
   [[nodiscard]] virtual const std::vector<double>& getDialData() const;
+
 
 };
 

--- a/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
@@ -87,3 +87,12 @@ double CompactSpline::evalResponse(const DialInputBuffer& input_) const {
 
   return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
 }
+
+
+std::string CompactSpline::getSummary() const {
+  std::stringstream ss;
+  ss << "spline data = " << GenericToolbox::parseVectorAsString(_splineData_) << std::endl;
+  ss << "defined bounds = { " << _splineBounds_.first << ", " << _splineBounds_.second << "}" << std::endl;
+  ss << "allow extrapolation ? " << _allowExtrapolation_;
+  return ss.str();
+};

--- a/src/DialDictionary/DialEngine/src/DialInterface.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInterface.cpp
@@ -47,5 +47,10 @@ std::string DialInterface::getSummary(bool shallow_) {
 
   ss << " response=" << this->evalResponse();
 
+  if( not shallow_ ){
+    ss << std::endl;
+    ss << _dialBaseRef_->getSummary();
+  }
+
   return ss.str();
 }

--- a/src/DialDictionary/DialEngine/src/EventDialCache.cpp
+++ b/src/DialDictionary/DialEngine/src/EventDialCache.cpp
@@ -127,6 +127,12 @@ void EventDialCache::reweightEntry(EventDialCache::CacheElem_t& entry_){
     if( std::isnan(dial_.result) or dial_.dial->getInputBufferRef()->isDialUpdateRequested() ){
       dial_.result = dial_.dial->evalResponse();
     }
+
+    if( std::isnan( dial_.result ) ){
+
+      LogThrow("Invalid dial response for " << dial_.dial->getSummary());
+    }
+
     LogThrowIf(std::isnan(dial_.result), "Invalid dial response for " << dial_.dial->getSummary());
     entry_.event->getEventWeightRef() *= dial_.result;
   });

--- a/src/DialDictionary/DialEngine/src/EventDialCache.cpp
+++ b/src/DialDictionary/DialEngine/src/EventDialCache.cpp
@@ -130,7 +130,7 @@ void EventDialCache::reweightEntry(EventDialCache::CacheElem_t& entry_){
 
     if( std::isnan( dial_.result ) ){
 
-      LogThrow("Invalid dial response for " << dial_.dial->getSummary());
+      LogThrow("Invalid dial response for " << dial_.dial->getSummary( false ));
     }
 
     LogThrowIf(std::isnan(dial_.result), "Invalid dial response for " << dial_.dial->getSummary());

--- a/src/FitSamples/src/PhysicsEvent.cpp
+++ b/src/FitSamples/src/PhysicsEvent.cpp
@@ -563,7 +563,7 @@ void PhysicsEvent::copyData(const std::vector<std::pair<const GenericToolbox::Le
       dict_[iLeaf].first->dropToAny(_leafContentList_[iLeaf][0], dict_[iLeaf].second);
     }
   }
-  this->invalidateVarToDoubleCache();
+  this->resizeVarToDoubleCache();
 }
 std::vector<std::pair<const GenericToolbox::LeafHolder*, int>> PhysicsEvent::generateDict(
     const GenericToolbox::TreeEntryBuffer& treeEventBuffer_,

--- a/src/FitSamples/src/PhysicsEvent.cpp
+++ b/src/FitSamples/src/PhysicsEvent.cpp
@@ -563,7 +563,7 @@ void PhysicsEvent::copyData(const std::vector<std::pair<const GenericToolbox::Le
       dict_[iLeaf].first->dropToAny(_leafContentList_[iLeaf][0], dict_[iLeaf].second);
     }
   }
-  this->resizeVarToDoubleCache();
+  this->invalidateVarToDoubleCache();
 }
 std::vector<std::pair<const GenericToolbox::LeafHolder*, int>> PhysicsEvent::generateDict(
     const GenericToolbox::TreeEntryBuffer& treeEventBuffer_,

--- a/src/Utils/include/DataBin.h
+++ b/src/Utils/include/DataBin.h
@@ -16,10 +16,8 @@
 class DataBin {
 
 public:
-  DataBin();
-  virtual ~DataBin();
-
-  void reset();
+  DataBin() = default;
+  virtual ~DataBin() = default;
 
   // Setters
   void setIsLowMemoryUsageMode(bool isLowMemoryUsageMode_);
@@ -32,31 +30,32 @@ public:
   // Init
 
   // Getters
-  bool isLowMemoryUsageMode() const;
-  bool isZeroWideRangesTolerated() const;
-  const std::vector<std::string> &getVariableNameList() const;
-  const std::vector<std::pair<double, double>> &getEdgesList() const;
-  const std::pair<double, double>& getVarEdges( const std::string& varName_ ) const;
-  const std::string &getFormulaStr() const;
-  const std::string &getTreeFormulaStr() const;
-  TFormula *getFormula() const;
-  TTreeFormula *getTreeFormula() const;
-  const std::vector<int> &getEventVarIndexCache() const;
+  [[nodiscard]] bool isLowMemoryUsageMode() const;
+  [[nodiscard]] bool isZeroWideRangesTolerated() const;
+  [[nodiscard]] const std::vector<std::string> &getVariableNameList() const;
+  [[nodiscard]] const std::vector<std::pair<double, double>> &getEdgesList() const;
+  [[nodiscard]] const std::pair<double, double>& getVarEdges( const std::string& varName_ ) const;
+  [[nodiscard]] const std::string &getFormulaStr() const;
+  [[nodiscard]] const std::string &getTreeFormulaStr() const;
+  [[nodiscard]] TFormula *getFormula() const;
+  [[nodiscard]] TTreeFormula *getTreeFormula() const;
+  [[nodiscard]] const std::vector<int> &getEventVarIndexCache() const;
 
   // Non-native Getters
-  size_t getNbEdges() const;
-  double getVolume() const;
+  [[nodiscard]] size_t getNbEdges() const;
+  [[nodiscard]] double getVolume() const;
 
   // Management
-  bool isInBin(const std::vector<double>& valuesList_) const;
-  bool isBetweenEdges(const std::string& variableName_, double value_) const;
-  bool isBetweenEdges(size_t varIndex_, double value_) const;
+  [[nodiscard]] bool isInBin(const std::vector<double>& valuesList_) const;
+  [[nodiscard]] bool isBetweenEdges(const std::string& variableName_, double value_) const;
+  [[nodiscard]] bool isBetweenEdges(size_t varIndex_, double value_) const;
+  [[nodiscard]] bool isVariableSet(const std::string& variableName_) const;
 
   // Misc
-  bool isVariableSet(const std::string& variableName_) const;
-  std::string getSummary() const;
   void generateFormula();
   void generateTreeFormula();
+  [[nodiscard]] std::string getSummary() const;
+  [[nodiscard]] std::vector<double> generateBinTarget() const;
 
   // Static
   static bool isBetweenEdges(const std::pair<double,double>& edges_, double value_);
@@ -70,10 +69,10 @@ private:
   std::vector<std::string> _variableNameList_{};
   std::vector<std::pair<double, double>> _edgesList_{};
 
-  std::string _formulaStr_;
-  std::shared_ptr<TFormula> _formula_;
-  std::string _treeFormulaStr_;
-  std::shared_ptr<TTreeFormula> _treeFormula_;
+  std::string _formulaStr_{};
+  std::string _treeFormulaStr_{};
+  std::shared_ptr<TFormula> _formula_{nullptr};
+  std::shared_ptr<TTreeFormula> _treeFormula_{nullptr};
 
   std::vector<int> _eventVarIndexCache_{};
 

--- a/src/Utils/include/DataBin.h
+++ b/src/Utils/include/DataBin.h
@@ -55,7 +55,7 @@ public:
   void generateFormula();
   void generateTreeFormula();
   [[nodiscard]] std::string getSummary() const;
-  [[nodiscard]] std::vector<double> generateBinTarget() const;
+  [[nodiscard]] std::vector<double> generateBinTarget(const std::vector<std::string>& varNameList_ = {}) const;
 
   // Static
   static bool isBetweenEdges(const std::pair<double,double>& edges_, double value_);

--- a/src/Utils/src/DataBin.cpp
+++ b/src/Utils/src/DataBin.cpp
@@ -151,13 +151,17 @@ std::string DataBin::getSummary() const{
   }
   return ss.str();
 }
-std::vector<double> DataBin::generateBinTarget() const{
+std::vector<double> DataBin::generateBinTarget( const std::vector<std::string>& varNameList_ ) const{
   std::vector<double> out;
   out.reserve( _edgesList_.size() );
-  for( auto& edge : _edgesList_ ){
-    out.emplace_back(edge.first);
-    if( edge.first != edge.second ){
-      out.back() = std::abs( edge.second - edge.first )/2.;
+
+  for( auto& var : (varNameList_.empty() ? _variableNameList_ : varNameList_) ){
+    LogThrowIf( not GenericToolbox::doesElementIsInVector(var, _variableNameList_),
+                "Could not find " << var << " within " << GenericToolbox::parseVectorAsString(_variableNameList_));
+    auto& edges = this->getVarEdges( var );
+    out.emplace_back(edges.first);
+    if( edges.first != edges.second ){
+      out.back() = std::abs(edges.second - edges.first ) / 2.;
     }
   }
   return out;

--- a/src/Utils/src/DataBin.cpp
+++ b/src/Utils/src/DataBin.cpp
@@ -161,7 +161,7 @@ std::vector<double> DataBin::generateBinTarget( const std::vector<std::string>& 
     auto& edges = this->getVarEdges( var );
     out.emplace_back(edges.first);
     if( edges.first != edges.second ){
-      out.back() = std::abs(edges.second - edges.first ) / 2.;
+      out.back() = edges.first + (edges.second - edges.first )/ 2.;
     }
   }
   return out;

--- a/src/Utils/src/DataBin.cpp
+++ b/src/Utils/src/DataBin.cpp
@@ -15,24 +15,6 @@ LoggerInit([]{
   Logger::setUserHeaderStr("[DataBin]");
 } );
 
-DataBin::DataBin() {
-  reset();
-}
-DataBin::~DataBin() {
-  reset();
-}
-
-void DataBin::reset() {
-  _edgesList_.clear();
-  _variableNameList_.clear();
-  _isLowMemoryUsageMode_ = false;
-  _isZeroWideRangesTolerated_ = false;
-  _formulaStr_ = "";
-  _treeFormulaStr_ = "";
-  _formula_ = nullptr;
-  _treeFormula_ = nullptr;
-}
-
 // Setters
 void DataBin::setIsLowMemoryUsageMode(bool isLowMemoryUsageMode_){
   _isLowMemoryUsageMode_ = isLowMemoryUsageMode_;
@@ -169,14 +151,22 @@ std::string DataBin::getSummary() const{
   }
   return ss.str();
 }
+std::vector<double> DataBin::generateBinTarget() const{
+  std::vector<double> out;
+  out.reserve( _edgesList_.size() );
+  for( auto& edge : _edgesList_ ){
+    out.emplace_back(edge.first);
+    if( edge.first != edge.second ){
+      out.back() = std::abs( edge.second - edge.first )/2.;
+    }
+  }
+  return out;
+}
 void DataBin::generateFormula() {
-
   _formulaStr_ = generateFormulaStr(false);
   _formula_ = std::make_shared<TFormula>(_formulaStr_.c_str(), _formulaStr_.c_str());
-
 }
 void DataBin::generateTreeFormula() {
-
   _treeFormulaStr_ = generateFormulaStr(true);
   // For treeFormula we need a fake tree to compile the formula
   std::vector<std::string> varNameList;


### PR DESCRIPTION
Instead of loading individual events from a TTree, data histograms for the fit can be loaded directly from external histograms set in a ROOT file.

This feature was motivated in order to load toy histograms from the BANFF and reproduce the fits.