### PR TITLE
Feature/add physical bounds

### DIFF
--- a/src/FitParameters/include/FitParameter.h
+++ b/src/FitParameters/include/FitParameter.h
@@ -56,6 +56,11 @@ public:
   void setMinMirror(double minMirror);
   void setMaxMirror(double maxMirror);
 
+  // Record the physical bounds for the parameter.  This is the range where
+  // the parameter has a physically meaningful value.
+  void setMinPhysical(double minPhysical);
+  void setMaxPhysical(double maxPhysical);
+
   void setValueAtPrior();
   void setCurrentValueAsPrior();
 
@@ -71,6 +76,8 @@ public:
   [[nodiscard]] double getMaxValue() const;
   [[nodiscard]] double getMinMirror() const;
   [[nodiscard]] double getMaxMirror() const;
+  [[nodiscard]] double getMinPhysical() const;
+  [[nodiscard]] double getMaxPhysical() const;
   [[nodiscard]] double getStepSize() const;
   [[nodiscard]] double getPriorValue() const;
   [[nodiscard]] double getThrowValue() const;
@@ -117,6 +124,8 @@ private:
   double _maxValue_{std::nan("unset")};
   double _minMirror_{std::nan("unset")};
   double _maxMirror_{std::nan("unset")};
+  double _minPhysical_{std::nan("unset")};
+  double _maxPhysical_{std::nan("unset")};
   double _stepSize_{std::nan("unset")};
   std::string _name_{};
   std::string _dialsWorkingDirectory_{"."};

--- a/src/FitParameters/src/FitParameter.cpp
+++ b/src/FitParameters/src/FitParameter.cpp
@@ -51,7 +51,7 @@ void FitParameter::readConfigImpl(){
       this->setStepSize( stepSize );
     }
 
-    if( GenericToolbox::Json::doKeyExist(_config_, "physicalLimits") ){
+    if( GenericToolbox::Json::doKeyExist(_parameterConfig_, "physicalLimits") ){
         auto physLimits = GenericToolbox::Json::fetchValue(_parameterConfig_, "physicalLimits", nlohmann::json());
         _minPhysical_ = GenericToolbox::Json::fetchValue(physLimits, "minValue", std::nan("UNSET"));
         _maxPhysical_ = GenericToolbox::Json::fetchValue(physLimits, "maxValue", std::nan("UNSET"));

--- a/src/FitParameters/src/FitParameter.cpp
+++ b/src/FitParameters/src/FitParameter.cpp
@@ -51,6 +51,12 @@ void FitParameter::readConfigImpl(){
       this->setStepSize( stepSize );
     }
 
+    if( GenericToolbox::Json::doKeyExist(_config_, "physicalLimits") ){
+        auto physLimits = GenericToolbox::Json::fetchValue(_parameterConfig_, "physicalLimits", nlohmann::json());
+        _minPhysical_ = GenericToolbox::Json::fetchValue(physLimits, "minValue", std::nan("UNSET"));
+        _maxPhysical_ = GenericToolbox::Json::fetchValue(physLimits, "maxValue", std::nan("UNSET"));
+    }
+
     _dialDefinitionsList_ = GenericToolbox::Json::fetchValue(_parameterConfig_, "dialSetDefinitions", _dialDefinitionsList_);
   }
 
@@ -157,6 +163,12 @@ void FitParameter::setMaxMirror(double maxMirror) {
   }
   _maxMirror_ = maxMirror;
 }
+void FitParameter::setMinPhysical(double minPhysical) {
+  _minPhysical_ = minPhysical;
+}
+void FitParameter::setMaxPhysical(double maxPhysical) {
+  _maxPhysical_ = maxPhysical;
+}
 void FitParameter::setStepSize(double stepSize) {
   _stepSize_ = stepSize;
 }
@@ -200,6 +212,12 @@ double FitParameter::getMinMirror() const {
 }
 double FitParameter::getMaxMirror() const {
   return _maxMirror_;
+}
+double FitParameter::getMinPhysical() const {
+  return _minPhysical_;
+}
+double FitParameter::getMaxPhysical() const {
+  return _maxPhysical_;
 }
 double FitParameter::getStepSize() const {
   return _stepSize_;

--- a/src/Fitter/include/LikelihoodInterface.h
+++ b/src/Fitter/include/LikelihoodInterface.h
@@ -72,8 +72,9 @@ public:
   ///  "range" (default) -- Between the parameter minimum and maximum values.
   ///  "mirror"          -- Between the mirrored values (if parameter has
   ///                       mirroring).
+  ///  "physical"        -- Only physically meaningful values.
   ///
-  /// Example: setParameterValidity("range,mirror")
+  /// Example: setParameterValidity("range,mirror,physical")
   void setParameterValidity(const std::string& validity);
 
   /// Check that the parameters for the last time the propagator was used are
@@ -158,7 +159,8 @@ private:
   /// validity.  The flaggs are:
   /// "1" -- require valid parameters
   /// "2" -- require in the mirrored range
-  int _validFlags_{3};
+  /// "4" -- require in the physical range
+  int _validFlags_{7};
 
   /// A vector of pointers to fit parameters that defined the elements in the
   /// array of parameters passed to evalFit.

--- a/src/Fitter/include/MCMCInterface.h
+++ b/src/Fitter/include/MCMCInterface.h
@@ -65,7 +65,7 @@ private:
   // between the allowed minimum and maximum values for the parameter.  The
   // "mirror" value means that the parameter needs to be between the mirror
   // bounds too.
-  std::string _likelihoodValidity_{"range,mirror"};
+  std::string _likelihoodValidity_{"range,mirror,physical"};
 
   // Save or dump the raw (fitter space) points.  This can save about half the
   // output file space.

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -41,7 +41,8 @@ void MCMCInterface::readConfigImpl(){
   // likelihood.  The "range" value means that the parameter needs to be
   // between the allowed minimum and maximum values for the parameter.  The
   // "mirror" value means that the parameter needs to be between the mirror
-  // bounds too.
+  // bounds too.  The "physical" value means that the parameter has to be in
+  // the physically allowed range.
   _likelihoodValidity_ = GenericToolbox::Json::fetchValue(_config_, "likelihoodValidity", _likelihoodValidity_);
 
   // Set whether the raw step should be saved, or only the step translated
@@ -201,6 +202,9 @@ void MCMCInterface::initializeImpl(){
   // likelihood code runs.
   getLikelihood().setMinimizerInfo(_algorithmName_,_proposalName_);
 
+  // Set how the parameter values are handled (outside of different validity
+  // ranges)
+  getLikelihood().setParameterValidity(_likelihoodValidity_);
 }
 
 /// An MCMC doesn't really converge in the sense meant here. This flags

--- a/src/Utils/include/TSimpleMCMC.H
+++ b/src/Utils/include/TSimpleMCMC.H
@@ -951,6 +951,10 @@ public:
         }
 
         double currentTrace = GetCovarianceTrace();
+        if (currentTrace <= 0) {
+            fCurrentCov.Print();
+            throw std::runtime_error("Invalid trace");
+        }
 
         MCMC_DEBUG(1) << " Covariance Trace: " << currentTrace
                       << std::endl;
@@ -1720,10 +1724,13 @@ private:
         for (std::size_t i=0; i<current.size(); ++i) {
             for (std::size_t j=0; j<i+1; ++j) {
                 double v = fCurrentCov(i,j);
-                // Correct for the center having moved!
+#ifdef APPLY_CENTRAL_MOVEMENT_CORRECTION
+                // Correct for the center having moved!  Only apply this
+                // when requested by the user.
                 v += fCentralPointChange[i]*fCentralPoint[j];
                 v += fCentralPointChange[j]*fCentralPoint[i];
                 v -= fCentralPointChange[i]*fCentralPointChange[j];
+#endif
                 // Calculate the "covariance" of the new point.
                 double r = (current[i]-fCentralPoint[i])
                     *(current[j]-fCentralPoint[j]);


### PR DESCRIPTION
This separates the parameter ranges into three categories

1. The parameter domain (where the function is defined)
2. The position of parameter mirroring (define the part of the domain that should be used)
3. The domain over which the parameter has physical meaning

This is used in the MCMCInterface which can easily deal with parameter discontinuities, but defining the physically valid domain is also important for documentation purposes.