### PR TITLE
GUNDAM 1.8.0: Fix for issue #485: LLH is throwing when there is a Inf (should continue)

### DIFF
--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -103,8 +103,11 @@ void SampleSet::initializeImpl() {
 double SampleSet::evalLikelihood(){
   double llh = 0.;
   for( auto& sample : _fitSampleList_ ){
-    llh += this->evalLikelihood(sample);
-    LogThrowIf(std::isnan(llh) or std::isinf(llh), sample.getName() << ": reportde likelihood is invalid:" << llh);
+    const double sampleLLH = this->evalLikelihood(sample);
+    LogThrowIf(std::isnan(sampleLLH),
+               sample.getName() << ": reported likelihood is invalid: "
+               << sampleLLH);
+    llh += sampleLLH;
   }
   return llh;
 }


### PR DESCRIPTION
The LLH calculation is throwing a runtime_error if the likelihood returned infinity (a valid likelihood).  This is changed so that it will only throw if the likelihood returns NAN.  That's probably a sign that something didn't get initialized and is still trapped as an error.