### PR TITLE
[API rename] Getting rid of "fit" prefixes in Propagator objects

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -583,7 +583,7 @@ int main(int argc, char** argv){
 
   {
     LogWarning << "Calculating weight at best-fit" << std::endl;
-    for( auto& parSet : propagator.getParametersManager().getParameterSetsList() ){ parSet.moveFitParametersToPrior(); }
+    for( auto& parSet : propagator.getParametersManager().getParameterSetsList() ){ parSet.moveParametersToPrior(); }
     propagator.propagateParametersOnSamples();
     writeBinDataFct();
     xsecAtBestFitTree->Fill();

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -144,7 +144,7 @@ int main(int argc, char** argv){
   propagator.setEnableEigenToOrigInPropagate( false );
 
   // Sample binning using parameterSetName
-  for( auto& sample : propagator.getFitSampleSet().getFitSampleList() ){
+  for( auto& sample : propagator.getFitSampleSet().getSampleList() ){
 
     if( clParser.isOptionTriggered("usePreFit") ){
       sample.setName( sample.getName() + " (pre-fit)" );
@@ -443,8 +443,8 @@ int main(int argc, char** argv){
   std::vector<CrossSectionData> crossSectionDataList{};
 
   LogInfo << "Initializing xsec samples..." << std::endl;
-  crossSectionDataList.reserve( propagator.getFitSampleSet().getFitSampleList().size() );
-  for( auto& sample : propagator.getFitSampleSet().getFitSampleList() ){
+  crossSectionDataList.reserve(propagator.getFitSampleSet().getSampleList().size() );
+  for( auto& sample : propagator.getFitSampleSet().getSampleList() ){
     crossSectionDataList.emplace_back();
     auto& xsecEntry = crossSectionDataList.back();
 
@@ -637,7 +637,7 @@ int main(int argc, char** argv){
   auto* globalCorMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(GenericToolbox::convertToCorrelationMatrix(globalCovMatrix));
 
   std::vector<TH1D> binValues{};
-  binValues.reserve( propagator.getFitSampleSet().getFitSampleList().size() );
+  binValues.reserve(propagator.getFitSampleSet().getSampleList().size() );
   int iBinGlobal{-1};
 
   for( auto& xsec : crossSectionDataList ){

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -144,7 +144,7 @@ int main(int argc, char** argv){
   propagator.setEnableEigenToOrigInPropagate( false );
 
   // Sample binning using parameterSetName
-  for( auto& sample : propagator.getFitSampleSet().getSampleList() ){
+  for( auto& sample : propagator.getSampleSet().getSampleList() ){
 
     if( clParser.isOptionTriggered("usePreFit") ){
       sample.setName( sample.getName() + " (pre-fit)" );
@@ -443,8 +443,8 @@ int main(int argc, char** argv){
   std::vector<CrossSectionData> crossSectionDataList{};
 
   LogInfo << "Initializing xsec samples..." << std::endl;
-  crossSectionDataList.reserve(propagator.getFitSampleSet().getSampleList().size() );
-  for( auto& sample : propagator.getFitSampleSet().getSampleList() ){
+  crossSectionDataList.reserve(propagator.getSampleSet().getSampleList().size() );
+  for( auto& sample : propagator.getSampleSet().getSampleList() ){
     crossSectionDataList.emplace_back();
     auto& xsecEntry = crossSectionDataList.back();
 
@@ -637,7 +637,7 @@ int main(int argc, char** argv){
   auto* globalCorMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(GenericToolbox::convertToCorrelationMatrix(globalCovMatrix));
 
   std::vector<TH1D> binValues{};
-  binValues.reserve(propagator.getFitSampleSet().getSampleList().size() );
+  binValues.reserve(propagator.getSampleSet().getSampleList().size() );
   int iBinGlobal{-1};
 
   for( auto& xsec : crossSectionDataList ){

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -725,7 +725,7 @@ int main(int argc, char** argv){
 
     const CrossSectionData* xsecDataPtr{nullptr};
     for( auto& xsecData : crossSectionDataList ){
-      if( xsecData.samplePtr  == histHolder.fitSamplePtr){
+      if( xsecData.samplePtr  == histHolder.samplePtr){
         xsecDataPtr = &xsecData;
         break;
       }

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -49,7 +49,7 @@ public:
     static bool Update(SampleSet& sampleList, EventDialCache& eventDials);
 
     /// Flag that the Cache::Manager internal caches must be updated from the
-    /// FitSampleSet and EventDialCache before it can be used.
+    /// SampleSet and EventDialCache before it can be used.
     static void UpdateRequired();
 
     /// This returns the index of the parameter in the cache.  If the

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -211,7 +211,7 @@ bool Cache::Manager::Build(SampleSet& sampleList,
 
     // Count the total number of histogram cells.
     int histCells = 0;
-    for(const Sample& sample : sampleList.getFitSampleList() ){
+    for(const Sample& sample : sampleList.getSampleList() ){
         if (!sample.getMcContainer().histogram) continue;
         int cells = sample.getMcContainer().histogram->GetNcells();
         LogInfo  << "Add histogram for " << sample.getName()
@@ -536,7 +536,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
     // Add the histogram cells to the cache.  THIS CODE IS SUSPECT!!!!
     LogInfo << "Add this histogram cells to the cache." << std::endl;
     int nextHist = 0;
-    for(Sample& sample : sampleList.getFitSampleList() ) {
+    for(Sample& sample : sampleList.getSampleList() ) {
         LogInfo  << "Fill cache for " << sample.getName()
                 << " with " << sample.getMcContainer().eventList.size()
                 << " events" << std::endl;

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -164,7 +164,7 @@ bool Cache::Manager::Build(SampleSet& sampleList,
             DialInterface* dialInterface = dialElem.interface;
             // This is depending behavior that is not guarranteed, but which
             // is probably valid because of the particular usage.
-            // Specifically, it depends on the vector of FitParameter objects
+            // Specifically, it depends on the vector of Parameter objects
             // not being moved.  This happens after the vectors are "closed",
             // so it is probably safe, but this isn't good.  The particular
             // usage is forced do to an API change.

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -168,7 +168,7 @@ bool Cache::Manager::Build(SampleSet& sampleList,
             // not being moved.  This happens after the vectors are "closed",
             // so it is probably safe, but this isn't good.  The particular
             // usage is forced do to an API change.
-            const Parameter* fp = &(dialInterface->getInputBufferRef()->getFitParameter());
+            const Parameter* fp = &(dialInterface->getInputBufferRef()->getParameter());
             usedParameters.insert(fp);
             ++useCount[fp->getFullTitle()];
 
@@ -389,7 +389,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 // parameter.  This only works for 1D dials.
                 const Parameter* fp
                     = &(dialInterface->getInputBufferRef()
-                        ->getFitParameter(i));
+                        ->getParameter(i));
                 auto parMapIt = Cache::Manager::ParameterMap.find(fp);
                 if (parMapIt == Cache::Manager::ParameterMap.end()) {
                     Cache::Manager::ParameterMap[fp]
@@ -400,7 +400,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
             // Apply the mirroring for the parameters
             if (dialInputs->useParameterMirroring()) {
                 for (std::size_t i = 0; i < dialInputs->getBufferSize(); ++i) {
-                    const Parameter* fp = &(dialInputs->getFitParameter(i));
+                    const Parameter* fp = &(dialInputs->getParameter(i));
                     const std::pair<double,double>& bounds =
                         dialInputs->getMirrorBounds(i);
                     int parIndex = Cache::Manager::ParameterMap[fp];
@@ -413,7 +413,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
 
             // Apply the clamps to the parameter range
             for (std::size_t i = 0; i < dialInputs->getBufferSize(); ++i) {
-                const Parameter* fp = &(dialInputs->getFitParameter(i));
+                const Parameter* fp = &(dialInputs->getParameter(i));
                 const DialResponseSupervisor* resp
                     = dialInterface->getResponseSupervisorRef();
                 int parIndex = Cache::Manager::ParameterMap[fp];
@@ -434,7 +434,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
             const Norm* normDial = dynamic_cast<const Norm*>(baseDial);
             if (normDial) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fNormalizations
@@ -444,7 +444,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 = dynamic_cast<const CompactSpline*>(baseDial);
             if (compactSpline) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fCompactSplines
@@ -455,7 +455,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 = dynamic_cast<const MonotonicSpline*>(baseDial);
             if (monotonicSpline) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fMonotonicSplines
@@ -466,7 +466,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 = dynamic_cast<const UniformSpline*>(baseDial);
             if (uniformSpline) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fUniformSplines
@@ -477,7 +477,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 = dynamic_cast<const GeneralSpline*>(baseDial);
             if (generalSpline) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fGeneralSplines
@@ -488,7 +488,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
                 = dynamic_cast<const LightGraph*>(baseDial);
             if (lightGraph) {
                 ++dialUsed;
-                const Parameter* fp = &(dialInputs->getFitParameter(0));
+                const Parameter* fp = &(dialInputs->getParameter(0));
                 int parIndex = Cache::Manager::ParameterMap[fp];
                 Cache::Manager::Get()
                     ->fGraphs

--- a/src/DatasetManager/include/EventTreeWriter.h
+++ b/src/DatasetManager/include/EventTreeWriter.h
@@ -2,8 +2,8 @@
 // Created by Adrien BLANCHET on 19/11/2021.
 //
 
-#ifndef GUNDAM_EVENTTREEWRITER_H
-#define GUNDAM_EVENTTREEWRITER_H
+#ifndef GUNDAM_EVENT_TREE_WRITER_H
+#define GUNDAM_EVENT_TREE_WRITER_H
 
 #include "SampleSet.h"
 #include "ParameterSet.h"
@@ -22,7 +22,7 @@ class EventTreeWriter : public GenericToolbox::ConfigBaseClass<JsonType> {
 public:
   EventTreeWriter() = default;
 
-  void setFitSampleSetPtr(const SampleSet *fitSampleSetPtr){ _fitSampleSetPtr_ = fitSampleSetPtr; }
+  void setSampleSetPtr( const SampleSet *sampleSetPtr){ _sampleSetPtr_ = sampleSetPtr; }
   void setEventDialCachePtr(const EventDialCache *eventDialCachePtr_){ _eventDialCachePtr_ = eventDialCachePtr_; }
   void setParSetListPtr(const std::vector<ParameterSet> *parSetListPtr){ _parSetListPtr_ = parSetListPtr; }
 
@@ -49,7 +49,7 @@ private:
   int _nPointsPerDial_{3};
 
   // parameters
-  const SampleSet* _fitSampleSetPtr_{nullptr};
+  const SampleSet* _sampleSetPtr_{nullptr};
   const EventDialCache* _eventDialCachePtr_{nullptr};
   const std::vector<ParameterSet>* _parSetListPtr_{nullptr};
 
@@ -57,4 +57,4 @@ private:
 };
 
 
-#endif //GUNDAM_EVENTTREEWRITER_H
+#endif //GUNDAM_EVENT_TREE_WRITER_H

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -134,7 +134,7 @@ std::string DataDispenser::getTitle(){
 void DataDispenser::buildSampleToFillList(){
   LogWarning << "Fetching samples to fill..." << std::endl;
 
-  for( auto& sample : _sampleSetPtrToLoad_->getFitSampleList() ){
+  for( auto& sample : _sampleSetPtrToLoad_->getSampleList() ){
     if( not sample.isEnabled() ) continue;
     if( sample.isDatasetValid(_owner_->getName()) ){
       _cache_.samplesToFillList.emplace_back(&sample);
@@ -310,7 +310,7 @@ void DataDispenser::fetchRequestedLeaves(){
   // sample binning
   if( _sampleSetPtrToLoad_ != nullptr ){
     std::vector<std::string> indexRequests;
-    for (auto &sample: _sampleSetPtrToLoad_->getFitSampleList()) {
+    for (auto &sample: _sampleSetPtrToLoad_->getSampleList()) {
       for (auto &bin: sample.getBinning().getBinList()) {
         for (auto &edges: bin.getEdgesList()) {
           GenericToolbox::addIfNotInVector(edges.varName, indexRequests);

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -37,7 +37,7 @@ void EventTreeWriter::readConfigImpl() {
 void EventTreeWriter::writeSamples(TDirectory* saveDir_) const{
   LogInfo << "Writing sample data in TTrees..." << std::endl;
 
-  for( const auto& sample : _fitSampleSetPtr_->getFitSampleList() ){
+  for( const auto& sample : _fitSampleSetPtr_->getSampleList() ){
     LogScopeIndent;
     LogInfo << "Writing sample: " << sample.getName() << std::endl;
 

--- a/src/DatasetManager/src/EventTreeWriter.cpp
+++ b/src/DatasetManager/src/EventTreeWriter.cpp
@@ -37,7 +37,7 @@ void EventTreeWriter::readConfigImpl() {
 void EventTreeWriter::writeSamples(TDirectory* saveDir_) const{
   LogInfo << "Writing sample data in TTrees..." << std::endl;
 
-  for( const auto& sample : _fitSampleSetPtr_->getSampleList() ){
+  for( const auto& sample : _sampleSetPtr_->getSampleList() ){
     LogScopeIndent;
     LogInfo << "Writing sample: " << sample.getName() << std::endl;
 

--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -47,7 +47,7 @@ public:
   /// Get a pointer to the Parameter for a DialInputBuffer entry.
   [[nodiscard]] const Parameter& getParameter( int i=0) const;
 
-  /// Get a pointer to the FitParameterSet for the DialInputBuffer entry.
+  /// Get a pointer to the ParameterSet for the DialInputBuffer entry.
   [[nodiscard]] const ParameterSet& getParameterSet( int i=0) const;
 
   /// Get the reference to the hash for the current cache.
@@ -58,7 +58,7 @@ public:
   /// mirroring to the parameter values.
   void updateBuffer();
 
-  /// Push the index of a FitParameterSet and FitParameter in the set onto the
+  /// Push the index of a ParameterSet and Parameter in the set onto the
   /// vector of parameters.  This must be used in the order that the dial will
   /// be expecting the parameters (e.g. for a 2D parameter,
   void addParameterIndices(const std::pair<size_t, size_t>& indices_);
@@ -120,10 +120,10 @@ private:
 
   /// Should be a struct with real names and documentation: For now,
   /// the pair is holding:
-  ///    * first  -- The index of the FitParameterSet in the *_parSetRef_
-  ///            vector.  This is the index of the FitParameterSet (e.g.
+  ///    * first  -- The index of the ParameterSet in the *_parSetRef_
+  ///            vector.  This is the index of the ParameterSet (e.g.
   ///            "Cross Section", "Cross Section (binned), "Flux", etc)
-  ///    * second -- The index of the parameter particular FitParameterSet.
+  ///    * second -- The index of the parameter particular ParameterSet.
   /// There is one entry per parameter used by the dial (e.g. a 1D parameter
   /// has one entry)
   std::vector<std::pair<size_t, size_t>> _inputParameterIndicesList_{};

--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -45,10 +45,10 @@ public:
   [[nodiscard]] const double* getBuffer() const{ return _buffer_.data(); }
 
   /// Get a pointer to the FitParameter for a DialInputBuffer entry.
-  [[nodiscard]] const Parameter& getFitParameter(int i=0) const;
+  [[nodiscard]] const Parameter& getParameter( int i=0) const;
 
   /// Get a pointer to the FitParameterSet for the DialInputBuffer entry.
-  [[nodiscard]] const ParameterSet& getFitParameterSet(int i=0) const;
+  [[nodiscard]] const ParameterSet& getParameterSet( int i=0) const;
 
   /// Get the reference to the hash for the current cache.
   [[nodiscard]] const uint32_t& getCurrentHash() const{ return _currentHash_; }
@@ -83,6 +83,11 @@ public:
   /// Function that allow to tweak the buffer from the inside. Used for
   /// individual spline evaluation.
   std::vector<double>& getBufferVector() { return _buffer_; }
+
+
+  // Deprecated
+  [[deprecated("use getParameter()")]] [[nodiscard]] const Parameter& getFitParameter(int i=0) const { return getParameter(i); }
+  [[deprecated("use getParameterSet()")]] [[nodiscard]] const ParameterSet& getFitParameterSet(int i=0) const { return getParameterSet(i); }
 
 protected:
   uint32_t generateHash();

--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -2,8 +2,8 @@
 // Created by Adrien Blanchet on 29/11/2022.
 //
 
-#ifndef GUNDAM_DIALINPUTBUFFER_H
-#define GUNDAM_DIALINPUTBUFFER_H
+#ifndef GUNDAM_DIAL_INPUT_BUFFER_H
+#define GUNDAM_DIAL_INPUT_BUFFER_H
 
 #include "ParameterSet.h"
 
@@ -44,7 +44,7 @@ public:
   /// of parameter values that should be passed to the dial.
   [[nodiscard]] const double* getBuffer() const{ return _buffer_.data(); }
 
-  /// Get a pointer to the FitParameter for a DialInputBuffer entry.
+  /// Get a pointer to the Parameter for a DialInputBuffer entry.
   [[nodiscard]] const Parameter& getParameter( int i=0) const;
 
   /// Get a pointer to the FitParameterSet for the DialInputBuffer entry.
@@ -138,4 +138,4 @@ private:
 };
 
 
-#endif //GUNDAM_DIALINPUTBUFFER_H
+#endif //GUNDAM_DIAL_INPUT_BUFFER_H

--- a/src/DialDictionary/DialEngine/include/DialInterface.h
+++ b/src/DialDictionary/DialEngine/include/DialInterface.h
@@ -29,15 +29,15 @@ public:
   void setResponseSupervisorRef(const DialResponseSupervisor *responseSupervisorRef){ _responseSupervisorRef_ = responseSupervisorRef; }
   void setDialBinRef(const DataBin *dialBinRef){ _dialBinRef_ = dialBinRef; }
 
-  /// Return the input buffer containing the connection to the FitParameter(s)
-  /// used by this dial.  The number of FitParameters contained in the input
+  /// Return the input buffer containing the connection to the Parameter(s)
+  /// used by this dial.  The number of Parameters contained in the input
   /// buffer musts mach the number expected by the specialization of the
   /// DialBase.
   [[nodiscard]] inline DialInputBuffer *getInputBufferRef() const {return _inputBufferRef_;}
 
   /// Get the dial calculation method.  The dial will need one or more
-  /// FitParameter inputs, and the number *must* match the number and order of
-  /// the FitParameters in the DialInputBuffer.
+  /// Parameter inputs, and the number *must* match the number and order of
+  /// the Parameters in the DialInputBuffer.
   [[nodiscard]] inline DialBase* getDialBaseRef() const {return _dialBaseRef_;}
 
   /// Get the DialResponseSupervisor. This conditions the return value of the

--- a/src/DialDictionary/DialEngine/include/EventDialCache.h
+++ b/src/DialDictionary/DialEngine/include/EventDialCache.h
@@ -70,7 +70,7 @@ public:
   struct EventIndexEntry_t {
     /// The index of the fit sample being referenced by this indexed cache
     /// entry in the FitSampleSet vector of FitSample objects (returned by
-    /// getFitSampleList().
+    /// getSampleList().
     std::size_t sampleIndex {std::size_t(-1)};
     /// The index of the MC event being reference by this indexed cache entry
     /// in the SampleElement eveltList vector for the SampleElement returned

--- a/src/DialDictionary/DialEngine/include/EventDialCache.h
+++ b/src/DialDictionary/DialEngine/include/EventDialCache.h
@@ -64,21 +64,21 @@ public:
     std::size_t interfaceIndex {std::size_t(-1)};
   };
 
-  /// A pair of indices into the the vector of FitSamples in the FitSampleSet
+  /// A pair of indices into the the vector of Samples in the SampleSet
   /// vector of fit samples, and the index of the event eventList in the
   /// SampleElement returned by getMcContainer().
   struct EventIndexEntry_t {
     /// The index of the fit sample being referenced by this indexed cache
-    /// entry in the FitSampleSet vector of FitSample objects (returned by
+    /// entry in the SampleSet vector of Sample objects (returned by
     /// getSampleList().
     std::size_t sampleIndex {std::size_t(-1)};
     /// The index of the MC event being reference by this indexed cache entry
     /// in the SampleElement eveltList vector for the SampleElement returned
-    /// by FitSample::getMcContainer()
+    /// by Sample::getMcContainer()
     std::size_t eventIndex {std::size_t(-1)};
   };
 
-  /// A mapping between the event (in the FitSampleSet, and the dial (in the
+  /// A mapping between the event (in the SampleSet, and the dial (in the
   /// DialCollectionVector).  This will be used to build a fast lookup table
   /// between the PhysicsEvent* and the DialInterface* (i.e. a CacheElem_t
   /// returned by getCache().

--- a/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
@@ -15,10 +15,10 @@ LoggerInit([]{
 });
 
 
-const Parameter& DialInputBuffer::getFitParameter(int i) const {
+const Parameter& DialInputBuffer::getParameter( int i) const {
     return _parSetRef_->at(_inputParameterIndicesList_[i].first).getParameterList().at(_inputParameterIndicesList_[i].second);
 }
-const ParameterSet& DialInputBuffer::getFitParameterSet(int i) const {
+const ParameterSet& DialInputBuffer::getParameterSet( int i) const {
   return _parSetRef_->at(_inputParameterIndicesList_[i].first);
 }
 
@@ -80,7 +80,7 @@ void DialInputBuffer::addParameterIndices(const std::pair<size_t, size_t>& indic
 void DialInputBuffer::addMirrorBounds(const std::pair<double, double>& lowEdgeAndRange_){
   const int p = _parameterMirrorBounds_.size();
   // Overriding the const to allow the mirroring information to be stored
-  Parameter& par = const_cast<Parameter&>(getFitParameter(p));
+  Parameter& par = const_cast<Parameter&>(getParameter(p));
   par.setMinMirror(lowEdgeAndRange_.first);
   par.setMaxMirror(lowEdgeAndRange_.first + lowEdgeAndRange_.second);
   _parameterMirrorBounds_.emplace_back(lowEdgeAndRange_);

--- a/src/DialDictionary/DialEngine/src/EventDialCache.cpp
+++ b/src/DialDictionary/DialEngine/src/EventDialCache.cpp
@@ -18,7 +18,7 @@ void EventDialCache::buildReferenceCache(SampleSet& sampleSet_, std::vector<Dial
   LogInfo << "Sorting events in sync with indexed cache..." << std::endl;
 
   size_t nCacheSlots{0};
-  std::vector<std::vector<IndexedEntry_t>> sampleIndexCacheList{sampleSet_.getFitSampleList().size()};
+  std::vector<std::vector<IndexedEntry_t>> sampleIndexCacheList{sampleSet_.getSampleList().size()};
 
   {
     LogScopeIndent;
@@ -39,7 +39,7 @@ void EventDialCache::buildReferenceCache(SampleSet& sampleSet_, std::vector<Dial
 
     LogInfo << "Performing per sample sorting..." << std::endl;
     int iSample{-1};
-    for( auto& sample : sampleSet_.getFitSampleList() ){
+    for( auto& sample : sampleSet_.getSampleList() ){
       iSample++;
 
       auto p = GenericToolbox::getSortPermutation(
@@ -94,7 +94,7 @@ void EventDialCache::buildReferenceCache(SampleSet& sampleSet_, std::vector<Dial
       auto& cacheEntry{_cache_.back()};
 
       cacheEntry.event =
-          &sampleSet_.getFitSampleList().at(
+          &sampleSet_.getSampleList().at(
               indexCache.event.sampleIndex
           ).getMcContainer().eventList.at(
               indexCache.event.eventIndex

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -219,7 +219,7 @@ void FitterEngine::initializeImpl(){
 
   // writing event rates
   LogInfo << "Writing event rates..." << std::endl;
-  for( auto& sample : _propagator_.getFitSampleSet().getFitSampleList() ){
+  for( auto& sample : _propagator_.getFitSampleSet().getSampleList() ){
     if( not sample.isEnabled() ){ continue; }
 
 

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -219,7 +219,7 @@ void FitterEngine::initializeImpl(){
 
   // writing event rates
   LogInfo << "Writing event rates..." << std::endl;
-  for( auto& sample : _propagator_.getFitSampleSet().getSampleList() ){
+  for( auto& sample : _propagator_.getSampleSet().getSampleList() ){
     if( not sample.isEnabled() ){ continue; }
 
 

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -328,7 +328,7 @@ void FitterEngine::fit(){
       }
       else{
         LogAlert << "Throwing correlated parameters for " << parSet.getName() << std::endl;
-        parSet.throwFitParameters(true, _throwGain_);
+        parSet.throwParameters(true, _throwGain_);
       }
     } // parSet
 
@@ -563,12 +563,12 @@ void FitterEngine::checkNumericalAccuracy(){
     for( auto& parSet : _propagator_.getParametersManager().getParameterSetsList() ){
       if(not parSet.isEnabled()) continue;
       if( not parSet.isEnabledThrowToyParameters() ){ continue;}
-      parSet.throwFitParameters(true, gain);
+      parSet.throwParameters(true, gain);
       throwEntry.emplace_back(parSet.getParameterList().size(), 0);
       for( size_t iPar = 0 ; iPar < parSet.getParameterList().size() ; iPar++){
         throwEntry.back()[iPar] = parSet.getParameterList()[iPar].getParameterValue();
       }
-      parSet.moveFitParametersToPrior();
+      parSet.moveParametersToPrior();
     }
   }
 

--- a/src/Fitter/src/FitterEngine.cpp
+++ b/src/Fitter/src/FitterEngine.cpp
@@ -187,7 +187,7 @@ void FitterEngine::initializeImpl(){
       GenericToolbox::writeInTFile( outDir, TNamed( "max", std::to_string( par.getMaxValue() ).c_str() ) );
     }
 
-    if( parSet.isUseEigenDecompInFit() ){
+    if( parSet.isEnableEigenDecomp() ){
       auto eigenSaveFolder = GenericToolbox::joinPath( saveFolder, "eigen" );
       for( auto& eigen : parSet.getEigenParameterList() ){
         auto eigenFolder = GenericToolbox::joinPath(eigenSaveFolder, GenericToolbox::generateCleanBranchName(eigen.getTitle()));
@@ -319,7 +319,7 @@ void FitterEngine::fit(){
           LogWarning << "Pushing #" << parIndex << " to " << pushVal << std::endl;
           parList[parIndex].setParameterValue( pushVal );
 
-          if( parSet.isUseEigenDecompInFit() ){
+          if( parSet.isEnableEigenDecomp() ){
             parSet.propagateOriginalToEigen();
           }
 
@@ -478,7 +478,7 @@ void FitterEngine::fixGhostFitParameters(){
 #endif
           LogInfo << red << ssPrint.str() << rst << std::endl;
 
-          if( parSet.isUseEigenDecompInFit() and GenericToolbox::Json::fetchValue(_config_, "fixGhostEigenParametersAfterFirstRejected", false) ){
+          if( parSet.isEnableEigenDecomp() and GenericToolbox::Json::fetchValue(_config_, "fixGhostEigenParametersAfterFirstRejected", false) ){
             fixNextEigenPars = true;
           }
         }
@@ -490,7 +490,7 @@ void FitterEngine::fixGhostFitParameters(){
 
     // Recompute inverse matrix for the fitter.  Note: Eigen decomposed parSet
     // don't need a new inversion since the matrix is diagonal
-    if( not parSet.isUseEigenDecompInFit() ){
+    if( not parSet.isEnableEigenDecomp() ){
       parSet.processCovarianceMatrix();
     }
 

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -59,7 +59,7 @@ void LikelihoodInterface::initialize() {
   _validFunctor_ = std::make_unique<ROOT::Math::Functor>(this, &LikelihoodInterface::evalFitValid, _nbFitParameters_);
 
   _nbFitBins_ = 0;
-  for( auto& sample : _owner_->getPropagator().getFitSampleSet().getSampleList() ){
+  for( auto& sample : _owner_->getPropagator().getSampleSet().getSampleList() ){
     _nbFitBins_ += int(sample.getBinning().getBinList().size());
   }
 
@@ -314,7 +314,7 @@ double LikelihoodInterface::evalFit(const double* parArray_){
   if( std::isnan(_owner_->getPropagator().getLlhBuffer()) and _throwOnBadLlh_ ){
     LogError << _owner_->getPropagator().getLlhBuffer() << ": invalid reported likelihood value." << std::endl;
     LogError << GET_VAR_NAME_VALUE( _owner_->getPropagator().getLlhStatBuffer() ) << std::endl;
-    for( auto& sample : _owner_->getPropagator().getFitSampleSet().getSampleList() ){
+    for( auto& sample : _owner_->getPropagator().getSampleSet().getSampleList() ){
       LogScopeIndent;
       LogError << sample.getName() << ": " << sample.getLlhStatBuffer() << std::endl;
     }

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -59,7 +59,7 @@ void LikelihoodInterface::initialize() {
   _validFunctor_ = std::make_unique<ROOT::Math::Functor>(this, &LikelihoodInterface::evalFitValid, _nbFitParameters_);
 
   _nbFitBins_ = 0;
-  for( auto& sample : _owner_->getPropagator().getFitSampleSet().getFitSampleList() ){
+  for( auto& sample : _owner_->getPropagator().getFitSampleSet().getSampleList() ){
     _nbFitBins_ += int(sample.getBinning().getBinList().size());
   }
 
@@ -314,7 +314,7 @@ double LikelihoodInterface::evalFit(const double* parArray_){
   if( std::isnan(_owner_->getPropagator().getLlhBuffer()) and _throwOnBadLlh_ ){
     LogError << _owner_->getPropagator().getLlhBuffer() << ": invalid reported likelihood value." << std::endl;
     LogError << GET_VAR_NAME_VALUE( _owner_->getPropagator().getLlhStatBuffer() ) << std::endl;
-    for( auto& sample : _owner_->getPropagator().getFitSampleSet().getFitSampleList() ){
+    for( auto& sample : _owner_->getPropagator().getFitSampleSet().getSampleList() ){
       LogScopeIndent;
       LogError << sample.getName() << ": " << sample.getLlhStatBuffer() << std::endl;
     }

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -269,7 +269,7 @@ double LikelihoodInterface::evalFit(const double* parArray_){
           if( not curParSet.empty() ) ssHeader << std::endl;
           curParSet = fitPar->getOwner()->getName();
           ssHeader << curParSet
-                   << (fitPar->getOwner()->isUseEigenDecompInFit()? " (eigen)": "")
+                   << (fitPar->getOwner()->isEnableEigenDecomp() ? " (eigen)" : "")
                    << ":" << std::endl;
           nParPerLine = 0;
         }

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -242,7 +242,7 @@ void MCMCInterface::fillPoint(bool fillModel) {
   _saveUncertainty_.clear();
   if (not fillModel) return;
   for (const Sample& sample
-         : getPropagator().getFitSampleSet().getFitSampleList()) {
+         : getPropagator().getFitSampleSet().getSampleList()) {
     std::shared_ptr<TH1D> hist = sample.getMcContainer().histogram;
     for (int i = 1; i < hist->GetNbinsX(); ++i) {
       _model_.push_back(hist->GetBinContent(i));
@@ -858,7 +858,7 @@ void MCMCInterface::minimize() {
 
   parameterSampleData.clear();
   for (const Sample& sample
-         : getPropagator().getFitSampleSet().getFitSampleList()) {
+         : getPropagator().getFitSampleSet().getSampleList()) {
     parameterSampleNames.push_back(sample.getName());
     parameterSampleOffsets.push_back(parameterSampleData.size());
     std::shared_ptr<TH1D> hist = sample.getDataContainer().histogram;

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -342,7 +342,7 @@ bool MCMCInterface::adaptiveDefaultProposalCovariance(AdaptiveStepMCMC& mcmc,
               << std::endl;
       continue;
     }
-    if (set1->isUseEigenDecompInFit()) {
+    if ( set1->isEnableEigenDecomp()) {
       continue;
     }
 
@@ -356,7 +356,7 @@ bool MCMCInterface::adaptiveDefaultProposalCovariance(AdaptiveStepMCMC& mcmc,
                 << std::endl;
         continue;
       }
-      if (set2->isUseEigenDecompInFit()) {
+      if ( set2->isEnableEigenDecomp()) {
         continue;
       }
 

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -919,7 +919,7 @@ void MCMCInterface::scanParameters(TDirectory* saveDir_) {
   LogThrowIf(not isInitialized());
   LogInfo << "Performing scans of fit parameters..." << std::endl;
   for(Parameter* par : getMinimizerFitParameterPtr()) {
-    getPropagator().getParScanner().scanFitParameter(*par, saveDir_);
+    getPropagator().getParScanner().scanParameter(*par, saveDir_);
   }
 }
 

--- a/src/Fitter/src/MCMCInterface.cpp
+++ b/src/Fitter/src/MCMCInterface.cpp
@@ -242,7 +242,7 @@ void MCMCInterface::fillPoint(bool fillModel) {
   _saveUncertainty_.clear();
   if (not fillModel) return;
   for (const Sample& sample
-         : getPropagator().getFitSampleSet().getSampleList()) {
+         : getPropagator().getSampleSet().getSampleList()) {
     std::shared_ptr<TH1D> hist = sample.getMcContainer().histogram;
     for (int i = 1; i < hist->GetNbinsX(); ++i) {
       _model_.push_back(hist->GetBinContent(i));
@@ -858,7 +858,7 @@ void MCMCInterface::minimize() {
 
   parameterSampleData.clear();
   for (const Sample& sample
-         : getPropagator().getFitSampleSet().getSampleList()) {
+         : getPropagator().getSampleSet().getSampleList()) {
     parameterSampleNames.push_back(sample.getName());
     parameterSampleOffsets.push_back(parameterSampleData.size());
     std::shared_ptr<TH1D> hist = sample.getDataContainer().histogram;

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -406,7 +406,7 @@ void MinimizerInterface::scanParameters(TDirectory* saveDir_){
   } // iPar
   for( auto& parSet : this->getPropagator().getParametersManager().getParameterSetsList() ){
     if( not parSet.isEnabled() ) continue;
-    if( parSet.isUseEigenDecompInFit() ){
+    if( parSet.isEnableEigenDecomp() ){
       LogWarning << parSet.getName() << " is using eigen decomposition. Scanning original parameters..." << std::endl;
       for( auto& par : parSet.getParameterList() ){
         if( not par.isEnabled() ) continue;
@@ -689,7 +689,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
         for( auto& par : *parList ){ parameterLabels[blocOffset + par.getParameterIndex()] = par.getFullTitle(); }
 
         parList = &parSet.getEffectiveParameterList();
-        if( parSet.isUseEigenDecompInFit() ){
+        if( parSet.isEnableEigenDecomp() ){
           int iParIdx{0};
           for( auto& iPar : *parList ){
             int jParIdx{0};
@@ -729,7 +729,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
               }
               else{
                 // Inherit from the prior in eigen -> only diagonal are non 0
-                if( &iParSet == &jParSet and iParSet.isUseEigenDecompInFit() ){
+                if( &iParSet == &jParSet and iParSet.isEnableEigenDecomp() ){
                   if( iPar.getParameterIndex() == jPar.getParameterIndex() ){
                     (*unstrippedCovMatrix)[iOffset + iPar.getParameterIndex()][jOffset + jPar.getParameterIndex()] = iPar.getStdDevValue()*iPar.getStdDevValue();
                   }
@@ -1100,7 +1100,7 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
     }
 
     TDirectory* saveDir;
-    if( parSet.isUseEigenDecompInFit() ){
+    if( parSet.isEnableEigenDecomp() ){
       saveDir = GenericToolbox::mkdirTFile(parSetDir, "eigen");
       savePostFitObjFct(parSet, *parList, covMatrix.get(), saveDir);
 

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -240,21 +240,21 @@ void MinimizerInterface::minimize(){
   bestFitStats->Branch("chi2StatBestFit",  (double*) getPropagator().getLlhStatBufferPtr() );
   bestFitStats->Branch("chi2PullsBestFit", (double*) getPropagator().getLlhPenaltyBufferPtr() );
 
-  std::vector<GenericToolbox::RawDataArray> samplesArrList(getPropagator().getFitSampleSet().getSampleList().size());
+  std::vector<GenericToolbox::RawDataArray> samplesArrList(getPropagator().getSampleSet().getSampleList().size());
   int iSample{-1};
-  for( auto& sample : getPropagator().getFitSampleSet().getSampleList() ){
+  for( auto& sample : getPropagator().getSampleSet().getSampleList() ){
     if( not sample.isEnabled() ) continue;
 
     std::vector<std::string> leavesDict;
     iSample++;
 
     leavesDict.emplace_back("llhSample/D");
-    samplesArrList[iSample].writeRawData(getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample));
+    samplesArrList[iSample].writeRawData(getPropagator().getSampleSet().getJointProbabilityFct()->eval(sample));
 
     int nBins = int(sample.getBinning().getBinList().size());
     for( int iBin = 1 ; iBin <= nBins ; iBin++ ){
       leavesDict.emplace_back("llhSample_bin" + std::to_string(iBin) + "/D");
-      samplesArrList[iSample].writeRawData(getPropagator().getFitSampleSet().getJointProbabilityFct()->eval(sample, iBin));
+      samplesArrList[iSample].writeRawData(getPropagator().getSampleSet().getJointProbabilityFct()->eval(sample, iBin));
     }
 
     samplesArrList[iSample].lockArraySize();

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -240,9 +240,9 @@ void MinimizerInterface::minimize(){
   bestFitStats->Branch("chi2StatBestFit",  (double*) getPropagator().getLlhStatBufferPtr() );
   bestFitStats->Branch("chi2PullsBestFit", (double*) getPropagator().getLlhPenaltyBufferPtr() );
 
-  std::vector<GenericToolbox::RawDataArray> samplesArrList(getPropagator().getFitSampleSet().getFitSampleList().size());
+  std::vector<GenericToolbox::RawDataArray> samplesArrList(getPropagator().getFitSampleSet().getSampleList().size());
   int iSample{-1};
-  for( auto& sample : getPropagator().getFitSampleSet().getFitSampleList() ){
+  for( auto& sample : getPropagator().getFitSampleSet().getSampleList() ){
     if( not sample.isEnabled() ) continue;
 
     std::vector<std::string> leavesDict;

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -402,7 +402,7 @@ void MinimizerInterface::scanParameters(TDirectory* saveDir_){
                  << " is fixed. Skipping..." << std::endl;
       continue;
     }
-    this->getPropagator().getParScanner().scanFitParameter(*getMinimizerFitParameterPtr()[iPar], saveDir_);
+    this->getPropagator().getParScanner().scanParameter(*getMinimizerFitParameterPtr()[iPar], saveDir_);
   } // iPar
   for( auto& parSet : this->getPropagator().getParametersManager().getParameterSetsList() ){
     if( not parSet.isEnabled() ) continue;
@@ -410,7 +410,7 @@ void MinimizerInterface::scanParameters(TDirectory* saveDir_){
       LogWarning << parSet.getName() << " is using eigen decomposition. Scanning original parameters..." << std::endl;
       for( auto& par : parSet.getParameterList() ){
         if( not par.isEnabled() ) continue;
-        this->getPropagator().getParScanner().scanFitParameter(par, saveDir_);
+        this->getPropagator().getParScanner().scanParameter(par, saveDir_);
       }
     }
   }

--- a/src/ParametersManager/ParametersLibLinkDef.h
+++ b/src/ParametersManager/ParametersLibLinkDef.h
@@ -15,8 +15,8 @@
 #pragma link C++ class Dial+;
 #pragma link C++ class DialSet+;
 #pragma link C++ class DialWrapper+;
-#pragma link C++ class FitParameter+;
-#pragma link C++ class FitParameterSet+;
+#pragma link C++ class Parameter+;
+#pragma link C++ class ParameterSet+;
 #pragma link C++ class GraphDial+;
 #pragma link C++ class NestedDialTest+;
 #pragma link C++ class NormDial+;

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -53,7 +53,7 @@ public:
   // Getters
   [[nodiscard]] bool isEnabled() const{ return _isEnabled_; }
   [[nodiscard]] bool isEnablePca() const{ return _enablePca_; }
-  [[nodiscard]] bool isUseEigenDecompInFit() const{ return _useEigenDecomp_; }
+  [[nodiscard]] bool isEnableEigenDecomp() const{ return _enableEigenDecomp_; }
   [[nodiscard]] bool isEnabledThrowToyParameters() const{ return _enabledThrowToyParameters_; }
   [[nodiscard]] bool isMaskForToyGeneration() const { return _maskForToyGeneration_; }
   [[nodiscard]] bool isMaskedForPropagation() const{ return _maskedForPropagation_; }
@@ -65,7 +65,7 @@ public:
   [[nodiscard]] const JsonType &getDialSetDefinitions() const{ return _dialSetDefinitions_; }
   [[nodiscard]] const TMatrixD* getInvertedEigenVectors() const{ return _eigenVectorsInv_.get(); }
   [[nodiscard]] const TMatrixD* getEigenVectors() const{ return _eigenVectors_.get(); }
-  [[nodiscard]] const std::vector<JsonType>& getCustomFitParThrow() const{ return _customFitParThrow_; }
+  [[nodiscard]] const std::vector<JsonType>& getCustomParThrow() const{ return _customParThrow_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCorrelationMatrix() const{ return _priorCorrelationMatrix_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
   [[nodiscard]] const std::vector<Parameter> &getParameterList() const{ return _parameterList_; }
@@ -99,6 +99,10 @@ public:
   static double toRealParValue(double normParValue, const Parameter& par);
   static double toRealParRange(double normParRange, const Parameter& par);
   static bool isValidCorrelatedParameter(const Parameter& par_);
+
+  // Deprecated
+  [[deprecated("use getCustomParThrow()")]] [[nodiscard]] const std::vector<JsonType>& getCustomFitParThrow() const{ return getCustomParThrow(); }
+  [[deprecated("use isEnableEigenDecomp()")]] [[nodiscard]] bool isUseEigenDecompInFit() const{ return isEnableEigenDecomp(); }
 
 protected:
   void readParameterDefinitionFile();
@@ -142,12 +146,12 @@ private:
 
   std::vector<JsonType> _enableOnlyParameters_{};
   std::vector<JsonType> _disableParameters_{};
-  std::vector<JsonType> _customFitParThrow_{};
+  std::vector<JsonType> _customParThrow_{};
 
   // Eigen objects
   int _nbEnabledEigen_{0};
   bool _enablePca_{false};
-  bool _useEigenDecomp_{false};
+  bool _enableEigenDecomp_{false};
   bool _useOnlyOneParameterPerEvent_{false};
   std::vector<Parameter> _eigenParameterList_{};
   std::shared_ptr<TMatrixDSymEigen> _eigenDecomp_{nullptr};

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -24,14 +24,6 @@
 #include <string>
 
 
-/*
- * \class FitParameterSet is a class which aims at handling a set of parameters bond together with a covariance matrix
- * User parameters:
- * - Covariance matrix (dim N)
- * - N Fit Parameters (handing dials)
- *
- * */
-
 class ParameterSet : public JsonBaseClass  {
 
 protected:
@@ -80,8 +72,8 @@ public:
   double getPenaltyChi2();
 
   // Throw / Shifts
-  void moveFitParametersToPrior();
-  void throwFitParameters(bool rethrowIfNotInbounds_ = true, double gain_ = 1);
+  void moveParametersToPrior();
+  void throwParameters( bool rethrowIfNotInbounds_ = true, double gain_ = 1);
 
   void propagateEigenToOriginal();
   void propagateOriginalToEigen();
@@ -103,6 +95,8 @@ public:
   // Deprecated
   [[deprecated("use getCustomParThrow()")]] [[nodiscard]] const std::vector<JsonType>& getCustomFitParThrow() const{ return getCustomParThrow(); }
   [[deprecated("use isEnableEigenDecomp()")]] [[nodiscard]] bool isUseEigenDecompInFit() const{ return isEnableEigenDecomp(); }
+  [[deprecated("use moveParametersToPrior()")]] void moveFitParametersToPrior(){ moveParametersToPrior(); }
+  [[deprecated("use throwParameters()")]] void throwFitParameters( bool rethrowIfNotInbounds_ = true, double gain_ = 1){ throwParameters(rethrowIfNotInbounds_, gain_); }
 
 protected:
   void readParameterDefinitionFile();

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -53,7 +53,7 @@ public:
   // Getters
   [[nodiscard]] bool isEnabled() const{ return _isEnabled_; }
   [[nodiscard]] bool isEnablePca() const{ return _enablePca_; }
-  [[nodiscard]] bool isUseEigenDecompInFit() const{ return _useEigenDecompInFit_; }
+  [[nodiscard]] bool isUseEigenDecompInFit() const{ return _useEigenDecomp_; }
   [[nodiscard]] bool isEnabledThrowToyParameters() const{ return _enabledThrowToyParameters_; }
   [[nodiscard]] bool isMaskForToyGeneration() const { return _maskForToyGeneration_; }
   [[nodiscard]] bool isMaskedForPropagation() const{ return _maskedForPropagation_; }
@@ -147,7 +147,7 @@ private:
   // Eigen objects
   int _nbEnabledEigen_{0};
   bool _enablePca_{false};
-  bool _useEigenDecompInFit_{false};
+  bool _useEigenDecomp_{false};
   bool _useOnlyOneParameterPerEvent_{false};
   std::vector<Parameter> _eigenParameterList_{};
   std::shared_ptr<TMatrixDSymEigen> _eigenDecomp_{nullptr};

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -48,7 +48,7 @@ public:
   void throwParameters();
   void throwParametersFromParSetCovariance();
   void throwParametersFromGlobalCovariance(bool quietVerbose_ = true);
-  ParameterSet* getFitParameterSetPtr(const std::string& name_);
+  ParameterSet* fetchParameterSetPtr( const std::string& name_);
   
   // Logger related
   static void muteLogger();
@@ -56,6 +56,7 @@ public:
 
   // Deprecated
   [[deprecated("use fetchParameterSetPtr()")]] [[nodiscard]] const ParameterSet* getFitParameterSetPtr( const std::string& name_) const{ return fetchParameterSetPtr(name_); }
+  [[deprecated("use fetchParameterSetPtr()")]] ParameterSet* getFitParameterSetPtr( const std::string& name_) { return fetchParameterSetPtr(name_); }
 
 private:
   // config

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -41,7 +41,7 @@ public:
   // const core
   [[nodiscard]] std::string getParametersSummary( bool showEigen_ = true ) const;
   [[nodiscard]] JsonType exportParameterInjectorConfig() const;
-  [[nodiscard]] const ParameterSet* getFitParameterSetPtr(const std::string& name_) const;
+  [[nodiscard]] const ParameterSet* fetchParameterSetPtr( const std::string& name_) const;
 
   // core
   void injectParameterValues(const JsonType &config_);
@@ -53,6 +53,9 @@ public:
   // Logger related
   static void muteLogger();
   static void unmuteLogger();
+
+  // Deprecated
+  [[deprecated("use fetchParameterSetPtr()")]] [[nodiscard]] const ParameterSet* getFitParameterSetPtr( const std::string& name_) const{ return fetchParameterSetPtr(name_); }
 
 private:
   // config

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -149,13 +149,13 @@ void ParameterSet::processCovarianceMatrix(){
   if( _priorCovarianceMatrix_ == nullptr ){ return; } // nothing to do
 
   LogInfo << "Stripping the matrix from fixed/disabled parameters..." << std::endl;
-  int nbFitParameters{0};
+  int nbParameters{0};
   for( const auto& par : _parameterList_ ){
-    if( ParameterSet::isValidCorrelatedParameter(par) ) nbFitParameters++;
+    if( ParameterSet::isValidCorrelatedParameter(par) ) nbParameters++;
   }
-  LogInfo << nbFitParameters << " effective parameters were defined in set: " << getName() << std::endl;
+  LogInfo << nbParameters << " effective parameters were defined in set: " << getName() << std::endl;
 
-  _strippedCovarianceMatrix_ = std::make_shared<TMatrixDSym>(nbFitParameters);
+  _strippedCovarianceMatrix_ = std::make_shared<TMatrixDSym>(nbParameters);
   int iStrippedPar = -1;
   for( int iPar = 0 ; iPar < int(_parameterList_.size()) ; iPar++ ){
     if( not ParameterSet::isValidCorrelatedParameter(_parameterList_[iPar]) ) continue;
@@ -337,7 +337,7 @@ double ParameterSet::getPenaltyChi2() {
 
 // Parameter throw
 void ParameterSet::moveParametersToPrior(){
-  LogInfo << "Moving back fit parameters to their prior value in set: " << getName() << std::endl;
+  LogInfo << "Moving back parameters to their prior value in set: " << getName() << std::endl;
 
   if( not _enableEigenDecomp_ ){
     for( auto& par : _parameterList_ ){
@@ -372,11 +372,11 @@ void ParameterSet::throwParameters( bool rethrowIfNotInbounds_, double gain_){
           throwFct_();
 
           // throws with this function are always done in real space.
-          int iFit{-1};
+          int iPar{-1};
           for( auto& par : this->getParameterList() ){
             if( ParameterSet::isValidCorrelatedParameter(par) ){
-              iFit++;
-              par.setThrowValue( par.getPriorValue() + gain_ * throwsList[iFit] );
+              iPar++;
+              par.setThrowValue( par.getPriorValue() + gain_ * throwsList[iPar] );
               par.setParameterValue( par.getThrowValue() );
             }
           }
@@ -566,7 +566,7 @@ void ParameterSet::propagateEigenToOriginal(){
 std::string ParameterSet::getSummary() const {
   std::stringstream ss;
 
-  ss << "FitParameterSet summary: " << _name_ << " -> enabled=" << _isEnabled_;
+  ss << "ParameterSet summary: " << _name_ << " -> enabled=" << _isEnabled_;
 
   if(_isEnabled_){
 
@@ -585,7 +585,7 @@ std::string ParameterSet::getSummary() const {
         if( not par.isEnabled() ) { statusStr = "Disabled"; colorStr = GenericToolbox::ColorCodes::yellowBackground; }
         else if( par.isFixed() )  { statusStr = "Fixed";    colorStr = GenericToolbox::ColorCodes::redBackground; }
         else if( par.isFree() )   { statusStr = "Free";     colorStr = GenericToolbox::ColorCodes::blueBackground; }
-        else                      { statusStr = "Fit"; }
+        else                      { statusStr = "Enabled"; }
 
 #ifdef NOCOLOR
         colorStr = "";
@@ -960,10 +960,10 @@ void ParameterSet::defineParameters(){
 }
 
 void ParameterSet::fillDeltaParameterList(){
-  int iFit{0};
+  int iPar{0};
   for( const auto& par : _parameterList_ ){
     if( ParameterSet::isValidCorrelatedParameter(par) ){
-      (*_deltaParameterList_)[iFit++] = par.getParameterValue() - par.getPriorValue();
+      (*_deltaParameterList_)[iPar++] = par.getParameterValue() - par.getPriorValue();
     }
   }
 }

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -43,8 +43,8 @@ void ParameterSet::readConfigImpl(){
     _globalParameterMaxValue_ = GenericToolbox::Json::fetchValue(parLimits, "maxValue", _globalParameterMaxValue_);
   }
 
-  _useEigenDecomp_ = GenericToolbox::Json::fetchValue(_config_ , {{"useEigenDecomp"}, {"useEigenDecompInFit"}}, false);
-  if( _useEigenDecomp_ ){
+  _enableEigenDecomp_ = GenericToolbox::Json::fetchValue(_config_ , {{"enableEigenDecomp"}, {"useEigenDecompInFit"}}, false);
+  if( _enableEigenDecomp_ ){
     LogWarning << "Using eigen decomposition in fit." << std::endl;
     LogScopeIndent;
 
@@ -72,7 +72,7 @@ void ParameterSet::readConfigImpl(){
   _enablePca_ = GenericToolbox::Json::fetchValue(_config_, std::vector<std::string>{"allowPca", "fixGhostFitParameters", "enablePca"}, _enablePca_);
   _enabledThrowToyParameters_ = GenericToolbox::Json::fetchValue(_config_, "enabledThrowToyParameters", _enabledThrowToyParameters_);
   _maskForToyGeneration_ = GenericToolbox::Json::fetchValue(_config_, "maskForToyGeneration", _maskForToyGeneration_);
-  _customFitParThrow_ = GenericToolbox::Json::fetchValue(_config_, "customFitParThrow", std::vector<JsonType>());
+  _customParThrow_ = GenericToolbox::Json::fetchValue(_config_, {{"customParThrow"}, {"customFitParThrow"}}, std::vector<JsonType>());
   _releaseFixedParametersOnHesse_ = GenericToolbox::Json::fetchValue(_config_, "releaseFixedParametersOnHesse", _releaseFixedParametersOnHesse_);
 
   _parameterDefinitionFilePath_ = GenericToolbox::Json::fetchValue( _config_,
@@ -171,7 +171,7 @@ void ParameterSet::processCovarianceMatrix(){
 
   LogThrowIf(not _strippedCovarianceMatrix_->IsSymmetric(), "Covariance matrix is not symmetric");
 
-  if( not _useEigenDecomp_ ){
+  if( not _enableEigenDecomp_ ){
     LogWarning << "Computing inverse of the stripped covariance matrix: "
                << _strippedCovarianceMatrix_->GetNcols() << "x"
                << _strippedCovarianceMatrix_->GetNrows() << std::endl;
@@ -299,13 +299,13 @@ void ParameterSet::processCovarianceMatrix(){
 
 // Getters
 const std::vector<Parameter>& ParameterSet::getEffectiveParameterList() const{
-  if( _useEigenDecomp_ ) return _eigenParameterList_;
+  if( _enableEigenDecomp_ ) return _eigenParameterList_;
   return _parameterList_;
 }
 
 // non const getters
 std::vector<Parameter>& ParameterSet::getEffectiveParameterList(){
-  if( _useEigenDecomp_ ) return _eigenParameterList_;
+  if( _enableEigenDecomp_ ) return _eigenParameterList_;
   return _parameterList_;
 }
 
@@ -317,7 +317,7 @@ double ParameterSet::getPenaltyChi2() {
   _penaltyChi2Buffer_ = 0;
 
   if( _priorCovarianceMatrix_ != nullptr ){
-    if( _useEigenDecomp_ ){
+    if( _enableEigenDecomp_ ){
       for( const auto& eigenPar : _eigenParameterList_ ){
         if( eigenPar.isFixed() ) continue;
         _penaltyChi2Buffer_ += TMath::Sq( (eigenPar.getParameterValue() - eigenPar.getPriorValue()) / eigenPar.getStdDevValue() ) ;
@@ -339,7 +339,7 @@ double ParameterSet::getPenaltyChi2() {
 void ParameterSet::moveFitParametersToPrior(){
   LogInfo << "Moving back fit parameters to their prior value in set: " << getName() << std::endl;
 
-  if( not _useEigenDecomp_ ){
+  if( not _enableEigenDecomp_ ){
     for( auto& par : _parameterList_ ){
       if( par.isFixed() or not par.isEnabled() ){ continue; }
       par.setParameterValue(par.getPriorValue());
@@ -380,7 +380,7 @@ void ParameterSet::throwFitParameters(bool rethrowIfNotInbounds_, double gain_){
               par.setParameterValue( par.getThrowValue() );
             }
           }
-          if( _useEigenDecomp_ ){
+          if( _enableEigenDecomp_ ){
             this->propagateOriginalToEigen();
             for( auto& eigenPar : _eigenParameterList_ ){
               eigenPar.setThrowValue( eigenPar.getParameterValue() );
@@ -421,7 +421,7 @@ void ParameterSet::throwFitParameters(bool rethrowIfNotInbounds_, double gain_){
               LogInfo << " → " << par.getParameterValue() << std::endl;
             }
           }
-          if( _useEigenDecomp_ ){
+          if( _enableEigenDecomp_ ){
             LogInfo << "Translated to eigen space:" << std::endl;
             for( auto& eigenPar : _eigenParameterList_ ){
               LogInfo << "Eigen par " << eigenPar.getTitle() << ": " << eigenPar.getPriorValue();
@@ -459,7 +459,7 @@ void ParameterSet::throwFitParameters(bool rethrowIfNotInbounds_, double gain_){
     throwParsFct( markScottThrowFct );
   }
   else{
-    if( _useEigenDecompForThrows_ and _useEigenDecomp_ ){
+    if( _useEigenDecompForThrows_ and _enableEigenDecomp_ ){
       LogInfo << "Throwing eigen parameters for " << _name_ << std::endl;
 
       int nTries{0};
@@ -720,7 +720,7 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
     }
   }
 
-  if( this->isUseEigenDecompInFit() ){
+  if( this->isEnableEigenDecomp() ){
     LogInfo << "Propagating back to the eigen decomposed parameters for parSet: " << this->getName() << std::endl;
     this->propagateOriginalToEigen();
   }

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -336,7 +336,7 @@ double ParameterSet::getPenaltyChi2() {
 }
 
 // Parameter throw
-void ParameterSet::moveFitParametersToPrior(){
+void ParameterSet::moveParametersToPrior(){
   LogInfo << "Moving back fit parameters to their prior value in set: " << getName() << std::endl;
 
   if( not _enableEigenDecomp_ ){
@@ -354,7 +354,7 @@ void ParameterSet::moveFitParametersToPrior(){
   }
 
 }
-void ParameterSet::throwFitParameters(bool rethrowIfNotInbounds_, double gain_){
+void ParameterSet::throwParameters( bool rethrowIfNotInbounds_, double gain_){
 
   LogThrowIf(_strippedCovarianceMatrix_==nullptr, "No covariance matrix provided");
 

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -290,13 +290,13 @@ void ParametersManager::injectParameterValues(const JsonType &config_) {
     auto parSetName = GenericToolbox::Json::fetchValue<std::string>(entryParSet, "name");
     LogInfo << "Reading injection parameters for parSet: " << parSetName << std::endl;
 
-    auto* selectedParSet = this->getFitParameterSetPtr(parSetName );
+    auto* selectedParSet = this->fetchParameterSetPtr(parSetName);
     LogThrowIf( selectedParSet == nullptr, "Could not find parSet: " << parSetName );
 
     selectedParSet->injectParameterValues(entryParSet);
   }
 }
-ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& name_){
+ParameterSet* ParametersManager::fetchParameterSetPtr( const std::string& name_){
   return const_cast<ParameterSet*>(const_cast<const ParametersManager *>(this)->fetchParameterSetPtr(name_));
 }
 

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -116,7 +116,7 @@ JsonType ParametersManager::exportParameterInjectorConfig() const{
 
   return out;
 }
-const ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& name_) const{
+const ParameterSet* ParametersManager::fetchParameterSetPtr( const std::string& name_) const{
   for( auto& parSet : _parameterSetList_ ){
     if( parSet.getName() == name_ ) return &parSet;
   }
@@ -297,6 +297,6 @@ void ParametersManager::injectParameterValues(const JsonType &config_) {
   }
 }
 ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& name_){
-  return const_cast<ParameterSet*>(const_cast<const ParametersManager*>(this)->getFitParameterSetPtr(name_));
+  return const_cast<ParameterSet*>(const_cast<const ParametersManager *>(this)->fetchParameterSetPtr(name_));
 }
 

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -226,7 +226,7 @@ void ParametersManager::throwParametersFromGlobalCovariance(bool quietVerbose_){
     // Making sure eigen decomposed parameters get the conversion done
     for( auto& parSet : _parameterSetList_ ){
       if( not parSet.isEnabled() ) continue;
-      if( parSet.isUseEigenDecompInFit() ){
+      if( parSet.isEnableEigenDecomp() ){
         parSet.propagateOriginalToEigen();
 
         // also check the bounds of real parameter space
@@ -260,7 +260,7 @@ void ParametersManager::throwParametersFromGlobalCovariance(bool quietVerbose_){
             LogInfo << " → " << par.getParameterValue() << std::endl;
           }
         }
-        if( parSet.isUseEigenDecompInFit() ){
+        if( parSet.isEnableEigenDecomp() ){
           LogInfo << "Translated to eigen space:" << std::endl;
           for( auto& eigenPar : parSet.getEigenParameterList() ){
             LogScopeIndent;

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -150,7 +150,7 @@ void ParametersManager::throwParametersFromParSetCovariance(){
     if( parSet.getPriorCovarianceMatrix() != nullptr ){
       LogWarning << parSet.getName() << ": throwing correlated parameters..." << std::endl;
       LogScopeIndent;
-      parSet.throwFitParameters(_reThrowParSetIfOutOfBounds_);
+      parSet.throwParameters(_reThrowParSetIfOutOfBounds_);
     } // throw?
     else{
       LogAlert << "No correlation matrix defined for " << parSet.getName() << ". NOT THROWING. (dev: could throw only with sigmas?)" << std::endl;

--- a/src/Propagator/include/ParScanner.h
+++ b/src/Propagator/include/ParScanner.h
@@ -2,8 +2,8 @@
 // Created by Adrien BLANCHET on 07/04/2022.
 //
 
-#ifndef GUNDAM_PARSCANNER_H
-#define GUNDAM_PARSCANNER_H
+#ifndef GUNDAM_PAR_SCANNER_H
+#define GUNDAM_PAR_SCANNER_H
 
 #include "JsonBaseClass.h"
 #include "Parameter.h"
@@ -49,8 +49,8 @@ public:
   [[nodiscard]] const std::vector<GraphEntry> &getGraphEntriesBuf() const { return _graphEntriesBuf_; };
 
   // Core
-  void scanFitParameters(std::vector<Parameter>& par_, TDirectory* saveDir_);
-  void scanFitParameter(Parameter& par_, TDirectory* saveDir_);
+  void scanParameters( std::vector<Parameter>& par_, TDirectory* saveDir_);
+  void scanParameter( Parameter& par_, TDirectory* saveDir_);
   void scanSegment(TDirectory *saveDir_, const JsonType &end_, const JsonType &start_ = JsonType(), int nSteps_=-1);
   void generateOneSigmaPlots(TDirectory* saveDir_);
   void varyEvenRates(const std::vector<double>& paramVariationList_, TDirectory* saveDir_);
@@ -60,6 +60,8 @@ public:
 
   static void writeGraphEntry(GraphEntry& entry_, TDirectory* saveDir_);
 
+  [[deprecated("use scanParameters")]] void scanFitParameters( std::vector<Parameter>& par_, TDirectory* saveDir_){ scanParameters(par_, saveDir_); }
+  [[deprecated("use scanParameter")]] void scanFitParameter( Parameter& par_, TDirectory* saveDir_){ scanParameter(par_, saveDir_); }
 
 protected:
   void readConfigImpl() override;
@@ -83,4 +85,4 @@ private:
 };
 
 
-#endif //GUNDAM_PARSCANNER_H
+#endif //GUNDAM_PAR_SCANNER_H

--- a/src/Propagator/include/Propagator.h
+++ b/src/Propagator/include/Propagator.h
@@ -54,7 +54,7 @@ public:
 
   // Non-const getters
   ParScanner& getParScanner(){ return _parScanner_; }
-  SampleSet &getFitSampleSet(){ return _fitSampleSet_; }
+  SampleSet &getSampleSet(){ return _fitSampleSet_; }
   ParametersManager &getParametersManager(){ return _parManager_; }
   PlotGenerator &getPlotGenerator(){ return _plotGenerator_; }
   EventDialCache& getEventDialCache(){ return _eventDialCache_; }
@@ -81,6 +81,9 @@ public:
   // Logger related
   static void muteLogger();
   static void unmuteLogger();
+
+  // Deprecated
+  [[deprecated("use getSampleSet()")]] SampleSet &getFitSampleSet(){ return _fitSampleSet_; }
 
 protected:
   void initializeThreads();

--- a/src/Propagator/src/ParScanner.cpp
+++ b/src/Propagator/src/ParScanner.cpp
@@ -72,7 +72,7 @@ void ParScanner::initializeImpl() {
     scanEntry.evalY = [this](){ return _owner_->getLlhStatBuffer(); };
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "llhStatPerSample", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
+    for( auto& sample : _owner_->getSampleSet().getSampleList() ){
       _scanDataDict_.emplace_back();
       auto& scanEntry = _scanDataDict_.back();
       scanEntry.yPoints = std::vector<double>(_nbPoints_+1,0);
@@ -80,11 +80,11 @@ void ParScanner::initializeImpl() {
       scanEntry.title = Form("Stat Likelihood Scan of sample \"%s\"", sample.getName().c_str());
       scanEntry.yTitle = "Stat LLH value";
       auto* samplePtr = &sample;
-      scanEntry.evalY = [this, samplePtr](){ return _owner_->getFitSampleSet().evalLikelihood(*samplePtr); };
+      scanEntry.evalY = [this, samplePtr](){ return _owner_->getSampleSet().evalLikelihood(*samplePtr); };
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "llhStatPerSamplePerBin", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
+    for( auto& sample : _owner_->getSampleSet().getSampleList() ){
       for( int iBin = 1 ; iBin <= sample.getMcContainer().histogram->GetNbinsX() ; iBin++ ){
         _scanDataDict_.emplace_back();
         auto& scanEntry = _scanDataDict_.back();
@@ -95,12 +95,12 @@ void ParScanner::initializeImpl() {
                                sample.getBinning().getBinList()[iBin-1].getSummary().c_str());
         scanEntry.yTitle = "Stat LLH value";
         auto* samplePtr = &sample;
-        scanEntry.evalY = [this, samplePtr, iBin](){ return _owner_->getFitSampleSet().getJointProbabilityFct()->eval(*samplePtr, iBin); };
+        scanEntry.evalY = [this, samplePtr, iBin](){ return _owner_->getSampleSet().getJointProbabilityFct()->eval(*samplePtr, iBin); };
       }
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "weightPerSample", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
+    for( auto& sample : _owner_->getSampleSet().getSampleList() ){
       _scanDataDict_.emplace_back();
       auto& scanEntry = _scanDataDict_.back();
       scanEntry.yPoints = std::vector<double>(_nbPoints_+1,0);
@@ -112,7 +112,7 @@ void ParScanner::initializeImpl() {
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "weightPerSamplePerBin", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
+    for( auto& sample : _owner_->getSampleSet().getSampleList() ){
       for( int iBin = 1 ; iBin <= sample.getMcContainer().histogram->GetNbinsX() ; iBin++ ){
         _scanDataDict_.emplace_back();
         auto& scanEntry = _scanDataDict_.back();
@@ -473,7 +473,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
       par_.setParameterValue( cappedParValue );
       _owner_->propagateParametersOnSamples();
 
-      for(auto & sample : _owner_->getFitSampleSet().getSampleList()){
+      for(auto & sample : _owner_->getSampleSet().getSampleList()){
         buffEvtRatesMap[iVar].emplace_back( sample.getMcContainer().getSumWeights() );
       }
 
@@ -497,7 +497,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
 
     TVectorD* buffVariedEvtRates_TVectorD{nullptr};
 
-    for( size_t iSample = 0 ; iSample < _owner_->getFitSampleSet().getSampleList().size() ; iSample++ ){
+    for( size_t iSample = 0 ; iSample < _owner_->getSampleSet().getSampleList().size() ; iSample++ ){
 
       buffVariedEvtRates_TVectorD = new TVectorD(int(variationList_.size()));
 
@@ -506,7 +506,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
       }
 
       GenericToolbox::writeInTFile(saveSubDir_, buffVariedEvtRates_TVectorD,
-                                   _owner_->getFitSampleSet().getSampleList()[iSample].getName());
+                                   _owner_->getSampleSet().getSampleList()[iSample].getName());
 
     }
 

--- a/src/Propagator/src/ParScanner.cpp
+++ b/src/Propagator/src/ParScanner.cpp
@@ -151,12 +151,12 @@ bool ParScanner::isUseParameterLimits() const {
   return _useParameterLimits_;
 }
 
-void ParScanner::scanFitParameters(std::vector<Parameter>& parList_, TDirectory* saveDir_){
+void ParScanner::scanParameters( std::vector<Parameter>& par_, TDirectory* saveDir_){
   LogThrowIf(not isInitialized());
   LogThrowIf(saveDir_ == nullptr);
-  for( auto& par : parList_ ){ this->scanFitParameter(par, saveDir_); }
+  for( auto& par : par_ ){ this->scanParameter(par, saveDir_); }
 }
-void ParScanner::scanFitParameter(Parameter& par_, TDirectory* saveDir_) {
+void ParScanner::scanParameter( Parameter& par_, TDirectory* saveDir_) {
   LogThrowIf(not isInitialized());
   LogThrowIf(saveDir_ == nullptr);
   std::vector<double> parPoints(_nbPoints_+1,0);

--- a/src/Propagator/src/ParScanner.cpp
+++ b/src/Propagator/src/ParScanner.cpp
@@ -72,7 +72,7 @@ void ParScanner::initializeImpl() {
     scanEntry.evalY = [this](){ return _owner_->getLlhStatBuffer(); };
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "llhStatPerSample", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getFitSampleList() ){
+    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
       _scanDataDict_.emplace_back();
       auto& scanEntry = _scanDataDict_.back();
       scanEntry.yPoints = std::vector<double>(_nbPoints_+1,0);
@@ -84,7 +84,7 @@ void ParScanner::initializeImpl() {
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "llhStatPerSamplePerBin", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getFitSampleList() ){
+    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
       for( int iBin = 1 ; iBin <= sample.getMcContainer().histogram->GetNbinsX() ; iBin++ ){
         _scanDataDict_.emplace_back();
         auto& scanEntry = _scanDataDict_.back();
@@ -100,7 +100,7 @@ void ParScanner::initializeImpl() {
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "weightPerSample", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getFitSampleList() ){
+    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
       _scanDataDict_.emplace_back();
       auto& scanEntry = _scanDataDict_.back();
       scanEntry.yPoints = std::vector<double>(_nbPoints_+1,0);
@@ -112,7 +112,7 @@ void ParScanner::initializeImpl() {
     }
   }
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "weightPerSamplePerBin", false) ){
-    for( auto& sample : _owner_->getFitSampleSet().getFitSampleList() ){
+    for( auto& sample : _owner_->getFitSampleSet().getSampleList() ){
       for( int iBin = 1 ; iBin <= sample.getMcContainer().histogram->GetNbinsX() ; iBin++ ){
         _scanDataDict_.emplace_back();
         auto& scanEntry = _scanDataDict_.back();
@@ -473,7 +473,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
       par_.setParameterValue( cappedParValue );
       _owner_->propagateParametersOnSamples();
 
-      for(auto & sample : _owner_->getFitSampleSet().getFitSampleList()){
+      for(auto & sample : _owner_->getFitSampleSet().getSampleList()){
         buffEvtRatesMap[iVar].emplace_back( sample.getMcContainer().getSumWeights() );
       }
 
@@ -497,7 +497,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
 
     TVectorD* buffVariedEvtRates_TVectorD{nullptr};
 
-    for( size_t iSample = 0 ; iSample < _owner_->getFitSampleSet().getFitSampleList().size() ; iSample++ ){
+    for( size_t iSample = 0 ; iSample < _owner_->getFitSampleSet().getSampleList().size() ; iSample++ ){
 
       buffVariedEvtRates_TVectorD = new TVectorD(int(variationList_.size()));
 
@@ -506,7 +506,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
       }
 
       GenericToolbox::writeInTFile(saveSubDir_, buffVariedEvtRates_TVectorD,
-                                   _owner_->getFitSampleSet().getFitSampleList()[iSample].getName());
+                                   _owner_->getFitSampleSet().getSampleList()[iSample].getName());
 
     }
 

--- a/src/Propagator/src/ParScanner.cpp
+++ b/src/Propagator/src/ParScanner.cpp
@@ -163,7 +163,7 @@ void ParScanner::scanFitParameter(Parameter& par_, TDirectory* saveDir_) {
 
   LogInfo << "Scanning: " << par_.getFullTitle() << " / " << _nbPoints_ << " steps..." << std::endl;
 
-  if( par_.getOwner()->isUseEigenDecompInFit() and not par_.isEigen() ){
+  if( par_.getOwner()->isEnableEigenDecomp() and not par_.isEigen() ){
     // temporarily disable the automatic conversion Eigen -> Original
     _owner_->setEnableEigenToOrigInPropagate( false );
   }
@@ -222,7 +222,7 @@ void ParScanner::scanFitParameter(Parameter& par_, TDirectory* saveDir_) {
   _owner_->updateLlhCache();
 
   // Disable the auto conversion from Eigen to Original if the fit is set to use eigen decomp
-  if( par_.getOwner()->isUseEigenDecompInFit() and not par_.isEigen() ){
+  if( par_.getOwner()->isEnableEigenDecomp() and not par_.isEigen() ){
     _owner_->setEnableEigenToOrigInPropagate( true );
   }
 
@@ -314,7 +314,7 @@ void ParScanner::scanSegment(TDirectory *saveDir_, const JsonType &end_, const J
 
     for( auto& parSet : _owner_->getParametersManager().getParameterSetsList() ){
       if( not parSet.isEnabled() ){ continue; }
-      if( parSet.isUseEigenDecompInFit() ){
+      if( parSet.isEnableEigenDecomp() ){
         // make sure the parameters don't get overwritten
         parSet.propagateOriginalToEigen();
       }
@@ -523,7 +523,7 @@ void ParScanner::varyEvenRates(const std::vector<double>& paramVariationList_, T
       continue;
     }
 
-    if( parSet.isUseEigenDecompInFit() ){
+    if( parSet.isEnableEigenDecomp() ){
       // TODO ?
       continue;
     }

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -269,7 +269,7 @@ void Propagator::initializeImpl(){
           parSet.setMaskedForPropagation( false );
         }
 
-        parSet.moveFitParametersToPrior();
+        parSet.moveParametersToPrior();
       }
     }
   }

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -242,7 +242,7 @@ void Propagator::initializeImpl(){
     // At this point, MC events have been reweighted using their prior
     // but when using eigen decomp, the conversion eigen -> original has a small computational error
     for( auto& parSet: _parManager_.getParameterSetsList() ) {
-      if( parSet.isUseEigenDecompInFit() ) { parSet.propagateEigenToOriginal(); }
+      if( parSet.isEnableEigenDecomp() ) { parSet.propagateEigenToOriginal(); }
     }
 
     bool cacheManagerState = GundamGlobals::getEnableCacheManager();
@@ -549,7 +549,7 @@ void Propagator::propagateParametersOnSamples(){
   if( _enableEigenToOrigInPropagate_ ){
     // Only real parameters are propagated on the spectra -> need to convert the eigen to original
     for( auto& parSet : _parManager_.getParameterSetsList() ){
-      if( parSet.isUseEigenDecompInFit() ) parSet.propagateEigenToOriginal();
+      if( parSet.isEnableEigenDecomp() ) parSet.propagateEigenToOriginal();
     }
   }
 

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -255,7 +255,7 @@ void Propagator::initializeImpl(){
     LogWarning << "Copying loaded mc-like event to data container..." << std::endl;
     _fitSampleSet_.copyMcEventListToDataContainer();
 
-    for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+    for( auto& sample : _fitSampleSet_.getSampleList() ){
       sample.getDataContainer().histScale = sample.getMcContainer().histScale;
     }
 
@@ -326,7 +326,7 @@ void Propagator::initializeImpl(){
   this->reweightMcEvents();
 
   LogInfo << "Set the current MC prior weights as nominal weight..." << std::endl;
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     for( auto& event : sample.getMcContainer().eventList ){
       event.setNominalWeight(event.getEventWeight());
     }
@@ -345,7 +345,7 @@ void Propagator::initializeImpl(){
     if( _enableEventMcThrow_ ){
       // Take into account the finite amount of event in MC
       LogInfo << "enableEventMcThrow is enabled: throwing individual MC events" << std::endl;
-      for( auto& sample : _fitSampleSet_.getFitSampleList() ) {
+      for( auto& sample : _fitSampleSet_.getSampleList() ) {
         sample.getDataContainer().throwEventMcError();
       }
     }
@@ -357,14 +357,14 @@ void Propagator::initializeImpl(){
     if( _gaussStatThrowInToys_ ) {
       LogWarning << "Using gaussian statistical throws. (caveat: distribution truncated when the bins are close to zero)" << std::endl;
     }
-    for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+    for( auto& sample : _fitSampleSet_.getSampleList() ){
       // Asimov bin content -> toy data
       sample.getDataContainer().throwStatError(_gaussStatThrowInToys_);
     }
   }
 
   LogInfo << "Locking data event containers..." << std::endl;
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     // Now the data won't be refilled each time
     sample.getDataContainer().isLocked = true;
   }
@@ -382,7 +382,7 @@ void Propagator::initializeImpl(){
 
   /// Copy the current state of MC as "nominal" histogram
   LogInfo << "Copy the current state of MC as \"nominal\" histogram..." << std::endl;
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     sample.getMcContainer().saveAsHistogramNominal();
   }
 
@@ -406,7 +406,7 @@ void Propagator::initializeImpl(){
       // STAGED MASK
       LogWarning << "Staged event breakdown:" << std::endl;
       std::vector<std::vector<double>> stageBreakdownList(
-          _fitSampleSet_.getFitSampleList().size(),
+          _fitSampleSet_.getSampleList().size(),
           std::vector<double>(_parManager_.getParameterSetsList().size() + 1, 0)
       ); // [iSample][iStage]
       std::vector<std::string> stageTitles;
@@ -427,8 +427,8 @@ void Propagator::initializeImpl(){
 
       this->resetReweight();
       this->reweightMcEvents();
-      for( size_t iSample = 0 ; iSample < _fitSampleSet_.getFitSampleList().size() ; iSample++ ){
-        stageBreakdownList[iSample][iStage] = _fitSampleSet_.getFitSampleList()[iSample].getMcContainer().getSumWeights();
+      for( size_t iSample = 0 ; iSample < _fitSampleSet_.getSampleList().size() ; iSample++ ){
+        stageBreakdownList[iSample][iStage] = _fitSampleSet_.getSampleList()[iSample].getMcContainer().getSumWeights();
       }
 
       for( auto* parSetPtr : maskedParSetList ){
@@ -436,16 +436,16 @@ void Propagator::initializeImpl(){
         this->resetReweight();
         this->reweightMcEvents();
         iStage++;
-        for( size_t iSample = 0 ; iSample < _fitSampleSet_.getFitSampleList().size() ; iSample++ ){
-          stageBreakdownList[iSample][iStage] = _fitSampleSet_.getFitSampleList()[iSample].getMcContainer().getSumWeights();
+        for( size_t iSample = 0 ; iSample < _fitSampleSet_.getSampleList().size() ; iSample++ ){
+          stageBreakdownList[iSample][iStage] = _fitSampleSet_.getSampleList()[iSample].getMcContainer().getSumWeights();
         }
       }
 
       GenericToolbox::TablePrinter t;
       t.setColTitles(stageTitles);
-      for( size_t iSample = 0 ; iSample < _fitSampleSet_.getFitSampleList().size() ; iSample++ ) {
+      for( size_t iSample = 0 ; iSample < _fitSampleSet_.getSampleList().size() ; iSample++ ) {
         std::vector<std::string> tableLine;
-        tableLine.emplace_back("\""+_fitSampleSet_.getFitSampleList()[iSample].getName()+"\"");
+        tableLine.emplace_back("\"" + _fitSampleSet_.getSampleList()[iSample].getName() + "\"");
         for( iStage = 0 ; iStage < stageBreakdownList[iSample].size() ; iStage++ ){
           tableLine.emplace_back( std::to_string(stageBreakdownList[iSample][iStage]) );
         }
@@ -484,7 +484,7 @@ std::string Propagator::getLlhBufferSummary() const{
   ss << "Total likelihood = " << getLlhBuffer();
   ss << std::endl << "Stat likelihood = " << getLlhStatBuffer();
   ss << " = sum of: " << GenericToolbox::toString(
-      _fitSampleSet_.getFitSampleList(), [](const Sample& sample_){
+      _fitSampleSet_.getSampleList(), []( const Sample& sample_){
         std::stringstream ssSub;
         ssSub << sample_.getName() << ": ";
         if( sample_.isEnabled() ){ ssSub << sample_.getLlhStatBuffer(); }
@@ -604,7 +604,7 @@ std::string Propagator::getSampleBreakdownTableStr() const{
   t << "MC (weighted)" << GenericToolbox::TablePrinter::NextColumn;
   t << "Data (weighted)" << GenericToolbox::TablePrinter::NextLine;
 
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     t << "\"" << sample.getName() << "\"" << GenericToolbox::TablePrinter::NextColumn;
     t << sample.getMcContainer().getNbBinnedEvents() << GenericToolbox::TablePrinter::NextColumn;
     t << sample.getDataContainer().getNbBinnedEvents() << GenericToolbox::TablePrinter::NextColumn;
@@ -667,13 +667,13 @@ void Propagator::reweightMcEvents(int iThread_) {
 
 }
 void Propagator::refillSampleHistogramsFct(int iThread_){
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     sample.getMcContainer().refillHistogram(iThread_);
     sample.getDataContainer().refillHistogram(iThread_);
   }
 }
 void Propagator::refillSampleHistogramsPostParallelFct(){
-  for( auto& sample : _fitSampleSet_.getFitSampleList() ){
+  for( auto& sample : _fitSampleSet_.getSampleList() ){
     sample.getMcContainer().rescaleHistogram();
     sample.getDataContainer().rescaleHistogram();
   }

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -388,7 +388,7 @@ void Propagator::initializeImpl(){
 
   /// Initialise other tools
   LogInfo << std::endl << GenericToolbox::addUpDownBars("Initializing the plot generator") << std::endl;
-  _plotGenerator_.setFitSampleSetPtr(&_fitSampleSet_);
+  _plotGenerator_.setSampleSetPtr(&_fitSampleSet_);
   _plotGenerator_.initialize();
 
   LogInfo << std::endl << GenericToolbox::addUpDownBars("Initializing the tree writer") << std::endl;

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -317,7 +317,7 @@ void Propagator::initializeImpl(){
   // reweighting cache.  This must also be before the first use of
   // reweightMcEvents.
   if(GundamGlobals::getEnableCacheManager()) {
-    Cache::Manager::Build(getFitSampleSet(), getEventDialCache());
+    Cache::Manager::Build(getSampleSet(), getEventDialCache());
   }
 #endif
 
@@ -569,7 +569,7 @@ void Propagator::reweightMcEvents() {
   bool usedGPU{false};
 #ifdef GUNDAM_USING_CACHE_MANAGER
   if(GundamGlobals::getEnableCacheManager()) {
-    Cache::Manager::Update(getFitSampleSet(), getEventDialCache());
+    Cache::Manager::Update(getSampleSet(), getEventDialCache());
     usedGPU = Cache::Manager::Fill();
   }
 #endif

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -392,7 +392,7 @@ void Propagator::initializeImpl(){
   _plotGenerator_.initialize();
 
   LogInfo << std::endl << GenericToolbox::addUpDownBars("Initializing the tree writer") << std::endl;
-  _treeWriter_.setFitSampleSetPtr( &_fitSampleSet_ );
+  _treeWriter_.setSampleSetPtr(&_fitSampleSet_);
   _treeWriter_.setParSetListPtr( &_parManager_.getParameterSetsList() );
   _treeWriter_.setEventDialCachePtr( &_eventDialCache_ );
 

--- a/src/SamplesManager/include/PlotGenerator.h
+++ b/src/SamplesManager/include/PlotGenerator.h
@@ -2,8 +2,8 @@
 // Created by Nadrino on 16/06/2021.
 //
 
-#ifndef GUNDAM_PLOTGENERATOR_H
-#define GUNDAM_PLOTGENERATOR_H
+#ifndef GUNDAM_PLOT_GENERATOR_H
+#define GUNDAM_PLOT_GENERATOR_H
 
 #include "SampleSet.h"
 #include "PhysicsEvent.h"
@@ -36,8 +36,8 @@ struct HistHolder{
 
   // Data
   bool isData{false};
-  const Sample* fitSamplePtr{nullptr};
-  std::function<void(TH1D*, const PhysicsEvent*)> fillFunctionFitSample;
+  const Sample* samplePtr{nullptr};
+  std::function<void(TH1D*, const PhysicsEvent*)> fillFunctionSample;
 
   // X axis
   std::string varToPlot;
@@ -81,7 +81,7 @@ class PlotGenerator : public JsonBaseClass {
 
 public:
   // Setters
-  void setFitSampleSetPtr(const SampleSet *fitSampleSetPtr);
+  void setSampleSetPtr(const SampleSet *sampleSetPtr_){ _sampleSetPtr_ = sampleSetPtr_; }
 
   // Getters
   [[nodiscard]] bool isEmpty() const;
@@ -104,6 +104,11 @@ public:
   std::vector<std::string> fetchListOfSplitVarNames();
 
   void defineHistogramHolders();
+
+  // Deprecated
+  [[deprecated("use setSampleSetPtr")]] void setFitSampleSetPtr(const SampleSet *sampleSetPtr_){ setSampleSetPtr(sampleSetPtr_); }
+
+
 protected:
   void readConfigImpl() override;
   void initializeImpl() override;
@@ -125,7 +130,7 @@ private:
   };
 
   // Internals
-  const SampleSet* _fitSampleSetPtr_{nullptr};
+  const SampleSet* _sampleSetPtr_{nullptr};
   std::vector<std::vector<HistHolder>> _histHolderCacheList_{};
   std::vector<HistHolder> _comparisonHistHolderList_;
   std::map<std::string, std::shared_ptr<TCanvas>> _bufferCanvasList_;
@@ -133,4 +138,4 @@ private:
 };
 
 
-#endif //GUNDAM_PLOTGENERATOR_H
+#endif //GUNDAM_PLOT_GENERATOR_H

--- a/src/SamplesManager/include/Sample.h
+++ b/src/SamplesManager/include/Sample.h
@@ -66,7 +66,7 @@ private:
   std::vector<std::string> _enabledDatasetList_;
 
   // Internals
-  double _llhStatBuffer_{std::nan("unset")}; // set by FitSampleSet which hold the joinProbability obj
+  double _llhStatBuffer_{std::nan("unset")}; // set by SampleSet which hold the joinProbability obj
   DataBinSet _binning_;
   SampleElement _mcContainer_;
   SampleElement _dataContainer_;

--- a/src/SamplesManager/include/SampleSet.h
+++ b/src/SamplesManager/include/SampleSet.h
@@ -34,16 +34,16 @@ public:
   void clearMcContainers();
 
   // const getters
-  const std::vector<Sample> &getFitSampleList() const { return _fitSampleList_; }
-  const std::shared_ptr<JointProbability::JointProbability> &getJointProbabilityFct() const{ return _jointProbabilityPtr_; }
-  const std::vector<std::string>& getAdditionalVariablesForStorage() const { return _additionalVariablesForStorage_; }
+  [[nodiscard]] const std::vector<Sample> &getSampleList() const { return _sampleList_; }
+  [[nodiscard]] const std::shared_ptr<JointProbability::JointProbability> &getJointProbabilityFct() const{ return _jointProbabilityPtr_; }
+  [[nodiscard]] const std::vector<std::string>& getAdditionalVariablesForStorage() const { return _additionalVariablesForStorage_; }
 
   // non-const getters
-  std::vector<Sample> &getFitSampleList(){ return _fitSampleList_; }
+  std::vector<Sample> &getSampleList(){ return _sampleList_; }
   std::vector<std::string>& getAdditionalVariablesForStorage() { return _additionalVariablesForStorage_; }
 
   //Core
-  bool empty() const{ return _fitSampleList_.empty(); }
+  [[nodiscard]] bool empty() const{ return _sampleList_.empty(); }
   double evalLikelihood();
   double evalLikelihood(Sample& sample_);
 
@@ -52,12 +52,19 @@ public:
   void updateSampleBinEventList() const;
   void updateSampleHistograms() const;
 
+  // Deprecated
+  [[deprecated("use getSampleList()")]] std::vector<Sample> &getFitSampleList(){ return getSampleList(); }
+  [[deprecated("use getSampleList()")]] [[nodiscard]] const std::vector<Sample> &getFitSampleList() const { return getSampleList(); }
+
 private:
+  // config
   bool _showTimeStats_{false};
-  std::vector<Sample> _fitSampleList_;
   std::shared_ptr<JointProbability::JointProbability> _jointProbabilityPtr_{nullptr};
   std::vector<std::string> _eventByEventDialLeafList_;
   std::vector<std::string> _additionalVariablesForStorage_;
+
+  // internals
+  std::vector<Sample> _sampleList_{};
 
 };
 

--- a/src/SamplesManager/src/PlotGenerator.cpp
+++ b/src/SamplesManager/src/PlotGenerator.cpp
@@ -123,7 +123,7 @@ void PlotGenerator::generateSampleHistograms(TDirectory *saveDir_, int cacheSlot
   }
 
   // Fill histograms
-  for( const auto& sample : _fitSampleSetPtr_->getFitSampleList() ){
+  for( const auto& sample : _fitSampleSetPtr_->getSampleList() ){
       // Datasets:
       for( bool isData : { false, true } ){
 
@@ -625,7 +625,7 @@ void PlotGenerator::defineHistogramHolders() {
     auto splitVars = GenericToolbox::Json::fetchValue(histConfig, "splitVars", std::vector<std::string>{""});
     for( auto& splitVar : splitVars ){
       if( not GenericToolbox::doesKeyIsInMap(splitVar, splitVarsDictionary) ){
-        for( const auto& sample : _fitSampleSetPtr_->getFitSampleList() ){
+        for( const auto& sample : _fitSampleSetPtr_->getSampleList() ){
           splitVarsDictionary[splitVar][&sample] = std::vector<int>();
           if( splitVar.empty() ) splitVarsDictionary[splitVar][&sample].emplace_back(0); // placeholder for no split var
         }
@@ -636,11 +636,11 @@ void PlotGenerator::defineHistogramHolders() {
   std::function<void(int)> fetchSplitVar = [&](int iThread_){
     auto bounds = GenericToolbox::ParallelWorker::getThreadBoundIndices(
         iThread_, GundamGlobals::getParallelWorker().getNbThreads(),
-        int(_fitSampleSetPtr_->getFitSampleList().size())
+        int(_fitSampleSetPtr_->getSampleList().size())
     );
 
     for( int iSample = bounds.first ; iSample < bounds.second ; iSample++ ){
-      const Sample& sample = _fitSampleSetPtr_->getFitSampleList()[iSample];
+      const Sample& sample = _fitSampleSetPtr_->getSampleList()[iSample];
       for( const auto& event : sample.getMcContainer().eventList ){
         for( auto& splitVarInstance: splitVarsDictionary ){
           if(splitVarInstance.first.empty()) continue;
@@ -659,7 +659,7 @@ void PlotGenerator::defineHistogramHolders() {
 
   int sampleCounter = -1;
   HistHolder histDefBase;
-  for( const auto& sample : _fitSampleSetPtr_->getFitSampleList() ){
+  for( const auto& sample : _fitSampleSetPtr_->getSampleList() ){
     LogScopeIndent;
     LogInfo << "Defining holders for sample: \"" << sample.getName() << "\"" << std::endl;
     sampleCounter++;

--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -28,10 +28,10 @@ void SampleSet::readConfigImpl(){
   auto fitSampleListConfig = GenericToolbox::Json::fetchValue(_config_, "fitSampleList", JsonType());
   for( const auto& fitSampleConfig: fitSampleListConfig ){
     if( not GenericToolbox::Json::fetchValue(fitSampleConfig, "isEnabled", true) ) continue;
-    _fitSampleList_.emplace_back();
-    _fitSampleList_.back().setIndex(int(_fitSampleList_.size())-1);
-    _fitSampleList_.back().setConfig(fitSampleConfig);
-    _fitSampleList_.back().readConfig();
+    _sampleList_.emplace_back();
+    _sampleList_.back().setIndex(int(_sampleList_.size()) - 1);
+    _sampleList_.back().setConfig(fitSampleConfig);
+    _sampleList_.back().readConfig();
   }
 
   // TODO: To be moved elsewhere -> nothing to do in sample... -> this should belong to the fitter engine
@@ -58,14 +58,14 @@ void SampleSet::readConfigImpl(){
 }
 void SampleSet::initializeImpl() {
   LogWarning << __METHOD_NAME__ << std::endl;
-  LogThrowIf(_fitSampleList_.empty(), "No sample is defined.");
+  LogThrowIf(_sampleList_.empty(), "No sample is defined.");
 
-  for( auto& sample : _fitSampleList_ ){ sample.initialize(); }
+  for( auto& sample : _sampleList_ ){ sample.initialize(); }
 
   // Fill the bin index inside each event
   std::function<void(int)> updateSampleEventBinIndexesFct = [this](int iThread){
     LogInfoIf(iThread <= 0) << "Updating event sample bin indices..." << std::endl;
-    for( auto& sample : _fitSampleList_ ){
+    for( auto& sample : _sampleList_ ){
       sample.getMcContainer().updateEventBinIndexes(iThread);
       sample.getDataContainer().updateEventBinIndexes(iThread);
     }
@@ -75,7 +75,7 @@ void SampleSet::initializeImpl() {
   // Fill bin event caches
   std::function<void(int)> updateSampleBinEventListFct = [this](int iThread){
     LogInfoIf(iThread <= 0) << "Updating sample per bin event lists..." << std::endl;
-    for( auto& sample : _fitSampleList_ ){
+    for( auto& sample : _sampleList_ ){
       sample.getMcContainer().updateBinEventList(iThread);
       sample.getDataContainer().updateBinEventList(iThread);
     }
@@ -85,13 +85,13 @@ void SampleSet::initializeImpl() {
 
   // Histogram fills
   std::function<void(int)> refillMcHistogramsFct = [this](int iThread){
-    for( auto& sample : _fitSampleList_ ){
+    for( auto& sample : _sampleList_ ){
       sample.getMcContainer().refillHistogram(iThread);
       sample.getDataContainer().refillHistogram(iThread);
     }
   };
   std::function<void()> rescaleMcHistogramsFct = [this](){
-    for( auto& sample : _fitSampleList_ ){
+    for( auto& sample : _sampleList_ ){
       sample.getMcContainer().rescaleHistogram();
       sample.getDataContainer().rescaleHistogram();
     }
@@ -102,7 +102,7 @@ void SampleSet::initializeImpl() {
 
 double SampleSet::evalLikelihood(){
   double llh = 0.;
-  for( auto& sample : _fitSampleList_ ){
+  for( auto& sample : _sampleList_ ){
     llh += this->evalLikelihood(sample);
     LogThrowIf(std::isnan(llh) or std::isinf(llh), sample.getName() << ": reportde likelihood is invalid:" << llh);
   }
@@ -114,7 +114,7 @@ double SampleSet::evalLikelihood(Sample& sample_){
 }
 
 void SampleSet::copyMcEventListToDataContainer(){
-  for( auto& sample : _fitSampleList_ ){
+  for( auto& sample : _sampleList_ ){
     LogInfo << "Copying MC events in sample \"" << sample.getName() << "\"" << std::endl;
     sample.getDataContainer().eventList.clear();
     sample.getDataContainer().eventList.reserve(sample.getMcContainer().eventList.size());
@@ -127,7 +127,7 @@ void SampleSet::copyMcEventListToDataContainer(){
   }
 }
 void SampleSet::clearMcContainers(){
-  for( auto& sample : _fitSampleList_ ){
+  for( auto& sample : _sampleList_ ){
     LogInfo << "Clearing event list for \"" << sample.getName() << "\"" << std::endl;
     sample.getMcContainer().eventList.clear();
   }


### PR DESCRIPTION
Before the FitterEngine, no class should be metioning the fit as the propagator engine is ment to be use by other front ends.

Old API method names are still available but will generate a warning of deprecation