### PR TITLE
Fix/compact and monotonic calls

### DIFF
--- a/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
@@ -124,7 +124,7 @@ double CompactSpline::evalResponse(const DialInputBuffer& input_) const {
     else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
-  return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+  return CalculateCompactSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()-2) );
 }
 
 

--- a/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
@@ -124,5 +124,5 @@ double MonotonicSpline::evalResponse(const DialInputBuffer& input_) const {
     else if(dialInput >= _splineBounds_.second){ dialInput = _splineBounds_.second; }
   }
 
-  return CalculateMonotonicSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()) );
+  return CalculateMonotonicSpline( dialInput, -1E20, 1E20, _splineData_.data(), int(_splineData_.size()-2) );
 }

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -100,7 +100,7 @@ double SplineDial::calcDial(double parameterValue_) {
   else if (_splineType_ == SplineDial::Monotonic) {
       dialResponse = CalculateMonotonicSpline(
           parameterValue_, -1E20, 1E20,
-          _splineData_.data(), int(_splineData_.size()));
+          _splineData_.data(), int(_splineData_.size()-2));
   }
   else if (_splineType_ == SplineDial::ROOTSpline) {
       dialResponse = _spline_.Eval(parameterValue_);

--- a/src/Utils/include/CalculateCompactSpline.h
+++ b/src/Utils/include/CalculateCompactSpline.h
@@ -34,12 +34,17 @@ namespace {
     // Interpolate one point using a compact spline.  This takes the "index"
     // of the point in the data, the parameter value (that made the index), a
     // minimum and maximum bound, the buffer of data for this spline, and the
-    // number of data elements in the spline data.  The input data is arrange
+    // number of knots in the spline data.  The input data is arrange
     // as
 
-    // data[0] -- spline lower bound (not used)
-    // data[1] -- spline inverse step (not used)
-    // data[2+2*n+0] -- The function value for knot n
+    // data[0] -- spline lower bound
+    // data[1] -- spline step between X values
+    // data[2+n+0] -- The function value for knot n (0 to dim-1)
+    //
+    // NOTE: CalculateUniformSpline, CalculateGeneralSpline,
+    // CalculateCompactSpline, and CalculateMonotonicSpline have very similar,
+    // but different calls.  In particular the dim parameter meaning is not
+    // consistent.
     DEVICE_CALLABLE_INLINE
     double CalculateCompactSpline(const double x,
                                   const double lowerBound, double upperBound,

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -36,10 +36,15 @@ namespace {
     // The input data is arrange as
     //
     // data[0] -- spline lower bound (not used)
-    // data[1] -- spline inverse step (not used)
+    // data[1] -- spline step (not used)
     // data[2+3*n+0] -- The function value for knot n
     // data[2+3*n+1] -- The function slope for knot n
     // data[2+3*n+2] -- The point for knot n
+    //
+    // NOTE: CalculateUniformSpline, CalculateGeneralSpline,
+    // CalculateCompactSpline, and CalculateMonotonicSpline have very similar,
+    // but different calls.  In particular the dim parameter meaning is not
+    // consistent.
     DEVICE_CALLABLE_INLINE
     double CalculateGeneralSpline(const double x,
                                   const double lowerBound, double upperBound,

--- a/src/Utils/include/CalculateMonotonicSpline.h
+++ b/src/Utils/include/CalculateMonotonicSpline.h
@@ -34,12 +34,17 @@ namespace {
     // Interpolate one point using a monotonic spline.  This takes the "index"
     // of the point in the data, the parameter value (that made the index), a
     // minimum and maximum bound, the buffer of data for this spline, and the
-    // number of data elements in the spline data.  The input data is arrange
+    // number of knots in the spline data.  The input data is arrange
     // as
 
     // data[0] -- spline lower bound (not used)
     // data[1] -- spline inverse step (not used)
-    // data[2+2*n+0] -- The function value for knot n
+    // data[2+n+0] -- The function value for knot n (0 to dim-1)
+    //
+    // NOTE: CalculateUniformSpline, CalculateGeneralSpline,
+    // CalculateCompactSpline, and CalculateMonotonicSpline have very similar,
+    // but different calls.  In particular the dim parameter meaning is not
+    // consistent.
     DEVICE_CALLABLE_INLINE
     double CalculateMonotonicSpline(const double x,
                                     const double lowerBound, double upperBound,

--- a/src/Utils/include/CalculateUniformSpline.h
+++ b/src/Utils/include/CalculateUniformSpline.h
@@ -34,10 +34,15 @@ namespace {
     // number of data elements in the spline data.  The input data is arrange
     // as
     //
-    // data[0] -- spline lower bound (not used)
-    // data[1] -- spline inverse step (not used)
-    // data[2+2*n+0] -- The function value for knot n
+    // data[0] -- spline lower bound
+    // data[1] -- spline step
+    // data[2+2*n+0] -- The function value for knot n (0 to dim-3)
     // data[2+2*n+1] -- The function slope for knot n
+    //
+    // NOTE: CalculateUniformSpline, CalculateGeneralSpline,
+    // CalculateCompactSpline, and CalculateMonotonicSpline have very similar,
+    // but different calls.  In particular the dim parameter meaning is not
+    // consistent.
     DEVICE_CALLABLE_INLINE
     double CalculateUniformSpline(const double x,
                                   const double lowerBound, double upperBound,


### PR DESCRIPTION
The Calculate{Monotonic,Compact,Uniform,General}Spline interfaces are deceptively similar, but different enough to be a "bug trap".  This doesn't fix the interfaces (which do need to be made more uniform), but does use the current interface as it was originally written.  It also updates the function documentation to call out the interface differences.  When merged, this close #315.