### PR TITLE
Feature/mcmc likelihood mirroring

### DIFF
--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -75,14 +75,14 @@ public:
   /// mirror for each parameter.  The first entry in the pair is the lower
   /// bound of the mirrored region, the second entry is the range of the
   /// mirror.  The valid region will be between first, and first+second.
-  [[nodiscard]]
-       const std::pair<double,double>& getMirrorBounds(int i) const;
+  [[nodiscard]] const std::pair<double,double>& getMirrorBounds(int i) const;
 
   /// Simple printout function for debug info on error
   [[nodiscard]] std::string getSummary() const;
 
-  /// Function that allow to tweak the buffer from the inside. Used for individual spline evaluation.
-  std::vector<double>& getBufferVector(){ return _buffer_; }
+  /// Function that allow to tweak the buffer from the inside. Used for
+  /// individual spline evaluation.
+  std::vector<double>& getBufferVector() { return _buffer_; }
 
 protected:
   uint32_t generateHash();

--- a/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
@@ -111,6 +111,11 @@ void DialInputBuffer::addParameterIndices(const std::pair<size_t, size_t>& indic
   _buffer_.emplace_back(std::nan("unset"));
 }
 void DialInputBuffer::addMirrorBounds(const std::pair<double, double>& lowEdgeAndRange_){
+  const int p = _parameterMirrorBounds_.size();
+  // Overriding the const to allow the mirroring information to be stored
+  FitParameter& par = const_cast<FitParameter&>(getFitParameter(p));
+  par.setMinMirror(lowEdgeAndRange_.first);
+  par.setMaxMirror(lowEdgeAndRange_.first + lowEdgeAndRange_.second);
   _parameterMirrorBounds_.emplace_back(lowEdgeAndRange_);
 }
 const std::pair<double,double>&

--- a/src/FitParameters/include/FitParameter.h
+++ b/src/FitParameters/include/FitParameter.h
@@ -52,6 +52,10 @@ public:
   void setOwner(const FitParameterSet *owner_);
   void setPriorType(PriorType::PriorType priorType);
 
+  // Record the mirroring being used by any dials.
+  void setMinMirror(double minMirror);
+  void setMaxMirror(double maxMirror);
+
   void setValueAtPrior();
   void setCurrentValueAsPrior();
 
@@ -65,6 +69,8 @@ public:
   [[nodiscard]] int getParameterIndex() const;
   [[nodiscard]] double getMinValue() const;
   [[nodiscard]] double getMaxValue() const;
+  [[nodiscard]] double getMinMirror() const;
+  [[nodiscard]] double getMaxMirror() const;
   [[nodiscard]] double getStepSize() const;
   [[nodiscard]] double getPriorValue() const;
   [[nodiscard]] double getThrowValue() const;
@@ -109,6 +115,8 @@ private:
   double _stdDevValue_{std::nan("unset")};
   double _minValue_{std::nan("unset")};
   double _maxValue_{std::nan("unset")};
+  double _minMirror_{std::nan("unset")};
+  double _maxMirror_{std::nan("unset")};
   double _stepSize_{std::nan("unset")};
   std::string _name_{};
   std::string _dialsWorkingDirectory_{"."};

--- a/src/FitParameters/src/FitParameter.cpp
+++ b/src/FitParameters/src/FitParameter.cpp
@@ -139,6 +139,24 @@ void FitParameter::setMinValue(double minValue) {
 void FitParameter::setMaxValue(double maxValue) {
   _maxValue_ = maxValue;
 }
+void FitParameter::setMinMirror(double minMirror) {
+  if (std::isfinite(_minMirror_) and std::abs(_minMirror_-minMirror) > 1E-6) {
+    LogWarning << "Minimum mirror bound changed for " << getFullTitle()
+               << " old: " << _minMirror_
+               << " new: " << minMirror
+               << std::endl;
+  }
+  _minMirror_ = minMirror;
+}
+void FitParameter::setMaxMirror(double maxMirror) {
+  if (std::isfinite(_maxMirror_) and std::abs(_maxMirror_-maxMirror) > 1E-6) {
+    LogWarning << "Maximum mirror bound changed for " << getFullTitle()
+               << " old: " << _maxMirror_
+               << " new: " << maxMirror
+               << std::endl;
+  }
+  _maxMirror_ = maxMirror;
+}
 void FitParameter::setStepSize(double stepSize) {
   _stepSize_ = stepSize;
 }
@@ -176,6 +194,12 @@ double FitParameter::getMinValue() const {
 }
 double FitParameter::getMaxValue() const {
   return _maxValue_;
+}
+double FitParameter::getMinMirror() const {
+  return _minMirror_;
+}
+double FitParameter::getMaxMirror() const {
+  return _maxMirror_;
 }
 double FitParameter::getStepSize() const {
   return _stepSize_;

--- a/src/Fitter/include/LikelihoodInterface.h
+++ b/src/Fitter/include/LikelihoodInterface.h
@@ -27,7 +27,7 @@ class FitterEngine;
 /// more closely related to the chi-square (so -LLH/2).
 
 class LikelihoodInterface {
-  
+
 public:
   /////////////////////////////////////////////////////////////////
   // Getters and Setters are defined in this file so the compiler can inline
@@ -64,6 +64,17 @@ public:
 
   /// A pointer to a ROOT runctor that calls the evalFitValid method.
   ROOT::Math::Functor* evalFitValidFunctor() {return _validFunctor_.get();}
+
+  /// Define the type of validity that needs to be required by
+  /// hasValidParameterValues.  This accepts a string with the possible values
+  /// being:
+  ///
+  ///  "range" (default) -- Between the parameter minimum and maximum values.
+  ///  "mirror"          -- Between the mirrored values (if parameter has
+  ///                       mirroring).
+  ///
+  /// Example: setParameterValidity("range,mirror")
+  void setParameterValidity(const std::string& validity);
 
   /// Check that the parameters for the last time the propagator was used are
   /// all within the allowed ranges.
@@ -143,6 +154,12 @@ private:
   /// evalFitValid.
   std::unique_ptr<ROOT::Math::Functor> _validFunctor_;
 
+  /// A set of flags used by the evalFitValid method to determine the function
+  /// validity.  The flaggs are:
+  /// "1" -- require valid parameters
+  /// "2" -- require in the mirrored range
+  int _validFlags_{3};
+
   /// A vector of pointers to fit parameters that defined the elements in the
   /// array of parameters passed to evalFit.
   std::vector<FitParameter*> _minimizerFitParameterPtr_{};
@@ -177,7 +194,6 @@ private:
 
   /// A tree that save the history of the minimization.
   std::unique_ptr<TTree> _chi2HistoryTree_{nullptr};
-
 
   // Output monitors!
   GenericToolbox::VariablesMonitor _convergenceMonitor_;

--- a/src/Fitter/include/MCMCInterface.h
+++ b/src/Fitter/include/MCMCInterface.h
@@ -60,6 +60,13 @@ private:
   std::string _proposalName_{"adaptive"};
   std::string _outTreeName_{"MCMC"};
 
+  // Define what sort of validity the parameters have to have for a finite
+  // likelihood.  The "range" value means that the parameter needs to be
+  // between the allowed minimum and maximum values for the parameter.  The
+  // "mirror" value means that the parameter needs to be between the mirror
+  // bounds too.
+  std::string _likelihoodValidity_{"range,mirror"};
+
   // The number of burn-in cylces to use.
   int _burninCycles_{0};
 

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -290,8 +290,8 @@ double LikelihoodInterface::evalFit(const double* parArray_){
     }
     else{
       LogInfo << _convergenceMonitor_.generateMonitorString(
-          GenericToolbox::getTerminalWidth() != 0, // trail back if not in batch mode
-          true // force generate
+        GenericToolbox::getTerminalWidth() != 0, // trail back if not in batch mode
+        true // force generate
       );
     }
 
@@ -316,12 +316,37 @@ double LikelihoodInterface::evalFitValid(const double* parArray_) {
   return RBN;
 }
 
+void LikelihoodInterface::setParameterValidity(const std::string& validity) {
+  if (validity.find("ran") != std::string::npos) _validFlags_ |= 1;
+  if (validity.find("noran") != std::string::npos) _validFlags_ &= ~1;
+  if (validity.find("mir") != std::string::npos) _validFlags_ |= 2;
+  if (validity.find("nomir") != std::string::npos) _validFlags_ &= ~2;
+}
+
 bool LikelihoodInterface::hasValidParameterValues() const {
   for (const FitParameterSet& parSet:
          _owner_->getPropagator().getParameterSetsList()) {
     for (const FitParameter& par : parSet.getParameterList()) {
-      if (std::isfinite(par.getMinValue()) && par.getParameterValue() < par.getMinValue()) [[unlikely]] return false;
-      if (std::isfinite(par.getMaxValue()) && par.getParameterValue() > par.getMaxValue()) [[unlikely]] return false;
+      if ( (_validFlags_&1) != 0
+          and std::isfinite(par.getMinValue())
+          and par.getParameterValue() < par.getMinValue()) [[unlikely]] {
+        return false;
+      }
+      if ((_validFlags_&1) != 0
+          and std::isfinite(par.getMaxValue())
+          and par.getParameterValue() > par.getMaxValue()) [[unlikely]] {
+        return false;
+      }
+      if ((_validFlags_&2) != 0
+          and std::isfinite(par.getMinMirror())
+          and par.getParameterValue() < par.getMinMirror()) [[unlikely]] {
+        return false;
+      }
+      if ((_validFlags_&2) != 0
+          and std::isfinite(par.getMaxMirror())
+          and par.getParameterValue() > par.getMaxMirror()) [[unlikely]] {
+        return false;
+      }
     }
   }
   return true;

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -37,6 +37,13 @@ void MCMCInterface::readConfigImpl(){
   // to be changed.  Generally, leave it alone.
   _outTreeName_ = GenericToolbox::Json::fetchValue(_config_, "mcmcOutputTree", "MCMC");
 
+  // Define what sort of validity the parameters have to have for a finite
+  // likelihood.  The "range" value means that the parameter needs to be
+  // between the allowed minimum and maximum values for the parameter.  The
+  // "mirror" value means that the parameter needs to be between the mirror
+  // bounds too.
+  _likelihoodValidity_ = GenericToolbox::Json::fetchValue(_config_, "likelihoodValidity", _likelihoodValidity_);
+
   // Get the MCMC chain parameters to be used during burn-in.  The burn-in will
   // be skipped if the state has been restored from a file.  The burn-in can be
   // skipped in favor of discarding the initial parts of the MCMC chain


### PR DESCRIPTION
This lets the MCMC have direct access to the parameter mirroring so we can study the effect of mirroring on the posterior probability ("likelihood").  The behavior is controlled by fitterEngineConfig.mcmcConfig.likelihoodValidity.  