### PR TITLE
Fix/cache manager mc stats

### DIFF
--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -27,6 +27,9 @@ private:
     // The accumulated weights for each histogram bin.
     std::unique_ptr<hemi::Array<double>> fSums;
 
+    // The accumulated weights for each histogram bin.
+    std::unique_ptr<hemi::Array<double>> fSums2;
+
     // Cache of whether the result values in memory are valid.
     bool fSumsValid;
 
@@ -62,8 +65,15 @@ public:
     /// from the device if that is necessary.
     double GetSum(int i);
 
+    /// Get the sum squared for index i from host memory.  This might trigger
+    /// a copy from the device if that is necessary.
+    double GetSum2(int i);
+
     /// The pointer to the array of sums on the host.
     const double* GetSumsPointer();
+
+    /// The pointer to the array of sums squared on the host.
+    const double* GetSums2Pointer();
 
     /// A pointer to the validity flag.
     bool* GetSumsValidPointer();

--- a/src/CacheManager/src/CacheIndexedSums.cpp
+++ b/src/CacheManager/src/CacheIndexedSums.cpp
@@ -39,6 +39,7 @@ Cache::IndexedSums::IndexedSums(Cache::Weights::Results& inputs,
         // set.  The initial values are seldom changed, so they are not
         // pinned.
         fSums = std::make_unique<hemi::Array<double>>(bins,true);
+        fSums2 = std::make_unique<hemi::Array<double>>(bins,true);
         fIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
 
     }
@@ -54,6 +55,9 @@ Cache::IndexedSums::IndexedSums(Cache::Weights::Results& inputs,
     // caches can be huge.
     std::fill(fSums->hostPtr(),
               fSums->hostPtr() + fSums->size(),
+              0.0);
+    std::fill(fSums2->hostPtr(),
+              fSums2->hostPtr() + fSums2->size(),
               0.0);
 }
 
@@ -86,8 +90,23 @@ double Cache::IndexedSums::GetSum(int i) {
     return value;
 }
 
+double Cache::IndexedSums::GetSum2(int i) {
+    if (i < 0) throw;
+    if (fSums2->size() <= i) throw;
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the sum is set to be valid.  The use of isfinite is to
+    // make sure that the optimizer doesn't reorder the statements.
+    double value = fSums2->hostPtr()[i];
+    if (std::isfinite(value)) fSumsValid = true;
+    return value;
+}
+
 const double* Cache::IndexedSums::GetSumsPointer() {
     return fSums->hostPtr();
+}
+
+const double* Cache::IndexedSums::GetSums2Pointer() {
+    return fSums2->hostPtr();
 }
 
 bool* Cache::IndexedSums::GetSumsValidPointer() {
@@ -114,14 +133,18 @@ namespace {
     // A function to do the sums
     HEMI_KERNEL_FUNCTION(HEMIIndexedSumKernel,
                          double* sums,
+                         double* sums2,
                          const double* inputs,
                          const short* indexes,
                          const int NP) {
         for (int i : hemi::grid_stride_range(0,NP)) {
+            const double v = inputs[i];
 #ifdef HEMI_DEV_CODE
-            CacheAtomicAdd(&sums[indexes[i]],inputs[i]);
+            CacheAtomicAdd(&sums[indexes[i]],v);
+            CacheAtomicAdd(&sums2[indexes[i]],v*v);
 #else
-            sums[indexes[i]] += inputs[i];
+            sums[indexes[i]] += v;
+            sums2[indexes[i]] += v*v;
 #endif
         }
     }
@@ -138,9 +161,15 @@ bool Cache::IndexedSums::Apply() {
                  0.0,
                  fSums->size());
 
+    hemi::launch(resetKernel,
+                 fSums2->writeOnlyPtr(),
+                 0.0,
+                 fSums2->size());
+
     HEMIIndexedSumKernel indexedSumKernel;
     hemi::launch(indexedSumKernel,
                  fSums->writeOnlyPtr(),
+                 fSums2->writeOnlyPtr(),
                  fEventWeights.readOnlyPtr(),
                  fIndexes->readOnlyPtr(),
                  fEventWeights.size());

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -561,11 +561,17 @@ bool Cache::Manager::Update(FitSampleSet& sampleList,
         sample.getMcContainer().setCacheManagerValuePointer(
             Cache::Manager::Get()->GetHistogramsCache()
             .GetSumsPointer());
+        sample.getMcContainer().setCacheManagerValue2Pointer(
+            Cache::Manager::Get()->GetHistogramsCache()
+            .GetSums2Pointer());
         sample.getMcContainer().setCacheManagerValidPointer(
             Cache::Manager::Get()->GetHistogramsCache()
             .GetSumsValidPointer());
         sample.getMcContainer().setCacheManagerUpdatePointer(
-            [](){Cache::Manager::Get()->GetHistogramsCache().GetSum(0);});
+            [](){
+                Cache::Manager::Get()->GetHistogramsCache().GetSum(0);
+                Cache::Manager::Get()->GetHistogramsCache().GetSum2(0);
+            });
         int cells = hist->GetNcells();
         nextHist += cells;
         /// ARE ALL OF THE EVENTS HANDLED?

--- a/src/FitSamples/include/SampleElement.h
+++ b/src/FitSamples/include/SampleElement.h
@@ -68,6 +68,7 @@ public:
   void setCacheManagerIndex(int i) {_CacheManagerIndex_ = i;}
   int  getCacheManagerIndex() {return _CacheManagerIndex_;}
   void setCacheManagerValuePointer(const double* v) {_CacheManagerValue_ = v;}
+  void setCacheManagerValue2Pointer(const double* v) {_CacheManagerValue2_ = v;}
   void setCacheManagerValidPointer(const bool* v) {_CacheManagerValid_ = v;}
   void setCacheManagerUpdatePointer(void (*p)()) {_CacheManagerUpdate_ = p;}
 private:
@@ -75,6 +76,8 @@ private:
   int _CacheManagerIndex_{-1};
   // A pointer to the cached result.
   const double* _CacheManagerValue_{nullptr};
+  // A pointer to the cached result.
+  const double* _CacheManagerValue2_{nullptr};
   // A pointer to the cache validity flag.
   const bool* _CacheManagerValid_{nullptr};
   // A pointer to a callback to force the cache to be updated.

--- a/src/FitSamples/src/SampleElement.cpp
+++ b/src/FitSamples/src/SampleElement.cpp
@@ -118,8 +118,10 @@ void SampleElement::refillHistogram(int iThread_){
     binErrorArray[iBin + 1] = 0;
 #ifdef GUNDAM_USING_CACHE_MANAGER
     if (_CacheManagerValue_ !=nullptr and _CacheManagerIndex_ >= 0) {
-      binContentArray[iBin + 1] += _CacheManagerValue_[_CacheManagerIndex_+iBin];
-      binErrorArray[iBin + 1] += binContentArray[iBin + 1]*binContentArray[iBin + 1];
+      const double ew = _CacheManagerValue_[_CacheManagerIndex_+iBin];
+      const double ew2 = _CacheManagerValue2_[_CacheManagerIndex_+iBin];
+      binContentArray[iBin + 1] += ew;
+      binErrorArray[iBin + 1] += ew2;
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
       double content = binContentArray[iBin+1];
       double slowValue = 0.0;

--- a/src/Fitter/include/LikelihoodInterface.h
+++ b/src/Fitter/include/LikelihoodInterface.h
@@ -65,14 +65,31 @@ public:
   /// A pointer to a ROOT runctor that calls the evalFitValid method.
   ROOT::Math::Functor* evalFitValidFunctor() {return _validFunctor_.get();}
 
+  /// Return the last likelihood value that was calculated.  This is a
+  /// short cut to call the owner's getPropagator().getLlhBuffer() method.
+  [[nodiscard]] double getLastLikelihood() const;
+
+  /// Return the statistical part of the last likelihood value that was
+  /// calculated.  This is a short cut to call the owner's
+  /// getPropagator().GetLlhStatBuffer() method
+  [[nodiscard]] double getLastLikelihoodStat() const;
+
+  /// Return the penalty part of the last likelihood value that was
+  /// calculated.  This is a short cut to call the owner's
+  /// getPropagator().GetLlhPenaltyBuffer() method.
+  [[nodiscard]] double getLastLikelihoodPenalty() const;
+
   /// Define the type of validity that needs to be required by
   /// hasValidParameterValues.  This accepts a string with the possible values
   /// being:
   ///
   ///  "range" (default) -- Between the parameter minimum and maximum values.
+  ///  "norange"         -- Do not require parameters in the valid range
   ///  "mirror"          -- Between the mirrored values (if parameter has
   ///                       mirroring).
+  ///  "nomirror"        -- Do not require parameters in the mirrored range
   ///  "physical"        -- Only physically meaningful values.
+  ///  "nophysical"      -- Do not require parameters in the physical range.
   ///
   /// Example: setParameterValidity("range,mirror,physical")
   void setParameterValidity(const std::string& validity);

--- a/src/Fitter/include/MCMCInterface.h
+++ b/src/Fitter/include/MCMCInterface.h
@@ -155,9 +155,35 @@ private:
   // point
   std::vector<float> _point_;
 
+  // The predicted values from the reweighted MC (histogram) for the last
+  // accepted step.  This will often be empty to reduce the size of the output
+  // file.
+  std::vector<float> _model_;
+
+  // The uncertainty for the predicted values from the MC (histogram) for the
+  // last accepted step.  This will often be empty to reduce the size of the
+  // output file.
+  std::vector<float> _uncertainty_;
+
+  // The model for the likelihood takes up quite a bit of space, so it should
+  // NOT be saved most of the time.  The _modelStride_ sets the number of
+  // steps between when the model is saved to the output file.  The model is a
+  // copy of the predicted sample histogram and can be used to calculate the
+  // posterior predictive p-value.  The stride should be zero (or negative)
+  // which won't save anything, or large(ish) compared to the autocorrelation
+  // lag.
+  int _modelStride_{-1};
+
+  // The statistical part of the likelihood
+  float _llhStatistical_{0.0};
+
+  // The penalty part of the likelihood
+  float _llhPenalty_{0.0};
+
   // Fill the point that will be saved to the output tree with the current set
-  // of parameters.
-  void fillPoint();
+  // of parameters.  If fillModel is true, this will also fill the model of
+  // the expected data for this set of parametrs.
+  void fillPoint(bool fillModel = false);
 
   /// A local proxy so the likelihood uses a ROOT::Math::Functor provided by
   /// the Likelihood interface.  The functor field MUST by accessing the

--- a/src/Fitter/include/MCMCInterface.h
+++ b/src/Fitter/include/MCMCInterface.h
@@ -75,10 +75,10 @@ private:
   int _burninCycles_{0};
 
   // The number of cycles to dump during burn-in
-  int _burninResets_{1};
+  int _burninResets_{0};
 
   // The length of each burn-in cycle
-  int _burninLength_{0};
+  int _burninLength_{10000};
 
   // Save the burnin (true) or dump it (false)
   bool _saveBurnin_{true};
@@ -88,6 +88,14 @@ private:
 
   // The number of steps in each run cycle.
   int _steps_{10000};
+
+  // The model for the likelihood takes up quite a bit of space, so it should
+  // NOT be saved most of the time.  The _modelStride_ sets the number of
+  // steps between when the model is saved to the output file.  The model is a
+  // copy of the predicted sample histogram and can be used to calculate the
+  // posterior predictive p-value.  The stride should be large(ish) compared
+  // to the autocorrelation lag, or zero (if not saving the model).
+  int _modelStride_{5000};
 
   //////////////////////////////////////////
   // Parameters for the adaptive stepper.
@@ -113,25 +121,25 @@ private:
   // covariance.  That works out to the approximate number of function
   // calculations that were used to estimate the covariance.  The default
   // value of zero triggers the interface to make it's own estimate.
-  double _adaptiveCovTrials_{0.0};
+  double _adaptiveCovTrials_{500000.0};
 
   // Freeze the burn-in step after this many cycles.
   int _burninFreezeAfter_{1000000000}; // Never freeze except by request
 
   // The window to calculate the covariance during burn-in
-  int _burninCovWindow_{100000};
+  int _burninCovWindow_{1000000};
 
   // The amount of deweighting during burning updates.
-  double _burninCovDeweighting_{0.5};
+  double _burninCovDeweighting_{0.0};
 
   // The acceptance window during burn-in.
-  int _burninWindow_{3000};
+  int _burninWindow_{1000};
 
   // Freeze the step after this many cycles.
   int _adaptiveFreezeAfter_{1000000000}; // Never freeze except by request
 
   // The window to calculate the covariance during normal chains.
-  int _adaptiveCovWindow_{1000000000};
+  int _adaptiveCovWindow_{1000000};
 
   // The covariance deweighting while the chain is running.  This should
   // usually be left at zero so the entire chain history is used after an
@@ -140,7 +148,7 @@ private:
   double _adaptiveCovDeweighting_{0.0};
 
   // The window used to calculate the current acceptance value.
-  int _adaptiveWindow_{5000};
+  int _adaptiveWindow_{1000};
 
   //////////////////////////////////////////
   // Parameters for the simple stepper
@@ -156,23 +164,22 @@ private:
   std::vector<float> _point_;
 
   // The predicted values from the reweighted MC (histogram) for the last
-  // accepted step.  This will often be empty to reduce the size of the output
-  // file.
+  // accepted step.
   std::vector<float> _model_;
 
-  // The uncertainty for the predicted values from the MC (histogram) for the
-  // last accepted step.  This will often be empty to reduce the size of the
+  // The predicted values from the reweighted MC (histogram) to be saved to
+  // the output file. This will often be empty to reduce the size of the
   // output file.
+  std::vector<float> _saveModel_;
+
+  // The uncertainty for the predicted values from the reweighted MC
+  // (histogram) for the last accepted step.
   std::vector<float> _uncertainty_;
 
-  // The model for the likelihood takes up quite a bit of space, so it should
-  // NOT be saved most of the time.  The _modelStride_ sets the number of
-  // steps between when the model is saved to the output file.  The model is a
-  // copy of the predicted sample histogram and can be used to calculate the
-  // posterior predictive p-value.  The stride should be zero (or negative)
-  // which won't save anything, or large(ish) compared to the autocorrelation
-  // lag.
-  int _modelStride_{-1};
+  // The uncertainty for the predicted values from the MC (histogram) to be
+  // saved to the output file. This will often be empty to reduce the size of
+  // the output file.
+  std::vector<float> _saveUncertainty_;
 
   // The statistical part of the likelihood
   float _llhStatistical_{0.0};
@@ -183,7 +190,7 @@ private:
   // Fill the point that will be saved to the output tree with the current set
   // of parameters.  If fillModel is true, this will also fill the model of
   // the expected data for this set of parametrs.
-  void fillPoint(bool fillModel = false);
+  void fillPoint(bool fillModel = true);
 
   /// A local proxy so the likelihood uses a ROOT::Math::Functor provided by
   /// the Likelihood interface.  The functor field MUST by accessing the

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -332,6 +332,18 @@ double LikelihoodInterface::evalFitValid(const double* parArray_) {
   return RBN;
 }
 
+double LikelihoodInterface::getLastLikelihood() const {
+  return _owner_->getPropagator().getLlhBuffer();
+}
+
+double LikelihoodInterface::getLastLikelihoodStat() const {
+  return _owner_->getPropagator().getLlhStatBuffer();
+}
+
+double LikelihoodInterface::getLastLikelihoodPenalty() const {
+  return _owner_->getPropagator().getLlhPenaltyBuffer();
+}
+
 void LikelihoodInterface::setParameterValidity(const std::string& validity) {
   LogWarning << "Set parameter validity to " << validity << std::endl;
   if (validity.find("noran") != std::string::npos) _validFlags_ &= ~0b0001;


### PR DESCRIPTION
Bug fix closing #388.  This fixes a bad mistake in how the Cache::Manager was filling the MC prediction statistical uncertainty.  It also includes code that started as a way to save the information necessary to calculate the PPP, became code to debug the MC statistical uncertainty calculation, and then transitioned back to saving the (small) amount of information needed to calculate the PPP (this also closes #385).