### PR TITLE
Resolve LTS/1.8.x issue 494: Check spline monotonicity

### DIFF
--- a/src/DialDictionary/DialFactories/include/SplineDialBaseFactory.h
+++ b/src/DialDictionary/DialFactories/include/SplineDialBaseFactory.h
@@ -34,11 +34,6 @@ public:
                       TObject* dialInitializer,
                       const std::string& splType);
 
-  /// Apply the monotonic constraint to the slopes.
-  void MakeMonotonic(const std::vector<double>& xPoint,
-                     const std::vector<double>& yPoint,
-                     std::vector<double>& slope);
-
   /// Implement the factory that constructs a pointer to the correct
   /// DialBase.  This uses the dialType and dialSubType to figure out the
   /// correct class, and then uses the object pointed to by the
@@ -93,7 +88,7 @@ private:
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/scripts/gundam-build.sh"
 // End:
 
 #endif

--- a/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
@@ -8,6 +8,7 @@
 #include "UniformSpline.h"
 #include "GeneralSpline.h"
 #include "MonotonicSpline.h"
+#include "MakeMonotonicSpline.h"
 #include "Shift.h"
 
 #include "TGraph.h"
@@ -174,34 +175,6 @@ void SplineDialBaseFactory::FillAkimaSlopes(
   }
   k = yPoint.size()-1;
   slope[k] = (yPoint[k]-yPoint[k-1])/(xPoint[k]-xPoint[k-1]);
-}
-
-
-void SplineDialBaseFactory::MakeMonotonic(const std::vector<double>& xPoint,
-                                          const std::vector<double>& yPoint,
-                                          std::vector<double>& slope) {
-  // Apply the Fritsh-Carlson monotonic condition to the slopes.  This adjusts
-  // the slopes (when necessary), however, with Catmull-Rom the modified
-  // slopes will be ignored and the monotonic criteria is applied as the
-  // spline is evaluated (saves memory).
-  //
-  // F.N.Fritsch, and R.E.Carlson, "Monotone Piecewise Cubic Interpolation"
-  // SIAM Journal on Numerical Analysis, Vol. 17, Iss. 2 (1980)
-  // doi:10.1137/0717021
-  //
-  for (int i = 0; i<xPoint.size(); ++i) {
-    double m{std::numeric_limits<double>::infinity()};
-    if (i>0) m = (yPoint[i] - yPoint[i-1])/(xPoint[i] - xPoint[i-1]);
-    double p{std::numeric_limits<double>::infinity()};
-    if (i<xPoint.size()-1) p =(yPoint[i+1]-yPoint[i])/(xPoint[i+1]-xPoint[i]);
-    double delta = std::min(std::abs(m),std::abs(p));
-    // This a conservative bound on when the slope is "safe".  It's not the
-    // actual value at which the spline becomes non-monotonic.
-    if (std::abs(slope[i]) > 3.0*delta) {
-      if (slope[i] < 0.0) slope[i] = -3.0*delta;
-      else slope[i] = 3.0*delta;
-    }
-  }
 }
 
 DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
@@ -390,7 +363,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
   // flag that can be checked later.
   ////////////////////////////////////////////////////////////////
   bool isMonotonic = ( dialSubType_.find("monotonic") != std::string::npos );
-  if ( isMonotonic ) { MakeMonotonic(_xPointListBuffer_, _yPointListBuffer_, _slopeListBuffer_); }
+  if ( isMonotonic ) { ::util::MakeMonotonicSpline(_xPointListBuffer_, _yPointListBuffer_, _slopeListBuffer_); }
 
   // If there are only two points, then force a catmull-rom.  This could be
   // handled using a graph, but Catmull-Rom is fast, and works better with the

--- a/src/Utils/include/MakeMonotonicSpline.h
+++ b/src/Utils/include/MakeMonotonicSpline.h
@@ -1,0 +1,76 @@
+#ifndef MakeMonotonicSpline_h_seen
+#define MakeMonotonicSpline_h_seen
+namespace {
+    // Place this in a namespace inside the anonymous namespace!
+    namespace util {
+
+        // Apply the Fritsh-Carlson monotonic condition to the slopes.  This
+        // adjusts the slopes (when necessary), however, with Catmull-Rom the
+        // modified slopes will be ignored and the monotonic criteria is
+        // applied as the spline is evaluated (saves memory).
+        //
+        // F.N.Fritsch, and R.E.Carlson, "Monotone Piecewise Cubic
+        // Interpolation" SIAM Journal on Numerical Analysis, Vol. 17, Iss. 2
+        // (1980) doi:10.1137/0717021
+        void MakeMonotonicSpline(const std::vector<double>& xPoint,
+                                 const std::vector<double>& yPoint,
+                                 std::vector<double>& slope) {
+            for (std::size_t i = 0; i<xPoint.size(); ++i) {
+                double m{std::numeric_limits<double>::infinity()};
+                if (i>0) {
+                    m = (yPoint[i] - yPoint[i-1])/(xPoint[i] - xPoint[i-1]);
+                }
+                else {
+                    m = slope[i];
+                }
+                double p{std::numeric_limits<double>::infinity()};
+                if (i<xPoint.size()-1) {
+                    p =(yPoint[i+1]-yPoint[i])/(xPoint[i+1]-xPoint[i]);
+                }
+                else {
+                    p = slope[i];
+                }
+                double delta = std::min(std::abs(m),std::abs(p));
+                // Make sure the slope at a cusp (where the average slope
+                // flips sign) is zero.
+                if (m*p < 0.0) delta = 0.0;
+                // This a conservative bound on when the slope is "safe".
+                // It's not the actual value where the spline becomes
+                // non-monotonic.
+                if (std::abs(slope[i]) > 3.0*delta) {
+                    if (slope[i] < 0.0) slope[i] = -3.0*delta;
+                    else slope[i] = 3.0*delta;
+                }
+            }
+        }
+    }
+}
+
+// An MIT Style License
+
+// Copyright (c) 2024 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/scripts/gundam-build.sh"
+// End:
+#endif

--- a/tests/fast-tests/100CheckMakeMonotonicSpline.C
+++ b/tests/fast-tests/100CheckMakeMonotonicSpline.C
@@ -1,0 +1,136 @@
+# !/bin/bash
+# Wrap a ROOT macro as a script.
+root <<EOF
+
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include <TSpline.h>
+
+////////////////////////////////////////////////////////////////////////
+// Test the CalculateGeneralSpline routine on the CPU.
+
+#include "${GUNDAM_ROOT}/src/Utils/include/CalculateGeneralSpline.h"
+#include "${GUNDAM_ROOT}/src/Utils/include/MakeMonotonicSpline.h"
+
+std::string args{"$*"};
+
+int status{0};
+
+/// Fail if fractional difference between "v1" and "v2" is larger than "tol"
+/// THIS IS COPIED HERE TO AVOID DEPENDENCIES
+#define TOLERANCE(_msg,_v1,_v2,_tol)                              \
+    do {                                                          \
+        double _v = (_v1)>0 ? (_v1): -(_v1);                      \
+        double _vv = (_v2)>0 ? (_v2): -(_v2);                     \
+        double _d = std::abs((_v1)-(_v2));                        \
+        double _r = _d/std::max(0.5*(_v+_vv),(_tol));             \
+        if (_r < (_tol)) {                                        \
+            break;                                                \
+        }                                                         \
+        ++status;                                                 \
+        std::cout << "FAIL:";                                     \
+        std::cout << " " << _msg                                  \
+                  << std::setprecision(8)                         \
+                  << std::scientific                              \
+                  << " (" << _r << "<" << (_tol) << ")"           \
+                  << " [" << #_v1 << "=" << (_v1)                 \
+                  << " " << #_v2 << "=" << (_v2)                  \
+                  << " " << _d << "]"                             \
+                  << std::endl;                                   \
+    } while(false);
+
+int main() {
+    std::cout << "Hello world" << std::endl;
+
+#define TEST1
+#ifdef TEST1
+    {
+        // Define a TSpline3 and make sure that GeneralSpline reproduces it
+        TGraph graph;
+        int point = 0;
+        graph.SetPoint(point++,-3.0, 0.0);
+        graph.SetPoint(point++, 0.0, 1.0);
+        graph.SetPoint(point++, 1.0, 2.0);
+        graph.SetPoint(point++, 2.0, 4.0);
+        graph.SetPoint(point++, 3.0, 5.0);
+        graph.SetPoint(point++, 4.4, 5.5);
+        graph.SetPoint(point++, 5.1, 4.5);
+        graph.SetPoint(point++, 6.0, 5.5);
+        TSpline3 spline("splineOfGraph",&graph);
+        graph.SetLineStyle(2);
+        graph.Draw("AL*");
+        graph.SetMinimum(-1.0);
+        graph.SetMaximum(6.0);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 0.0;
+        std::cout << "Number of knots " << nKnots << std::endl;
+        std::vector<double> xValues;
+        std::vector<double> yValues;
+        std::vector<double> slopes;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            xValues.push_back(xx);
+            yValues.push_back(yy);
+            slopes.push_back(ss);
+        }
+        for (int knot = 0; knot < nKnots; ++knot) {
+            data[2+3*knot+0] = yValues[knot];
+            data[2+3*knot+1] = slopes[knot];
+            data[2+3*knot+2] = xValues[knot];
+        }
+        TGraph monotonicSpline;
+        ::util::MakeMonotonicSpline(xValues,yValues,slopes);
+        for (int knot = 0; knot < nKnots; ++knot) {
+            data[2+3*knot+0] = yValues[knot];
+            data[2+3*knot+1] = slopes[knot];
+            data[2+3*knot+2] = xValues[knot];
+        }
+        point = 0;
+        double last{-std::numeric_limits<double>::infinity()};
+        int flips = 0;
+        int sign = 1;
+        for (double xxx = spline.GetXmin(); xxx<=spline.GetXmax(); xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateGeneralSpline(xxx,-100.0, 100.0,
+                                         data, dim);
+            if (sign > 0 and last > calcValue) {
+                ++flips;
+                sign = -1;
+            }
+            else if (sign < 0 and last < calcValue) {
+                ++flips;
+                sign = 1;
+            }
+            monotonicSpline.SetPoint(point++, xxx, calcValue);
+            last = calcValue;
+        }
+        TOLERANCE("Test1: Wrong number of flips in spline", flips, 2, 0.1);
+        monotonicSpline.SetLineWidth(2);
+        monotonicSpline.Draw("same");
+        gPad->Print("100CheckMakeMonotonicSpline1.pdf");
+        gPad->Print("100CheckMakeMonotonicSpline1.png");
+    }
+#endif
+
+    return status;
+}
+exit(main());
+EOF
+# Local Variables:
+# mode:c++
+# c-basic-offset:4
+# End:


### PR DESCRIPTION
Adds validation for making the spline knot slopes meet the Fritsche-Carlson monotonicity requirements.  This also separates the actual Fritsche-Carlson code out of the specific DialFactory so that it can be used outside of that class.  It is no longer a class method.