### PR TITLE
Fix/spline extrapolation

### DIFF
--- a/src/CacheManager/src/WeightCompactSpline.cpp
+++ b/src/CacheManager/src/WeightCompactSpline.cpp
@@ -338,8 +338,6 @@ namespace {
             const int id1 = sIndex[i+1];
             const int dim = id1-id0-2;
             const double x = params[pIndex[i]];
-            const double lowBound = knots[id0];
-            const double step = 1.0/knots[id0+1];
             const double lClamp = lowerClamp[pIndex[i]];
             const double uClamp = upperClamp[pIndex[i]];
 

--- a/src/CacheManager/src/WeightMonotonicSpline.cpp
+++ b/src/CacheManager/src/WeightMonotonicSpline.cpp
@@ -339,8 +339,6 @@ namespace {
             const int id1 = sIndex[i+1];
             const int dim = id1-id0-2;
             const double x = params[pIndex[i]];
-            const double lowBound = knots[id0];
-            const double step = 1.0/knots[id0+1];
             const double lClamp = lowerClamp[pIndex[i]];
             const double uClamp = upperClamp[pIndex[i]];
 

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -78,8 +78,6 @@ namespace {
         const double step = x2-x1;
 
         const double fx = (x - x1)/step;
-        const double fxx = fx*fx;
-        const double fxxx = fx*fxx;
 
         const double p1 = data[2+3*ix];
         const double m1 = data[2+3*ix+1]*step;

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -90,10 +90,11 @@ namespace {
         // double v = p1*(2.0*fxxx-3.0*fxx+1.0) + m1*(fxxx-2.0*fxx+fx)
         //         + p2*(3.0*fxx-2.0*fxxx) + m2*(fxxx-fxx));
 
-        // A more numerically stable calculation
-        const double t = 3.0*fxx-2.0*fxxx;
-        double v = p1 - p1*t + m1*(fxxx-2.0*fxx+fx)
-                    + p2*t + m2*(fxxx-fxx);
+        // Factored via Horner's method.
+        double v = ((((2.0*p1 - 2.0*p2 + m2 + m1)*fx
+                      + 3.0*p2 - 3.0*p1 - m2 - 2.0*m1)*fx
+                     +m1)*fx
+                    +p1);
 
         if (v < lowerBound) v = lowerBound;
         if (v > upperBound) v = upperBound;

--- a/src/Utils/include/CalculateUniformSpline.h
+++ b/src/Utils/include/CalculateUniformSpline.h
@@ -57,8 +57,6 @@ namespace {
         if (2*ix+7>dim) ix = (dim-2)/2 - 2 ;
 
         const double fx = xx-ix;
-        const double fxx = fx*fx;
-        const double fxxx = fx*fxx;
 
         const double p1 = data[2+2*ix];
         const double m1 = data[2+2*ix+1]*step;

--- a/src/Utils/include/CalculateUniformSpline.h
+++ b/src/Utils/include/CalculateUniformSpline.h
@@ -69,10 +69,11 @@ namespace {
         // double v = p1*(2.0*fxxx-3.0*fxx+1.0) + m1*(fxxx-2.0*fxx+fx)
         //         + p2*(3.0*fxx-2.0*fxxx) + m2*(fxxx-fxx));
 
-        // A more numerically stable calculation
-        const double t = 3.0*fxx-2.0*fxxx;
-        double v = p1 - p1*t + m1*(fxxx-2.0*fxx+fx)
-                    + p2*t + m2*(fxxx-fxx);
+        // Factored via Horner's method.
+        double v = ((((2.0*p1 - 2.0*p2 + m2 + m1)*fx
+                      + 3.0*p2 - 3.0*p1 - m2 - 2.0*m1)*fx
+                     +m1)*fx
+                    +p1);
 
         if (v < lowerBound) v = lowerBound;
         if (v > upperBound) v = upperBound;

--- a/tests/fast-tests/100CheckCompactSpline.C
+++ b/tests/fast-tests/100CheckCompactSpline.C
@@ -43,24 +43,97 @@ int main() {
     std::cout << "Hello world" << std::endl;
 
     {
-        // Test linear interpolation between two points
         double data[] = {0.0, 1.0, 0.0, 1.0};
-        for (double x = 0.0; x <= 2.0; x += 0.1) {
-            double v = CalculateCompactSpline(x, 0.0, 10.0, data, 2);
-            TOLERANCE("Two Point Tolarance", x, v, 1E-6);
-            std::cout << x << " " << v << std::endl;
+        // Test linear interpolation between two points
+        int p = 0;
+        for (double x = -1.0; x <= 2.0; x += 0.1) {
+            double v = CalculateCompactSpline(x, -10.0, 10.0, data, 2);
+            TOLERANCE("Two Point Tolerance", x, v, 1E-6);
         }
     }
 
     {
         // Test non-linear interpolation between three points
         double data[] = {-1.0, 1.0, 0.0, 1.0, 0.0};
-        for (double x = 0.0; x <= 1.0; x += 0.1) {
-            double v0 = CalculateCompactSpline(x, 0.0, 10.0, data, 3);
-            double v1 = CalculateCompactSpline(-x, 0.0, 10.0, data, 3);
-            TOLERANCE("Symmetric Tolarance", v0, v1, 1E-6);
-            std::cout << x << " " << v0 << " " << v1 << std::endl;
+        int nData = 3;
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
         }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.1; x <= 1.1; x += 0.1) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 2) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        data1->Draw("A*");
+        graph1->Draw("C,same");
+        gPad->Print("100CheckCompactSpline2.pdf");
+        gPad->Print("100CheckCompactSpline2.png");
+    }
+
+    {
+        // Test interpolation between six points
+        int nData = 6;
+        double data[] = {-1.0, 2.0/(nData-1), 0.0, 0.0, 1.0, 1.0, 0.0, 0.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.1; x <= 1.1; x += 0.01) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 3) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+            graph1->SetPoint(p++,x,v0);
+        }
+        data1->Draw("A*");
+        graph1->Draw("C,same");
+        gPad->Print("100CheckCompactSpline3.pdf");
+        gPad->Print("100CheckCompactSpline3.png");
+    }
+
+    {
+        // Test interpolation where there can be a lot of overshoot
+        int nData = 13;
+        double data[] = {-1.0, 2.0/(nData-1),
+                         0.5, 1.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         0.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         1.5, 0.5};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.1; x <= 1.1; x += 0.01) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        data1->Draw("A*");
+        graph1->Draw("C,same");
+        gPad->Print("100CheckCompactSpline4.pdf");
+        gPad->Print("100CheckCompactSpline4.png");
     }
 
     return status;

--- a/tests/fast-tests/100CheckMonotonicSpline.C
+++ b/tests/fast-tests/100CheckMonotonicSpline.C
@@ -8,9 +8,9 @@ root <<EOF
 #include <cmath>
 
 ////////////////////////////////////////////////////////////////////////
-// Test the CalculateCompactSpline routine on the CPU.
+// Test the CalculateMonotonicSpline routine on the CPU.
 
-#include "${GUNDAM_ROOT}/src/Utils/include/CalculateCompactSpline.h"
+#include "${GUNDAM_ROOT}/src/Utils/include/CalculateMonotonicSpline.h"
 
 std::string args{"$*"};
 
@@ -58,14 +58,14 @@ int main() {
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
         for (double x = -1.0; x <= 2.0; x += 0.1) {
-            double v = CalculateCompactSpline(x, -10.0, 10.0, data, 2);
+            double v = CalculateMonotonicSpline(x, -10.0, 10.0, data, 2);
             TOLERANCE("Two Point Tolerance", x, v, 1E-6);
             graph1->SetPoint(p++,x,v);
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckCompactSpline1.pdf");
-        gPad->Print("100CheckCompactSpline1.png");
+        gPad->Print("100CheckMonotonicSpline1.pdf");
+        gPad->Print("100CheckMonotonicSpline1.png");
     }
 #endif
 
@@ -84,8 +84,8 @@ int main() {
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
         for (double x = -1.5; x <= 1.5; x += 0.1) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            double v0 = CalculateMonotonicSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateMonotonicSpline(-x, -10.0, 10.0, data, nData);
             std::ostringstream tmp;
             tmp << "Symmetric tolerance (test 2) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
@@ -93,8 +93,8 @@ int main() {
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckCompactSpline2.pdf");
-        gPad->Print("100CheckCompactSpline2.png");
+        gPad->Print("100CheckMonotonicSpline2.pdf");
+        gPad->Print("100CheckMonotonicSpline2.png");
     }
 #endif
 
@@ -113,8 +113,8 @@ int main() {
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
         for (double x = -1.5; x <= 1.5; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            double v0 = CalculateMonotonicSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateMonotonicSpline(-x, -10.0, 10.0, data, nData);
             std::ostringstream tmp;
             tmp << "Symmetric tolerance (test 3) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
@@ -123,8 +123,8 @@ int main() {
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckCompactSpline3.pdf");
-        gPad->Print("100CheckCompactSpline3.png");
+        gPad->Print("100CheckMonotonicSpline3.pdf");
+        gPad->Print("100CheckMonotonicSpline3.png");
     }
 #endif
 
@@ -148,8 +148,8 @@ int main() {
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
         for (double x = -1.1; x <= 1.1; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            double v0 = CalculateMonotonicSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateMonotonicSpline(-x, -10.0, 10.0, data, nData);
             std::ostringstream tmp;
             tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
@@ -157,8 +157,8 @@ int main() {
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckCompactSpline4.pdf");
-        gPad->Print("100CheckCompactSpline4.png");
+        gPad->Print("100CheckMonotonicSpline4.pdf");
+        gPad->Print("100CheckMonotonicSpline4.png");
     }
 #endif
 
@@ -183,8 +183,8 @@ int main() {
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
         for (double x = -1.5; x <= 1.5; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            double v0 = CalculateMonotonicSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateMonotonicSpline(-x, -10.0, 10.0, data, nData);
             std::ostringstream tmp;
             tmp << "Symmetric tolerance (test 5) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
@@ -192,8 +192,8 @@ int main() {
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckCompactSpline5.pdf");
-        gPad->Print("100CheckCompactSpline5.png");
+        gPad->Print("100CheckMonotonicSpline5.pdf");
+        gPad->Print("100CheckMonotonicSpline5.png");
     }
 #endif
 

--- a/tests/fast-tests/900CovarianceFitCheck-catmull.C
+++ b/tests/fast-tests/900CovarianceFitCheck-catmull.C
@@ -114,24 +114,24 @@ int main() {
     // 100CovarianceTree.C.  They need to be changed if that tree is
     // changed.
     TOLERANCE("Check HESSE value for #0_norm_A",
-              postFitErrorsHesse->GetBinContent(1), 1.01098897, tolerance);
+              postFitErrorsHesse->GetBinContent(1), 1.01026268, tolerance);
     TOLERANCE("Check variance for #0_norm_A",
-              (*covariance)(0,0), 1.47159120e-04, tolerance);
+              (*covariance)(0,0), 1.47099577e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #1_norm_B",
-              postFitErrorsHesse->GetBinContent(2), 9.66679130e-01, tolerance);
+              postFitErrorsHesse->GetBinContent(2), 9.74959268e-01, tolerance);
     TOLERANCE("Check variance for #1_norm_B",
-              (*covariance)(1,1), 1.54976726e-04, tolerance);
+              (*covariance)(1,1), 1.42798481e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #2_spline_C",
-              postFitErrorsHesse->GetBinContent(3), -3.76645381e-02, tolerance);
+              postFitErrorsHesse->GetBinContent(3), -3.14576477e-02, tolerance);
     TOLERANCE("Check variance for #2_spline_C",
-              (*covariance)(2,2), 1.21695737e-04, tolerance);
+              (*covariance)(2,2), 1.15916364e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #3_spline_D",
-              postFitErrorsHesse->GetBinContent(4), 7.52184903e-03, tolerance);
+              postFitErrorsHesse->GetBinContent(4), 3.22459930e-02, tolerance);
     TOLERANCE("Check variance for #3_spline_D",
-              (*covariance)(3,3), 2.31579600e-05, tolerance);
+              (*covariance)(3,3), 1.37589224e-04, tolerance);
 
     file->Close();
 


### PR DESCRIPTION
This mostly fixes CalculateCompactSpline and CalculateMonotonicSpline so that when they extrapolate, the extrapolation is symmetric.  Part of maintaining the CalculateMonotonicSpline symmetry was to change the monotonicity calculation to use the full Fritsche-Carlson method, instead of short cutting.  In addition all of the spline polynomial calculations are updated to use a Horner factorization, and several unused variables have been removed (fewer warnings).