### PR TITLE
Fix/cache manager with gpu

### DIFF
--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -152,13 +152,8 @@ Cache::Manager::Manager(int events, int parameters,
                                   fParameterCache->GetLowerClamps(),
                                   fParameterCache->GetUpperClamps(),
                                   graphs, graphPoints);
-        std::cout << "Allocated graphs Cache " << std::endl;
         fWeightsCache->AddWeightCalculator(fGraphs.get());
-        std::cout << "Added graph weight calculator" << std::endl;
         fTotalBytes += fGraphs->GetResidentMemory();
-        std::cout << "got total bytes " << std::endl;
-
-        std::cout << "Allocate histogram Cache " << histBins << std::endl;
         fHistogramsCache = std::make_unique<Cache::IndexedSums>(
                                   fWeightsCache->GetWeights(),
                                   histBins);

--- a/src/FitSamples/src/PhysicsEvent.cpp
+++ b/src/FitSamples/src/PhysicsEvent.cpp
@@ -68,7 +68,7 @@ double PhysicsEvent::getEventWeight() const {
             // _CacheManagerValue_ and _CacheManagerValid_ are inside
             // of the weights cache (a bit of evil coding here), and are
             // updated by the cache.  The update is triggered by
-            // _CacheManagerUpdate().
+            // (*_CacheManagerUpdate_)().
             if (_CacheManagerUpdate_) (*_CacheManagerUpdate_)();
         }
 #ifdef CACHE_MANAGER_SLOW_VALIDATION

--- a/src/FitSamples/src/SampleElement.cpp
+++ b/src/FitSamples/src/SampleElement.cpp
@@ -110,10 +110,19 @@ void SampleElement::refillHistogram(int iThread_){
   auto* binContentArray = histogram->GetArray();
   auto* binErrorArray = histogram->GetSumw2()->GetArray();
   while( iBin < nBins ) {
-    binContentArray[iBin + 1] = 0; 
+    binContentArray[iBin + 1] = 0;
     binErrorArray[iBin + 1] = 0;
 #ifdef GUNDAM_USING_CACHE_MANAGER
-    if (_CacheManagerValue_!=nullptr and _CacheManagerIndex_ >= 0) {
+    if (_CacheManagerValue_ !=nullptr and _CacheManagerIndex_ >= 0) {
+      if (_CacheManagerValid_ and not (*_CacheManagerValid_)) {
+        // This is can be slowish on when data must be copied from the device,
+        // but makes sure that the cached result is updated when the cache has
+        // changed.  The values pointed to by _CacheManagerValue_ and
+        // _CacheManagerValid_ are inside of the summed index cache (a bit of
+        // evil coding here), and are updated by the cache.  The update is
+        // triggered by (*_CacheManagerUpdate_)().
+        if (_CacheManagerUpdate_) (*_CacheManagerUpdate_)();
+      }
       binContentArray[iBin + 1] += _CacheManagerValue_[_CacheManagerIndex_+iBin];
       binErrorArray[iBin + 1] += binContentArray[iBin + 1]*binContentArray[iBin + 1];
 #ifdef CACHE_MANAGER_SLOW_VALIDATION


### PR DESCRIPTION
This applies a small fix to make sure that the GPU results are copied back to the CPU.  This passes all of the tests with and without a GPU enabled.