### PR TITLE
Add DialInput input checks for debug build

### DIFF
--- a/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
@@ -115,9 +115,13 @@ void CompactSpline::buildDial(const std::vector<double>& v1,
 double CompactSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for CompactSpline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
-    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+    if     (dialInput <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
   return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );

--- a/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
@@ -75,9 +75,13 @@ void GeneralSpline::buildDial(const std::vector<double>& xPoints,
 double GeneralSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for GeneralSpline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
-    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+    if     (dialInput <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
   return CalculateGeneralSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );

--- a/src/DialDictionary/DialDefinitions/src/Graph.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Graph.cpp
@@ -24,9 +24,15 @@ void Graph::buildDial(const TGraph &graph, const std::string& option_) {
 }
 
 double Graph::evalResponse(const DialInputBuffer& input_) const {
+  double dialInput{input_.getBuffer()[0]};
+
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for Graph");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _graph_.GetX()[0])                { return _graph_.GetY()[0]; }
-    else if(input_.getBuffer()[0] >= _graph_.GetX()[_graph_.GetN()-1]) { return _graph_.GetY()[_graph_.GetN() - 1]; }
+    if     (dialInput <= _graph_.GetX()[0])                { return _graph_.GetY()[0]; }
+    else if(dialInput >= _graph_.GetX()[_graph_.GetN()-1]) { return _graph_.GetY()[_graph_.GetN() - 1]; }
   }
-  return _graph_.Eval(input_.getBuffer()[0]);
+  return _graph_.Eval(dialInput);
 }

--- a/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
@@ -115,9 +115,13 @@ void MonotonicSpline::buildDial(const std::vector<double>& v1,
 double MonotonicSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for MonotonicSpline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
-    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+    if     (dialInput <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
   return CalculateMonotonicSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );

--- a/src/DialDictionary/DialDefinitions/src/SimpleSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/SimpleSpline.cpp
@@ -101,9 +101,13 @@ void SimpleSpline::buildDial(const TSpline3& sp_, const std::string& option_) {
 double SimpleSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for SimpleSpline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
-    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+    if     (dialInput <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
   if( _isUniform_ ){

--- a/src/DialDictionary/DialDefinitions/src/Spline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Spline.cpp
@@ -53,13 +53,19 @@ void Spline::buildDial(const std::vector<double>& v1,
 const TSpline3 &Spline::getSpline() const {return _spline_;}
 
 double Spline::evalResponse(const DialInputBuffer& input_) const {
+  const double dialInput{input_.getBuffer()[0]};
+
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for Spline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if (input_.getBuffer()[0] <= _spline_.GetXmin()) {
+    if (dialInput <= _spline_.GetXmin()) {
       return _spline_.Eval( _spline_.GetXmin() );
     }
-    else if (input_.getBuffer()[0] >= _spline_.GetXmax()) {
+    else if (dialInput >= _spline_.GetXmax()) {
       return _spline_.Eval( _spline_.GetXmax() );
     }
   }
-  return _spline_.Eval( input_.getBuffer()[0] );
+  return _spline_.Eval( dialInput );
 }

--- a/src/DialDictionary/DialDefinitions/src/UniformSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/UniformSpline.cpp
@@ -85,9 +85,13 @@ void UniformSpline::buildDial(const std::vector<double>& xPoints,
 double UniformSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getBuffer()[0]};
 
+#ifndef NDEBUG
+  LogThrowIf(not std::isfinite(dialInput), "Invalid input for UniformSpline");
+#endif
+
   if( not _allowExtrapolation_ ){
-    if     (input_.getBuffer()[0] <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
-    else if(input_.getBuffer()[0] >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
+    if     (dialInput <= _splineBounds_.first) { dialInput = _splineBounds_.first; }
+    else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
   return CalculateUniformSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );


### PR DESCRIPTION
This adds a check that the DialInputs buffer value is a finite number to all of the DialBase derived objects.  It's only compiled when NDEBUG is not set (so that means during the Debug build). If NDEBUG is not defined, this will throw.  If NDEBUG is defined, this is a noop.