### PR TITLE
Update JSON keys for overriding in gundamCalcXsec

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -111,14 +111,14 @@ int main(int argc, char** argv){
   LogInfo << "Removing defined samples..." << std::endl;
   ConfigUtils::applyOverrides(
       cHandler.getConfig(),
-      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"propagatorConfig":{"fitSampleSetConfig":{"fitSampleList":[]}}}})")
+      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"likelihoodInterfaceConfig":{"dataSetManagerConfig":{"propagatorConfig":{"fitSampleSetConfig":{}}}}}})")
   );
 
   // Disabling defined plots:
   LogInfo << "Removing defined plots..." << std::endl;
   ConfigUtils::applyOverrides(
       cHandler.getConfig(),
-      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"propagatorConfig":{"plotGeneratorConfig":{}}}})")
+      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"likelihoodInterfaceConfig":{"dataSetManagerConfig":{"propagatorConfig":{"plotGeneratorConfig":{}}}}}})")
   );
 
   // Defining signal samples

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -111,7 +111,7 @@ int main(int argc, char** argv){
   LogInfo << "Removing defined samples..." << std::endl;
   ConfigUtils::applyOverrides(
       cHandler.getConfig(),
-      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"likelihoodInterfaceConfig":{"dataSetManagerConfig":{"propagatorConfig":{"fitSampleSetConfig":{}}}}}})")
+      GenericToolbox::Json::readConfigJsonStr(R"({"fitterEngineConfig":{"likelihoodInterfaceConfig":{"dataSetManagerConfig":{"propagatorConfig":{"fitSampleSetConfig":{"fitSampleList":[]}}}}}})")
   );
 
   // Disabling defined plots:


### PR DESCRIPTION
We recently updated `gundam` from 1.7.2 to 1.9.0, and noticed some structural changes in yaml. If I understand the update correctly, before we had 
```
"fitterEngineConfig": {
  "propagatorConfig": {
    "fitSampleSetConfig": {
      "fitSampleList": {

      }
    },
    "plotGeneratorConfig": {

    }
  }
}
```
but now we have
```
"fitterEngineConfig": {
  "likelihoodInterfaceConfig": {
    "dataSetManagerConfig": {
      "propagatorConfig": {
        "fitSampleSetConfig": {
          "fitSampleList": [

          ]
        },
        "plotGeneratorConfig": {

        }
      }
    }
  }
}
```
Please let me know if this is not what was intended! But if this is correct, I found the JSON overriding lines in `gundamCalcXsec.cxx` need  to be changed as well, and tried to update them in this PR.