### PR TITLE
Resolve LTS 1.8.x  issue493: Add general spline test

### DIFF
--- a/src/Utils/include/CalculateUniformSpline.h
+++ b/src/Utils/include/CalculateUniformSpline.h
@@ -57,13 +57,15 @@ namespace {
         if (2*ix+7>dim) ix = (dim-2)/2 - 2 ;
 
         const double fx = xx-ix;
-        const double fxx = fx*fx;
-        const double fxxx = fx*fxx;
 
         const double p1 = data[2+2*ix];
         const double m1 = data[2+2*ix+1]*step;
         const double p2 = data[2+2*ix+2];
         const double m2 = data[2+2*ix+3]*step;
+
+#ifdef DO_NOT_USE_HORNER_FACTORIZATION
+        const double fxx = fx*fx;
+        const double fxxx = fx*fxx;
 
         // Cubic spline with the points and slopes.
         // double v = p1*(2.0*fxxx-3.0*fxx+1.0) + m1*(fxxx-2.0*fxx+fx)
@@ -73,6 +75,13 @@ namespace {
         const double t = 3.0*fxx-2.0*fxxx;
         double v = p1 - p1*t + m1*(fxxx-2.0*fxx+fx)
                     + p2*t + m2*(fxxx-fxx);
+#else
+        // Factored via Horner's method.
+        double v = ((((2.0*p1 - 2.0*p2 + m2 + m1)*fx
+                      + 3.0*p2 - 3.0*p1 - m2 - 2.0*m1)*fx
+                     +m1)*fx
+                    +p1);
+#endif
 
         if (v < lowerBound) v = lowerBound;
         if (v > upperBound) v = upperBound;
@@ -106,6 +115,6 @@ namespace {
 // Local Variables:
 // mode:c++
 // c-basic-offset:4
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/scripts/gundam-build.sh"
 // End:
 #endif

--- a/tests/fast-tests/100CheckGeneralSpline.C
+++ b/tests/fast-tests/100CheckGeneralSpline.C
@@ -1,0 +1,156 @@
+# !/bin/bash
+# Wrap a ROOT macro as a script.
+root <<EOF
+
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include <TSpline.h>
+
+////////////////////////////////////////////////////////////////////////
+// Test the CalculateGeneralSpline routine on the CPU.
+
+#include "${GUNDAM_ROOT}/src/Utils/include/CalculateGeneralSpline.h"
+
+std::string args{"$*"};
+
+int status{0};
+
+/// Fail if fractional difference between "v1" and "v2" is larger than "tol"
+/// THIS IS COPIED HERE TO AVOID DEPENDENCIES
+#define TOLERANCE(_msg,_v1,_v2,_tol)                              \
+    do {                                                          \
+        double _v = (_v1)>0 ? (_v1): -(_v1);                      \
+        double _vv = (_v2)>0 ? (_v2): -(_v2);                     \
+        double _d = std::abs((_v1)-(_v2));                        \
+        double _r = _d/std::max(0.5*(_v+_vv),(_tol));             \
+        if (_r < (_tol)) {                                        \
+            break;                                                \
+        }                                                         \
+        ++status;                                                 \
+        std::cout << "FAIL:";                                     \
+        std::cout << " " << _msg                                  \
+                  << std::setprecision(8)                         \
+                  << std::scientific                              \
+                  << " (" << _r << "<" << (_tol) << ")"           \
+                  << " [" << #_v1 << "=" << (_v1)                 \
+                  << " " << #_v2 << "=" << (_v2)                  \
+                  << " " << _d << "]"                             \
+                  << std::endl;                                   \
+    } while(false);
+
+int main() {
+    std::cout << "Hello world" << std::endl;
+
+#define TEST1
+#ifdef TEST1
+    {
+        // Define a TSpline3 and make sure that GeneralSpline reproduces it
+        TGraph graph;
+        graph.SetPoint(0,-3.0, 0.0);
+        graph.SetPoint(1, 0.0, 1.0);
+        graph.SetPoint(2, 3.0, 5.5);
+        TSpline3 spline("splineOfGraph",&graph);
+        graph.Draw("AC*");
+        graph.SetMinimum(-0.5);
+        graph.SetMaximum(6.0);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 0.0;
+        std::cout << "Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+3*knot+0] = yy;
+            data[2+3*knot+1] = ss;
+            data[2+3*knot+2] = xx;
+        }
+        TGraph generalSpline;
+        int point = 0;
+        for (double xxx = spline.GetXmin();
+             xxx<=spline.GetXmax(); xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateGeneralSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            generalSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        generalSpline.SetLineWidth(3);
+        generalSpline.SetLineColor(kGreen);
+        generalSpline.Draw("same");
+        gPad->Print("100CheckGeneralSpline1.pdf");
+        gPad->Print("100CheckGeneralSpline1.png");
+    }
+#endif
+
+#define TEST2
+#ifdef TEST2
+    {
+        // Define a TSpline3 and make sure that GeneralSpline reproduces it
+        TGraph graph(3);
+        graph.SetPoint(0,-3.0, 0.0);
+        graph.SetPoint(1, 0.1, 1.0);
+        graph.SetPoint(2, 2.3, 3.5);
+        graph.SetPoint(3, 3.0, 5.5);
+        graph.SetPoint(4, 4.3, 5.8);
+        graph.Draw("AC*");
+        graph.SetMinimum(-1.0);
+        graph.SetMaximum(7.0);
+        TSpline3 spline("splineOfGraph",&graph);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 0.0;
+        std::cout << "Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+3*knot+0] = yy;
+            data[2+3*knot+1] = ss;
+            data[2+3*knot+2] = xx;
+        }
+        TGraph generalSpline;
+        int point = 0;
+        for (double xxx = spline.GetXmin();
+             xxx<=spline.GetXmax(); xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateGeneralSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            generalSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        generalSpline.SetLineWidth(3);
+        generalSpline.SetLineColor(kGreen);
+        generalSpline.Draw("same");
+        gPad->Print("100CheckGeneralSpline2.pdf");
+        gPad->Print("100CheckGeneralSpline2.png");
+    }
+#endif
+
+    return status;
+}
+exit(main());
+EOF
+# Local Variables:
+# mode:c++
+# c-basic-offset:4
+# End:

--- a/tests/fast-tests/100CheckUniformSpline.C
+++ b/tests/fast-tests/100CheckUniformSpline.C
@@ -1,0 +1,154 @@
+# !/bin/bash
+# Wrap a ROOT macro as a script.
+root <<EOF
+
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include <TSpline.h>
+
+////////////////////////////////////////////////////////////////////////
+// Test the CalculateUniformSpline routine on the CPU.
+
+#include "${GUNDAM_ROOT}/src/Utils/include/CalculateUniformSpline.h"
+
+std::string args{"$*"};
+
+int status{0};
+
+/// Fail if fractional difference between "v1" and "v2" is larger than "tol"
+/// THIS IS COPIED HERE TO AVOID DEPENDENCIES
+#define TOLERANCE(_msg,_v1,_v2,_tol)                              \
+    do {                                                          \
+        double _v = (_v1)>0 ? (_v1): -(_v1);                      \
+        double _vv = (_v2)>0 ? (_v2): -(_v2);                     \
+        double _d = std::abs((_v1)-(_v2));                        \
+        double _r = _d/std::max(0.5*(_v+_vv),(_tol));             \
+        if (_r < (_tol)) {                                        \
+            break;                                                \
+        }                                                         \
+        ++status;                                                 \
+        std::cout << "FAIL:";                                     \
+        std::cout << " " << _msg                                  \
+                  << std::setprecision(8)                         \
+                  << std::scientific                              \
+                  << " (" << _r << "<" << (_tol) << ")"           \
+                  << " [" << #_v1 << "=" << (_v1)                 \
+                  << " " << #_v2 << "=" << (_v2)                  \
+                  << " " << _d << "]"                             \
+                  << std::endl;                                   \
+    } while(false);
+
+int main() {
+    std::cout << "Hello world" << std::endl;
+
+#define TEST1
+#ifdef TEST1
+    {
+        // Define a TSpline3 and make sure that UniformSpline reproduces it
+        TGraph graph;
+        graph.SetPoint(0,-3.0, 0.0);
+        graph.SetPoint(1, 0.0, 1.0);
+        graph.SetPoint(2, 3.0, 5.5);
+        TSpline3 spline("splineOfGraph",&graph);
+        graph.Draw("AC*");
+        graph.SetMinimum(-0.5);
+        graph.SetMaximum(6.0);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 2*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 3.0;
+        std::cout << "Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+2*knot+0] = yy;
+            data[2+2*knot+1] = ss;
+        }
+        TGraph uniformSpline;
+        int point = 0;
+        for (double xxx = spline.GetXmin();
+             xxx<=spline.GetXmax(); xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            uniformSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        uniformSpline.SetLineWidth(3);
+        uniformSpline.SetLineColor(kGreen);
+        uniformSpline.Draw("same");
+        gPad->Print("100CheckUniformSpline1.pdf");
+        gPad->Print("100CheckUniformSpline1.png");
+    }
+#endif
+
+#define TEST2
+#ifdef TEST2
+    {
+        // Define a TSpline3 and make sure that UniformSpline reproduces it
+        TGraph graph(3);
+        graph.SetPoint(0,-3.0, 0.0);
+        graph.SetPoint(1,-2.0, 1.0);
+        graph.SetPoint(2,-1.0, 3.5);
+        graph.SetPoint(3, 0.0, 5.5);
+        graph.SetPoint(4, 1.0, 5.8);
+        graph.Draw("AC*");
+        graph.SetMinimum(-1.0);
+        graph.SetMaximum(7.0);
+        TSpline3 spline("splineOfGraph",&graph);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 1.0;
+        std::cout << "Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+2*knot+0] = yy;
+            data[2+2*knot+1] = ss;
+        }
+        TGraph uniformSpline;
+        int point = 0;
+        for (double xxx = spline.GetXmin();
+             xxx<=spline.GetXmax(); xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            uniformSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        uniformSpline.SetLineWidth(3);
+        uniformSpline.SetLineColor(kGreen);
+        uniformSpline.Draw("same");
+        gPad->Print("100CheckUniformSpline2.pdf");
+        gPad->Print("100CheckUniformSpline2.png");
+    }
+#endif
+
+    return status;
+}
+exit(main());
+EOF
+# Local Variables:
+# mode:c++
+# c-basic-offset:4
+# End:


### PR DESCRIPTION
This adds tests for the CalculateGeneralSpline.h function.  As a special bonus it also adds tests for CalculateUniformSpline.h, and resolves unused variable warnings for both those functions.