### PR TITLE
Make sure gRandom is properly initialized

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -67,15 +67,12 @@ int main(int argc, char** argv){
 
 
   // Global parameters
+  gRandom = new TRandom3(0);     // Initialize with a UUID
   if( clParser.isOptionTriggered("randomSeed") ){
     LogAlert << "Using user-specified random seed: " << clParser.getOptionVal<ULong_t>("randomSeed") << std::endl;
     gRandom->SetSeed(clParser.getOptionVal<ULong_t>("randomSeed"));
   }
-  else{
-    ULong_t seed = time(nullptr);
-    LogInfo << "Using \"time(nullptr)\" random seed: " << seed << std::endl;
-    gRandom->SetSeed(seed);
-  }
+
   GlobalVariables::setNbThreads(clParser.getOptionVal("nbThreads", 1));
   LogInfo << "Running the fitter with " << GlobalVariables::getNbThreads() << " parallel threads." << std::endl;
 
@@ -346,7 +343,7 @@ int main(int argc, char** argv){
   struct BinNormaliser{
     void readConfig(const nlohmann::json& config_){
       LogScopeIndent;
-      
+
       name = GenericToolbox::Json::fetchValue<std::string>(config_, "name");
 
       if( not GenericToolbox::Json::fetchValue(config_, "isEnabled", true) ){
@@ -682,4 +679,3 @@ int main(int argc, char** argv){
 
   GlobalVariables::getParallelWorker().reset();
 }
-

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -140,14 +140,10 @@ int main(int argc, char** argv){
   }
 
   // PRNG seed?
+  gRandom = new TRandom3(0);    // Initialize with a UUID;
   if( clParser.isOptionTriggered("randomSeed") ){
     LogAlert << "Using user-specified random seed: " << clParser.getOptionVal<ULong_t>("randomSeed") << std::endl;
     gRandom->SetSeed(clParser.getOptionVal<ULong_t>("randomSeed"));
-  }
-  else{
-    ULong_t seed = time(nullptr);
-    LogInfo << "Using \"time(nullptr)\" random seed: " << seed << std::endl;
-    gRandom->SetSeed(seed);
   }
 
   // How many parallel threads?


### PR DESCRIPTION
The `gRandom` "variable" was being initialized by default.  That usually means it's assigned to `TRandom3`, with a seed of 1.  The seed was then being set off of the time which caused problems when starting a lot of parallel jobs.  Changed to explicitly initialize `gRandom` to `TRandom3(0)` so we get a well known generator that is initialized from the UUID.