### PR TITLE
Feature/dial factory error messages

### DIFF
--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1319,6 +1319,7 @@ void DataDispenser::fillFunction(int iThread_){
               // there is an exception (being stupidly paranoid).
               std::unique_ptr<DialBase> dialBase(
                   factory.makeDial(
+                      dialCollectionRef->getTitle(),
                       dialCollectionRef->getGlobalDialType(),
                       dialCollectionRef->getGlobalDialSubType(),
                       grPtr,

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -309,7 +309,7 @@ bool DialCollection::initializeNormDialsWithParBinning() {
   _dialBaseList_.reserve( _dialBinSet_.getBinsList().size() );
   DialBaseFactory factory;
   for(const auto & bin : _dialBinSet_.getBinsList()) {
-    _dialBaseList_.emplace_back(DialBaseObject(factory.makeDial("Normalization","",nullptr,false)));
+    _dialBaseList_.emplace_back(DialBaseObject(factory.makeDial(getTitle(), "Normalization","",nullptr,false)));
   }
 
   return true;
@@ -337,7 +337,7 @@ bool DialCollection::initializeDialsWithDefinition() {
     // This dial collection is a normalization, so there is a single dial.
     // Create it here.
     _dialBaseList_.emplace_back(
-      DialBaseObject(dialBaseFactory.makeDial("Normalization","",nullptr,false)));
+      DialBaseObject(dialBaseFactory.makeDial(getTitle(),"Normalization","",nullptr,false)));
   }
   else {
     if     (not _globalDialLeafName_.empty()) {
@@ -384,6 +384,7 @@ bool DialCollection::initializeDialsWithDefinition() {
           TObject* binnedInitializer = dialsList->At(iBin);
 
           DialBase *dialBase = dialBaseFactory.makeDial(
+              getTitle(),
               getGlobalDialType(),
               getGlobalDialSubType(),
               binnedInitializer,
@@ -469,6 +470,7 @@ bool DialCollection::initializeDialsWithDefinition() {
           if (getGlobalDialType() == "Graph") dialInitializer = graphPtr;
           DialBaseFactory factory;
           DialBase *dialBase = factory.makeDial(
+              getTitle(),
               getGlobalDialType(),
               getGlobalDialSubType(),
               dialInitializer,

--- a/src/DialDictionary/DialFactories/include/DialBaseFactory.h
+++ b/src/DialDictionary/DialFactories/include/DialBaseFactory.h
@@ -20,13 +20,15 @@ public:
   DialBaseFactory() = default;
   ~DialBaseFactory() = default;
 
-  // Construct a pointer to the correct DialBase.  This uses the dialType and
+  // Construct a pointer to the correct DialBase.  The dial title is provided
+  // so that better error messages can be printed. This uses the dialType and
   // dialSubType to figure out the correct class, and then uses the object
   // pointed to by the dialInitializer to fill the dial.  The initializer is
   // not a constant due to constraints from ROOT.  NOTE: The ownership of the
   // pointer is passed to the caller, so it should be put in a managed
   // variable (e.g. a unique_ptr, or shared_ptr).
-  DialBase* makeDial(const std::string& dialType_,
+  DialBase* makeDial(const std::string& dialTitle_,
+                     const std::string& dialType_,
                      const std::string& dialSubType_,
                      TObject* dialInitializer_,
                      bool useCachedDial_);

--- a/src/DialDictionary/DialFactories/include/GraphDialBaseFactory.h
+++ b/src/DialDictionary/DialFactories/include/GraphDialBaseFactory.h
@@ -20,7 +20,8 @@ public:
   // pointed to by the dialInitializer to fill the dial.  The ownership of the
   // pointer is passed to the caller, so it should be put in a managed
   // variable (e.g. a unique_ptr, or shared_ptr).
-  DialBase* makeDial(const std::string& dialType_,
+  DialBase* makeDial(const std::string& dialTitle_,
+                     const std::string& dialType_,
                      const std::string& dialSubType_,
                      TObject* dialInitializer_,
                      bool useCachedDial_);

--- a/src/DialDictionary/DialFactories/include/NormDialBaseFactory.h
+++ b/src/DialDictionary/DialFactories/include/NormDialBaseFactory.h
@@ -21,7 +21,8 @@ public:
   // pointed to by the dialInitializer to fill the dial.  The ownership of the
   // pointer is passed to the caller, so it should be put in a managed
   // variable (e.g. a unique_ptr, or shared_ptr).
-  DialBase* makeDial(const std::string& dialType_,
+  DialBase* makeDial(const std::string& dialTitle_,
+                     const std::string& dialType_,
                      const std::string& dialSubType_,
                      TObject* dialInitializer_,
                      bool useCachedDial_);

--- a/src/DialDictionary/DialFactories/include/SplineDialBaseFactory.h
+++ b/src/DialDictionary/DialFactories/include/SplineDialBaseFactory.h
@@ -45,7 +45,8 @@ public:
   /// dialInitializer to fill the dial.  The ownership of the pointer is
   /// passed to the caller, so it should be put in a managed variable (e.g. a
   /// unique_ptr, or shared_ptr).
-  DialBase* makeDial(const std::string& dialType_,
+  DialBase* makeDial(const std::string& dialTitle_,
+                     const std::string& dialType_,
                      const std::string& dialSubType_,
                      TObject* dialInitializer_,
                      bool useCachedDial_);

--- a/src/DialDictionary/DialFactories/src/DialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/DialBaseFactory.cpp
@@ -10,10 +10,11 @@ LoggerInit([]{
 });
 
 
-DialBase* DialBaseFactory::makeDial(const std::string& dialType_,
-                                        const std::string& dialSubType_,
-                                        TObject* dialInitializer_,
-                                        bool useCachedDial_) {
+DialBase* DialBaseFactory::makeDial(const std::string& dialTitle_,
+                                    const std::string& dialType_,
+                                    const std::string& dialSubType_,
+                                    TObject* dialInitializer_,
+                                    bool useCachedDial_) {
 
   // Stuff the created dial into a unique_ptr, so it will be properly deleted
   // in the event of an exception.
@@ -21,15 +22,15 @@ DialBase* DialBaseFactory::makeDial(const std::string& dialType_,
 
   if (dialType_ == "Norm" || dialType_ == "Normalization") {
     NormDialBaseFactory factory;
-    dialBase.reset(factory.makeDial(dialType_, dialSubType_, dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, dialType_, dialSubType_, dialInitializer_, useCachedDial_));
   }
   else if (dialType_ == "Graph") {
     GraphDialBaseFactory factory;
-    dialBase.reset(factory.makeDial(dialType_, dialSubType_, dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, dialType_, dialSubType_, dialInitializer_, useCachedDial_));
   }
   else if (dialType_ == "Spline") {
     SplineDialBaseFactory factory;
-    dialBase.reset(factory.makeDial(dialType_, dialSubType_, dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, dialType_, dialSubType_, dialInitializer_, useCachedDial_));
   }
 #define INCLUDE_DEPRECATED_DIAL_TYPES
 #ifdef INCLUDE_DEPRECATED_DIAL_TYPES
@@ -39,26 +40,26 @@ DialBase* DialBaseFactory::makeDial(const std::string& dialType_,
     << std::endl << "  dialSubType: \"catmull-rom, monotonic\""
             << std::endl;
     SplineDialBaseFactory factory;
-    dialBase.reset(factory.makeDial("Spline", "catmull-rom, monotonic",
+    dialBase.reset(factory.makeDial(dialTitle_, "Spline", "catmull-rom, monotonic",
                            dialInitializer_, useCachedDial_));
   }
   else if (dialType_ == "GeneralSpline") {
     LogAlertOnce << "DEPRECATED DIAL-TYPE USED: GeneralSpline will be removed. Instead use: \"Spline\""
             << std::endl;
     SplineDialBaseFactory factory;
-    dialBase.reset(factory.makeDial("Spline", "not-a-knot", dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, "Spline", "not-a-knot", dialInitializer_, useCachedDial_));
   }
   else if (dialType_ == "SimpleSpline") {
     LogAlertOnce << "DEPRECATED DIAL-TYPE USED: SimpleSpline will be removed. Instead use: \"Spline\""
             << std::endl;
     SplineDialBaseFactory factory;
-    dialBase.reset(factory.makeDial("Spline", "knot-a-knot", dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, "Spline", "knot-a-knot", dialInitializer_, useCachedDial_));
   }
   else if (dialType_ == "LightGraph") {
     LogAlertOnce << "DEPRECATED DIAL-TYPE USED: LightGraph will be removed. Instead use: \"Graph\""
             << std::endl;
     GraphDialBaseFactory factory;
-    dialBase.reset(factory.makeDial("Graph", "light", dialInitializer_, useCachedDial_));
+    dialBase.reset(factory.makeDial(dialTitle_, "Graph", "light", dialInitializer_, useCachedDial_));
   }
 #endif
 

--- a/src/DialDictionary/DialFactories/src/GraphDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/GraphDialBaseFactory.cpp
@@ -8,7 +8,8 @@ LoggerInit([]{
   Logger::setUserHeaderStr("[GraphFactory]");
 });
 
-DialBase* GraphDialBaseFactory::makeDial(const std::string& dialType_,
+DialBase* GraphDialBaseFactory::makeDial(const std::string& dialTitle_,
+                                         const std::string& dialType_,
                                          const std::string& dialSubType_,
                                          TObject* dialInitializer_,
                                          bool useCachedDial_) {

--- a/src/DialDictionary/DialFactories/src/NormDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/NormDialBaseFactory.cpp
@@ -5,7 +5,8 @@ LoggerInit([]{
   Logger::setUserHeaderStr("[NormFactory]");
 });
 
-DialBase* NormDialBaseFactory::makeDial(const std::string& dialType_,
+DialBase* NormDialBaseFactory::makeDial(const std::string& dialTitle_,
+                                        const std::string& dialType_,
                                         const std::string& dialSubType_,
                                         TObject* dialInitializer_,
                                         bool useCachedDial_) {

--- a/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
@@ -120,7 +120,8 @@ void SplineDialBaseFactory::MakeMonotonic(const std::vector<double>& xPoint,
   }
 }
 
-DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
+DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
+                                          const std::string& dialType_,
                                           const std::string& dialSubType_,
                                           TObject* dialInitializer_,
                                           bool useCachedDial_) {
@@ -149,7 +150,8 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
     bg = dialSubType_.find("(",bg);
     std::size_t en = dialSubType_.find(")",bg);
     LogThrowIf(en == std::string::npos,
-               "Invalid spline uniformity with dialSubType: " << dialSubType_);
+               "Invalid spline uniformity with dialSubType: " << dialSubType_
+               << " dial: " << dialTitle_);
     en = en - bg;
     std::string uniformityString = dialSubType_.substr(bg+1,en-1);
     std::istringstream unif(uniformityString);
@@ -198,7 +200,8 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
   // number of points or something is very wrong.
   LogThrowIf( _xPointListBuffer_.size() != _yPointListBuffer_.size(),
               "INVALID Spline Input: "
-              << "must have the same number of X and Y points" );
+              << "must have the same number of X and Y points "
+              << "for dial " << dialTitle_ );
 
   // Check that the X points are in strictly increasing order (sorted order is
   // not sufficient) with explicit comparisons in case we want to add more
@@ -206,7 +209,8 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
   // with the inputs.  Don't try to continue!
   for (int i = 1; i<_xPointListBuffer_.size(); ++i) {
     LogThrowIf(_xPointListBuffer_[i] <= _xPointListBuffer_[i-1],
-               "INVALID Spline Input: points are not in increasing order." );
+               "INVALID Spline Input: points are not in increasing order "
+               << " for dial " << dialTitle_);
   }
 
   // Check if the spline is flat.  Flat functions won't be handled with
@@ -265,7 +269,9 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
   // Sanity check.  By the time we get here, there can't be fewer than two
   // points, and it should have been trapped above by other conditionals
   // (e.g. a single point "spline" should have been flagged as flat).
-  LogThrowIf((_xPointListBuffer_.size() < 2), "Input data logic error: two few points");
+  LogThrowIf((_xPointListBuffer_.size() < 2),
+             "Input data logic error: two few points "
+             << "for dial " << dialTitle_ );
 
   // If there are only two points, then force catmull-rom.  This could be
   // handled using a graph, but Catmull-Rom is fast, and works better with the
@@ -316,6 +322,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
     // uniformly spaced knots.
     if (not isUniform) {
       LogError << "Monotonic Catmull-rom splines need a uniformly spaced points"
+               << " Dial: " << dialTitle_
                << std::endl;
       double step = (_xPointListBuffer_.back()-_xPointListBuffer_.front())/(_xPointListBuffer_.size()-1);
       for (int i = 0; i<_xPointListBuffer_.size()-1; ++i) {
@@ -339,6 +346,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialType_,
     // This is the version when the spline doesn't need to be monotonic.
     if (not isUniform) {
       LogError << "Catmull-rom splines need a uniformly spaced points"
+               << " Dial: " << dialTitle_
                << std::endl;
       double step = (_xPointListBuffer_.back()-_xPointListBuffer_.front())/(_xPointListBuffer_.size()-1);
       for (int i = 0; i<_xPointListBuffer_.size()-1; ++i) {

--- a/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
@@ -143,7 +143,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
 
   // Get the numeric tolerance for when a uniform spline can be used.  We
   // should be able to set this in the DialSubType.
-  const double defUniformityTolerance{std::numeric_limits<float>::epsilon()};
+  const double defUniformityTolerance{16*std::numeric_limits<float>::epsilon()};
   double uniformityTolerance{defUniformityTolerance};
   if (dialSubType_.find("uniformity(") != std::string::npos) {
     std::size_t bg = dialSubType_.find("uniformity(");


### PR DESCRIPTION
An exception is thrown when the dial factories find invalid inputs.  This improves the output so that the user knows which parameter is causing the problem (the `DialCollection::getTitle()` value is printed).  The spline uniformity tolerance was also a little too tight and it was causing lots of warning messages, so it's been loosened. 