### PR TITLE
Resolve Issue 492: Remove compilation warnings with NVCC

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,3 +1,9 @@
+Fixes relative to 1.8.2
+
+Issue #502 : Update the validation code.  A validation failure caused by the recent corrections to the monotonic spline calculation (#486 and $494) has been fixed.  The expected result has been updated.  Unit testing with GoogleTest has been added and used for the HEMI GPU interface code.  Further tests are being implemented.  
+
+Issue #492 : Fix compiler warnings from NVCC.  This is removing some unused variables.  It also fixes a "fix" that applied some correct C++ conventions to code that is aimed at the GPU (the fix produces inefficient code on a SIMD processor, and was primarily aesthetic.
+
 Fixes relative to 1.8.1
 
 Issue #499 : Update to a new version of the cpp-generic-toolkit submodule. The cpp-generic-toolkit fix sets the branch status to enable branches that are used for the data.

--- a/src/CacheManager/include/hemi/range/range.hpp
+++ b/src/CacheManager/include/hemi/range/range.hpp
@@ -11,7 +11,7 @@
 #define DEVICE_CALLABLE
 #endif
 
-namespace util::lang {
+namespace util { namespace lang {
 
 namespace detail {
 
@@ -21,7 +21,7 @@ struct range_iter_base {
     using value_type = T;
 
     DEVICE_CALLABLE
-    explicit range_iter_base(T current) : current(current) { }
+    range_iter_base(T current) : current(current) { }
 
     DEVICE_CALLABLE
     T operator *() const { return current; }
@@ -49,7 +49,7 @@ struct range_iter_base {
 
     DEVICE_CALLABLE
     bool operator !=(range_iter_base const& other) const {
-        return *this != other;
+        return not (*this == other);
     }
 
 protected:
@@ -260,6 +260,6 @@ indices(std::initializer_list<T>&& cont) {
     return {0, cont.size()};
 }
 
-} // namespace util::lang
+} } // namespace util::lang
 
 #endif // ndef UTIL_LANG_RANGE_HPP

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -154,6 +154,7 @@ bool Cache::Manager::Build(SampleSet& sampleList,
     /// Find the amount of space needed for the cache.
     std::set<const Parameter*> usedParameters;
 
+    int dialErrorCount = 0;
     std::map<std::string, int> useCount;
     for (EventDialCache::CacheElem_t& elem : eventDials.getCache()) {
         if (elem.event->getSampleBinIndex() < 0) {
@@ -201,12 +202,19 @@ bool Cache::Manager::Build(SampleSet& sampleList,
                 ++shifts;
             }
             else {
-                LogError << "Unsupported dial type in CacheManager -- "
+                LogError << "Unsupported dial type -- "
                           << dialType
                           << std::endl;
-                // throw std::runtime_error("unsupported dial");
+                ++dialErrorCount;
             }
         }
+    }
+
+    if (dialErrorCount > 0) {
+        LogError << "Dial creation errors: "
+                 << dialErrorCount
+                 << std::endl;
+        throw std::runtime_error("Unsupported dial type: Incomplete dial implementation");
     }
 
     // Count the total number of histogram cells.
@@ -374,6 +382,7 @@ bool Cache::Manager::Update(SampleSet& sampleList,
         // Get the initial value for this event and save it.
         double initialEventWeight = event.getBaseWeight();
 
+        int dialErrorCount = 0;
         // Add each dial for the event to the GPU caches.
         for (EventDialCache::DialsElem_t& dialElem : elem.dials) {
             DialInterface* dialInterface = dialElem.interface;
@@ -505,11 +514,18 @@ bool Cache::Manager::Update(SampleSet& sampleList,
             if (dialUsed != 1) {
                 LogError << "Problem with dial: " << dialUsed
                           << std::endl;
-                LogError << "Dial Type Name: "
+                LogError << "Unsupported Dial Type Name: "
                           << baseDial->getDialTypeName()
                           << std::endl;
-                // std::runtime_error("Dial use problem");
+                ++dialErrorCount;
             }
+        }
+
+        if (dialErrorCount > 0) {
+            LogError << "Dial creation errors --"
+                     << " Unsupported dial types: " << dialErrorCount
+                     << std::endl;
+            throw std::runtime_error("Unsupported dial type: Incomplete dial implementation");
         }
 
         // Set the initial weight for the event.  This is done here since the

--- a/src/CacheManager/src/WeightCompactSpline.cpp
+++ b/src/CacheManager/src/WeightCompactSpline.cpp
@@ -338,8 +338,6 @@ namespace {
             const int id1 = sIndex[i+1];
             const int dim = id1-id0-2;
             const double x = params[pIndex[i]];
-            const double lowBound = knots[id0];
-            const double step = 1.0/knots[id0+1];
             const double lClamp = lowerClamp[pIndex[i]];
             const double uClamp = upperClamp[pIndex[i]];
 

--- a/src/CacheManager/src/WeightMonotonicSpline.cpp
+++ b/src/CacheManager/src/WeightMonotonicSpline.cpp
@@ -339,8 +339,6 @@ namespace {
             const int id1 = sIndex[i+1];
             const int dim = id1-id0-2;
             const double x = params[pIndex[i]];
-            const double lowBound = knots[id0];
-            const double step = 1.0/knots[id0+1];
             const double lClamp = lowerClamp[pIndex[i]];
             const double uClamp = upperClamp[pIndex[i]];
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,58 @@
-# Run the gundam-tests.sh script for the test target (i.e. make test)
+# Define tests.  These are run via `CTest', or by hand.  The "make
+# test" target will also run ctest so the tests can be easily added to the build
 #
 #  This places the output of the test script in
 #  ${CMAKE_BINARY_DIR}/Testing/Temporary/LastTest.log and the output
 #  of the individual gundam tests in to
-#  ${CMAKE_BINARY_DIR}/tests/output.<date>
-#
-# The COMMAND is a little complicated since the testing script needs
-# to run in the source directory, but puts the output in a
-# sub-directory of the binary directory.
+#  ${CMAKE_BINARY_DIR}/Testing/gundam-tests.<date>
 #
 
-cmessage( STATUS "Setting up test command..." )
+cmessage( STATUS "Setting up tests..." )
+
+# Run the gundam-tests.sh script which runs scripted tests.  The
+# COMMAND is a little complicated since the testing script needs to
+# run in the source directory, but puts the output in a sub-directory
+# of the binary directory.  The variable GUNDAM_TESTS_ARGUMENT may be
+# set from the CMAKE (i.e. -DGUNDAM_TESTS_ARGUMENT="value") command
+# line, or it will take a default value of "-f".  The useful values
+# are "-f" for fast test, "-r" for regular tests, "-e" for extended
+# tests, and "-s" for slow tests.
+#
+if(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
+  set(GUNDAM_TESTS_ARGUMENT "-f")
+endif(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
+
 add_test(
     NAME gundam-tests
-    COMMAND "sh" "-c" "(cd ${CMAKE_SOURCE_DIR}/tests && ./gundam-tests.sh -f -a ${CMAKE_CURRENT_BINARY_DIR}/output.$(date +%Y-%m-%d-%H%M%S) )"
+    COMMAND "sh" "-c" "(cd ${CMAKE_SOURCE_DIR}/tests && ./gundam-tests.sh ${GUNDAM_TESTS_ARGUMENT} -a ${CMAKE_BINARY_DIR}/Testing/gundam-tests.$(date +%Y-%m-%d-%H%M%S) )"
 )
+
+## Compiled unit tests using GoogleTest.  These are only run if GTest
+## is found.
+find_package(GTest)
+if(GTEST_FOUND)
+  enable_testing()
+
+  # Setup the hemi test suite for the host
+  add_executable(hemiTest_host.exe
+    GTests/hemiArrayTest.cpp
+    GTests/hemiExecutionPolicyTest.cpp
+    GTests/hemiExternals.cpp)
+  target_link_libraries(hemiTest_host.exe GTest::gtest_main)
+  target_link_libraries(hemiTest_host.exe GundamCache)
+  target_compile_definitions(hemiTest_host.exe PUBLIC HEMI_CUDA_DISABLE)
+  gtest_discover_tests(hemiTest_host.exe)
+
+  if(CMAKE_CUDA_COMPILER)
+    # Setup the hemi test suite for the device.
+    add_executable(hemiTest_device.exe
+      GTests/hemiArrayTest.cu
+      GTests/hemiExecutionPolicyTest.cu
+      GTests/hemiLaunch.cu
+      GTests/hemiExternals.cpp)
+    target_link_libraries(hemiTest_device.exe GTest::gtest_main)
+    target_link_libraries(hemiTest_device.exe GundamCache)
+    gtest_discover_tests(hemiTest_device.exe)
+  endif(CMAKE_CUDA_COMPILER)
+
+endif(GTEST_FOUND)

--- a/tests/GTests/README-GTests.md
+++ b/tests/GTests/README-GTests.md
@@ -1,0 +1,9 @@
+# Unit tests written using GoogleTest
+
+This directory contains the source files for unit tests written using
+the GoogleTest library.  The GoogleTest library will need to have been
+externally installed on the system running the tests.  If it is found
+by cmake, then these tests will be added to `make test` and run under
+the control of ctest.
+
+

--- a/tests/GTests/hemiArrayTest.cpp
+++ b/tests/GTests/hemiArrayTest.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include "hemi/array.h"
+#include "hemi/launch.h"
+#include "hemi/grid_stride_range.h"
+#include <algorithm>
+
+#include "gtest/gtest.h"
+
+#ifdef HEMI_CUDA_COMPILER
+#define ASSERT_SUCCESS(res) ASSERT_EQ(cudaSuccess, (res));
+#define ASSERT_FAILURE(res) ASSERT_NE(cudaSuccess, (res));
+#define hemiArrayTest hemiArrayTestDevice
+#else
+#define ASSERT_SUCCESS(res)
+#define ASSERT_FAILURE(res)
+#define hemiArrayTest hemiArrayTestHost
+#endif
+
+TEST(hemiArrayTest, CreatesAndFillsArrayOnHost)
+{
+	const int n = 1000000;
+	const float val = 3.14159f;
+	hemi::Array<float> data(n);
+
+	ASSERT_EQ(data.size(), n);
+
+	float *ptr = data.writeOnlyHostPtr();
+	std::fill(ptr, ptr+n, val);
+
+	for(int i = 0; i < n; i++) {
+		ASSERT_EQ(val, data.readOnlyHostPtr()[i]);
+	}
+}
+
+namespace {
+    // A function to be used as the kernel on either the CPU or GPU.  This
+    // must be valid CUDA coda.
+    HEMI_KERNEL_FUNCTION(HEMIFill, float* ptr, int N, float val) {
+        for (int i : hemi::grid_stride_range(0,N)) {
+            ptr[i] = val;
+        }
+    }
+}
+
+void fillOnDevice(float* ptr, int n, float val) {
+    HEMIFill fillArray;
+    hemi::launch(fillArray,ptr,n,val);
+}
+
+TEST(hemiArrayTest, CreatesAndFillsArrayOnDevice)
+{
+	const int n = 1000000;
+	const float val = 3.14159f;
+	hemi::Array<float> data(n);
+
+	ASSERT_EQ(data.size(), n);
+
+	fillOnDevice(data.writeOnlyPtr(), n, val);
+
+	for(int i = 0; i < n; i++) {
+		ASSERT_EQ(val, data.readOnlyPtr(hemi::host)[i]);
+	}
+
+	ASSERT_SUCCESS(hemi::deviceSynchronize());
+}
+
+namespace {
+    // A function to be used as the kernel on either the CPU or GPU.  This
+    // must be valid CUDA coda.
+    HEMI_KERNEL_FUNCTION(HEMISquare, float* ptr, int N) {
+        for (int i : hemi::grid_stride_range(0,N)) {
+            ptr[i] = ptr[i]*ptr[i];
+        }
+    }
+}
+
+void squareOnDevice(hemi::Array<float> &a) {
+        HEMISquare squareArray;
+        hemi::launch(squareArray,a.ptr(),a.size());
+}
+
+TEST(hemiArrayTest, FillsOnHostModifiesOnDevice)
+{
+	const int n = 50;
+	const float val = 3.14159f;
+	hemi::Array<float> data(n);
+
+	ASSERT_EQ(data.size(), n);
+
+	float *ptr = data.writeOnlyHostPtr();
+	std::fill(ptr, ptr+n, val);
+
+	squareOnDevice(data);
+
+	for(int i = 0; i < n; i++) {
+		ASSERT_EQ(val*val, data.readOnlyPtr(hemi::host)[i]);
+	}
+
+	ASSERT_SUCCESS(hemi::deviceSynchronize());
+}

--- a/tests/GTests/hemiArrayTest.cu
+++ b/tests/GTests/hemiArrayTest.cu
@@ -1,0 +1,4 @@
+#ifndef __CUDACC__
+#error NOT A CUDA COMPILER
+#endif
+#include "hemiArrayTest.cpp"

--- a/tests/GTests/hemiExecutionPolicyTest.cpp
+++ b/tests/GTests/hemiExecutionPolicyTest.cpp
@@ -1,0 +1,175 @@
+#include "gtest/gtest.h"
+#include "hemi/hemi.h"
+#include "hemi/execution_policy.h"
+
+#ifdef HEMI_CUDA_COMPILER
+#define ASSERT_SUCCESS(res) ASSERT_EQ(cudaSuccess, (res));
+#define ASSERT_FAILURE(res) ASSERT_NE(cudaSuccess, (res));
+#define hemiExecutionPolicyTest hemiExecutionPolicyTestDevice
+#else
+#define ASSERT_SUCCESS(res)
+#define ASSERT_FAILURE(res)
+#define hemiExecutionPolicyTest hemiExecutionPolicyTestHost
+#endif
+
+using namespace hemi;
+
+// Ensure we are setting appropriate level of configuration
+// Automatic to Full Manual spectrum
+TEST(hemiExecutionPolicyTest, StateReflectsConfiguration) {
+	// Defaults: fully automatic
+	ExecutionPolicy p;
+    int configState = p.getConfigState();
+    EXPECT_EQ (ExecutionPolicy::Automatic,  configState);
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_EQ (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_EQ (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_EQ (0, configState & ExecutionPolicy::GridSize);
+	EXPECT_EQ (0, p.getGridSize());
+	EXPECT_EQ (0, p.getBlockSize());
+	EXPECT_EQ (0, p.getSharedMemBytes());
+
+	// shared memory only
+    p = ExecutionPolicy(); // reset
+    p.setSharedMemBytes( 1024 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic,  configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_EQ (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_EQ (0, configState & ExecutionPolicy::GridSize);
+	EXPECT_EQ (0, p.getGridSize());
+	EXPECT_EQ (0, p.getBlockSize());
+	EXPECT_EQ (1024, p.getSharedMemBytes());
+
+    // Block Size Only
+    p = ExecutionPolicy(); // reset
+    p.setBlockSize( 512 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic,  configState);
+    EXPECT_EQ (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_NE (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_EQ (0, configState & ExecutionPolicy::GridSize);
+    EXPECT_EQ (0, p.getGridSize());
+	EXPECT_EQ (512, p.getBlockSize());
+	EXPECT_EQ (0, p.getSharedMemBytes());
+
+    // Block Size and Shared Memory Only
+    p = ExecutionPolicy(); // reset
+    p.setBlockSize( 512 );
+    p.setSharedMemBytes( 1024 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic,  configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_NE (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_EQ (0, configState & ExecutionPolicy::GridSize);
+    EXPECT_EQ (0, p.getGridSize());
+	EXPECT_EQ (512, p.getBlockSize());
+	EXPECT_EQ (1024, p.getSharedMemBytes());
+
+    // Grid Size Only
+    p = ExecutionPolicy(); // reset
+    p.setGridSize( 100 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_EQ (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_EQ (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_NE (0, configState & ExecutionPolicy::GridSize);
+    EXPECT_EQ (100, p.getGridSize());
+	EXPECT_EQ (0, p.getBlockSize());
+	EXPECT_EQ (0, p.getSharedMemBytes());
+
+    // Grid Size and Shared Memory Only
+    p = ExecutionPolicy(); // reset
+    p.setGridSize( 100 );
+    p.setSharedMemBytes( 1024 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_EQ (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_NE (0, configState & ExecutionPolicy::GridSize);
+	EXPECT_EQ (100, p.getGridSize());
+	EXPECT_EQ (0, p.getBlockSize());
+	EXPECT_EQ (1024, p.getSharedMemBytes());
+
+    // Grid Size and Block Size Only
+    p = ExecutionPolicy(); // reset
+    p.setGridSize( 100 );
+    p.setBlockSize( 512 );
+    configState = p.getConfigState();
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_EQ (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_NE (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_NE (0, configState & ExecutionPolicy::GridSize);
+	EXPECT_EQ (100, p.getGridSize());
+	EXPECT_EQ (512, p.getBlockSize());
+	EXPECT_EQ (0, p.getSharedMemBytes());
+
+    // Full Manual Configuration
+    p = ExecutionPolicy{1, 256, 10};
+    configState = p.getConfigState();
+    EXPECT_EQ (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_NE (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_NE (0, configState & ExecutionPolicy::GridSize);
+   	EXPECT_EQ (1, p.getGridSize());
+	EXPECT_EQ (256, p.getBlockSize());
+	EXPECT_EQ (10, p.getSharedMemBytes());
+
+	// Full Manual Configuration With Separate Calls
+    p = ExecutionPolicy(); // reset
+    p.setGridSize( 100 );
+    p.setBlockSize( 512 );
+    p.setSharedMemBytes( 1024);
+    configState = p.getConfigState();
+    EXPECT_EQ (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+    EXPECT_NE (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_NE (0, configState & ExecutionPolicy::GridSize);
+   	EXPECT_EQ (100, p.getGridSize());
+	EXPECT_EQ (512, p.getBlockSize());
+	EXPECT_EQ (1024, p.getSharedMemBytes());
+
+	p = ExecutionPolicy(); // reset
+    p.setGridSize( 0 );
+    p.setBlockSize( 0 );
+    p.setSharedMemBytes( 0 );
+    configState = p.getConfigState();
+
+	// Setting Zero Shared Memory makes it *Manual*
+    EXPECT_NE (ExecutionPolicy::FullManual, configState);
+    EXPECT_NE (ExecutionPolicy::Automatic, configState);
+    EXPECT_NE (0, configState & ExecutionPolicy::SharedMem);
+
+    // Setting 0 grid or block size makes them *Automatic*
+    EXPECT_EQ (0, configState & ExecutionPolicy::BlockSize);
+    EXPECT_EQ (0, configState & ExecutionPolicy::GridSize);
+   	EXPECT_EQ (0, p.getGridSize());
+	EXPECT_EQ (0, p.getBlockSize());
+	EXPECT_EQ (0, p.getSharedMemBytes());
+
+	// Re-setting block or grid size to >0 should set them to manual
+	p.setGridSize( 100 );
+	p.setBlockSize( 512 );
+	configState = p.getConfigState();
+	EXPECT_NE(0, configState & ExecutionPolicy::GridSize);
+	EXPECT_NE(0, configState & ExecutionPolicy::BlockSize);
+
+	// Re-setting block or grid size to zero should set them to automatic
+	p.setGridSize( 0 );
+	p.setBlockSize( 0 );
+	configState = p.getConfigState();
+	EXPECT_EQ(0, configState & ExecutionPolicy::GridSize);
+	EXPECT_EQ(0, configState & ExecutionPolicy::BlockSize);
+
+    // Setting stream (trivial)
+        p.setStream((hemiStream_t) 1);
+        EXPECT_EQ((hemiStream_t)1, p.getStream());
+}

--- a/tests/GTests/hemiExecutionPolicyTest.cu
+++ b/tests/GTests/hemiExecutionPolicyTest.cu
@@ -1,0 +1,4 @@
+#ifndef __CUDACC__
+#error NOT A CUDA COMPILER
+#endif
+#include "hemiExecutionPolicyTest.cpp"

--- a/tests/GTests/hemiExternals.cpp
+++ b/tests/GTests/hemiExternals.cpp
@@ -1,0 +1,5 @@
+// This is complete and total KLUDGE necessary for pre c++17 compilers.  If
+// you are using a later compiler HEMI_EXTERNAL_DEFINITIONS is empty.
+
+#define HEMI_DEFINITION_COMPILATION
+#include <hemi/hemi.h>

--- a/tests/GTests/hemiLaunch.cu
+++ b/tests/GTests/hemiLaunch.cu
@@ -1,0 +1,219 @@
+#include "gtest/gtest.h"
+#include "hemi/hemi.h"
+#include "hemi/launch.h"
+
+#define ASSERT_SUCCESS(res) ASSERT_EQ(cudaSuccess, (res));
+#define ASSERT_FAILURE(res) ASSERT_NE(cudaSuccess, (res));
+
+// for testing hemi::launch()
+struct KernelClass {
+	template <typename... Arguments>
+	HEMI_DEV_CALLABLE_MEMBER void operator()(int *count, int *bdim, int *gdim, Arguments... args) {
+		*count = sizeof...(args);
+		*bdim = blockDim.x;
+		*gdim = gridDim.x;
+	}
+};
+
+// for testing hemi::cudaLaunch()
+template <typename... Arguments>
+HEMI_LAUNCHABLE void KernelFunc(int *count, int *bdim, int *gdim, Arguments... args) {
+	KernelClass k;
+	k(count, bdim, gdim, args...);
+}
+
+class hemiLaunchTestDevice : public ::testing::Test {
+protected:
+  virtual void SetUp() {
+  	cudaMalloc(&dCount, sizeof(int));
+    cudaMalloc(&dBdim, sizeof(int));
+	cudaMalloc(&dGdim, sizeof(int));
+
+	int devId;
+	cudaGetDevice(&devId);
+	cudaDeviceGetAttribute(&smCount, cudaDevAttrMultiProcessorCount, devId);
+  }
+
+  virtual void TearDown() {
+  	cudaFree(dCount);
+  	cudaFree(dBdim);
+  	cudaFree(dGdim);
+  }
+
+  KernelClass kernel;
+  int smCount;
+
+  int *dCount;
+
+  int *dBdim;
+  int *dGdim;
+
+  int count;
+
+  int bdim;
+  int gdim;
+};
+
+
+TEST_F(hemiLaunchTestDevice, CorrectVariadicParams) {
+        hemi::launch(kernel, dCount, dBdim, dGdim, 1);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 1);
+
+	hemi::launch(kernel, dCount, dBdim, dGdim, 1, 2);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 2);
+
+	hemi::launch(kernel, dCount, dBdim, dGdim, 1, 2, 'a', 4.0, "hello");
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 5);
+}
+
+TEST_F(hemiLaunchTestDevice, AutoConfigMaximalLaunch) {
+	hemi::launch(kernel, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_GE(gdim, smCount);
+	ASSERT_EQ(gdim%smCount, 0);
+	ASSERT_GE(bdim, 32);
+}
+
+TEST_F(hemiLaunchTestDevice, ExplicitBlockSize)
+{
+	hemi::ExecutionPolicy ep;
+	ep.setBlockSize(128);
+	hemi::launch(ep, kernel, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_GE(gdim, smCount);
+	ASSERT_EQ(gdim%smCount, 0);
+	ASSERT_EQ(bdim, 128);
+}
+
+TEST_F(hemiLaunchTestDevice, ExplicitGridSize)
+{
+	hemi::ExecutionPolicy ep;
+	ep.setGridSize(100);
+	hemi::launch(ep, kernel, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_EQ(gdim, 100);
+	ASSERT_GE(bdim, 32);
+}
+
+TEST_F(hemiLaunchTestDevice, InvalidConfigShouldFail)
+{
+	// Fail due to block size too large
+	hemi::ExecutionPolicy ep;
+	ep.setBlockSize(10000);
+        try {
+            hemi::launch(ep, kernel, dCount, dBdim, dGdim);
+            ASSERT_FAILURE(checkCudaErrors());
+        }
+        catch (...) {
+            ASSERT_SUCCESS(checkCudaErrors());
+        }
+
+
+	// Fail due to excessive shared memory size
+	ep.setBlockSize(0);
+	ep.setGridSize(0);
+	ep.setSharedMemBytes(1000000);
+        try {
+            hemi::launch(ep, kernel, dCount, dBdim, dGdim);
+            ASSERT_FAILURE(checkCudaErrors());
+        }
+        catch (...) {
+            ASSERT_SUCCESS(checkCudaErrors());
+        }
+}
+
+TEST_F(hemiLaunchTestDevice, CorrectVariadicParams_cudaLaunch) {
+	hemi::cudaLaunch(KernelFunc, dCount, dBdim, dGdim, 1);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 1);
+
+	hemi::cudaLaunch(KernelFunc, dCount, dBdim, dGdim, 1, 2);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 2);
+
+	hemi::cudaLaunch(KernelFunc, dCount, dBdim, dGdim, 1, 2, 'a', 4.0, "hello");
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&count, dCount, sizeof(int), cudaMemcpyDefault));
+	ASSERT_EQ(count, 5);
+}
+
+TEST_F(hemiLaunchTestDevice, AutoConfigMaximalLaunch_cudaLaunch) {
+	hemi::cudaLaunch(KernelFunc, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_GE(gdim, smCount);
+	ASSERT_EQ(gdim%smCount, 0);
+	ASSERT_GE(bdim, 32);
+}
+
+TEST_F(hemiLaunchTestDevice, ExplicitBlockSize_cudaLaunch)
+{
+	hemi::ExecutionPolicy ep;
+	ep.setBlockSize(128);
+	hemi::cudaLaunch(ep, KernelFunc, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_GE(gdim, smCount);
+	ASSERT_EQ(gdim%smCount, 0);
+	ASSERT_EQ(bdim, 128);
+}
+
+TEST_F(hemiLaunchTestDevice, ExplicitGridSize_cudaLaunch)
+{
+	hemi::ExecutionPolicy ep;
+	ep.setGridSize(100);
+	hemi::cudaLaunch(ep, KernelFunc, dCount, dBdim, dGdim);
+	ASSERT_SUCCESS(cudaDeviceSynchronize());
+	ASSERT_SUCCESS(cudaMemcpy(&bdim, dBdim, sizeof(int), cudaMemcpyDefault));
+	ASSERT_SUCCESS(cudaMemcpy(&gdim, dGdim, sizeof(int), cudaMemcpyDefault));
+
+	ASSERT_EQ(gdim, 100);
+	ASSERT_GE(bdim, 32);
+}
+
+TEST_F(hemiLaunchTestDevice, InvalidConfigShouldFail_cudaLaunch)
+{
+	// Fail due to block size too large
+	hemi::ExecutionPolicy ep;
+	ep.setBlockSize(10000);
+        try {
+            hemi::cudaLaunch(ep, KernelFunc, dCount, dBdim, dGdim);
+            ASSERT_FAILURE(checkCudaErrors());
+        }
+        catch (...) {
+            ASSERT_SUCCESS(checkCudaErrors());
+        }
+
+	// Fail due to excessive shared memory size
+	ep.setBlockSize(0);
+	ep.setGridSize(0);
+	ep.setSharedMemBytes(1000000);
+        try {
+            hemi::cudaLaunch(ep, KernelFunc, dCount, dBdim, dGdim);
+            ASSERT_FAILURE(checkCudaErrors());
+        }
+        catch (...) {
+            ASSERT_SUCCESS(checkCudaErrors());
+        }
+}

--- a/tests/GTests/hemiPortableLaunchTest.cpp
+++ b/tests/GTests/hemiPortableLaunchTest.cpp
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+#include "hemi/launch.h"
+
+#ifdef HEMI_CUDA_COMPILER
+#define ASSERT_SUCCESS(res) ASSERT_EQ(cudaSuccess, (res));
+#define ASSERT_FAILURE(res) ASSERT_NE(cudaSuccess, (res));
+#define hemiPortableLaunchTest hemiPortableLaunchTestDevice
+#else
+#define ASSERT_SUCCESS(res)
+#define ASSERT_FAILURE(res)
+#define hemiPortableLaunchTest hemiPortableLaunchTestHost
+#endif
+
+HEMI_MEM_DEVICE int result;
+HEMI_MEM_DEVICE int rGDim;
+HEMI_MEM_DEVICE int rBDim;
+
+template <typename T, typename... Arguments>
+HEMI_DEV_CALLABLE
+T first(T f, Arguments...) {
+	return f;
+}
+
+template <typename... Arguments>
+struct k {
+	HEMI_DEV_CALLABLE_MEMBER void operator()(Arguments... args) const {
+		result = first(args...); //sizeof...(args);
+#ifdef HEMI_DEV_CODE
+		rGDim = 1;//gridDim.x;
+		rBDim = 1;//blockDim.x;
+#endif
+	}
+};
+
+TEST(hemiPortableLaunchTest, KernelFunction_AutoConfig) {
+	k<int> kernel;
+	hemi::launch(kernel, 1);
+}

--- a/tests/GTests/hemiPortableLaunchTest.cu
+++ b/tests/GTests/hemiPortableLaunchTest.cu
@@ -1,0 +1,4 @@
+#ifndef __CUDACC__
+#error NOT A CUDA COMPILER
+#endif
+#include "hemiPortableLaunchTest.cpp"

--- a/tests/fast-tests/900CovarianceFitCheck-catmull.C
+++ b/tests/fast-tests/900CovarianceFitCheck-catmull.C
@@ -114,24 +114,24 @@ int main() {
     // 100CovarianceTree.C.  They need to be changed if that tree is
     // changed.
     TOLERANCE("Check HESSE value for #0_norm_A",
-              postFitErrorsHesse->GetBinContent(1), 1.01098897, tolerance);
+              postFitErrorsHesse->GetBinContent(1), 1.01026268, tolerance);
     TOLERANCE("Check variance for #0_norm_A",
-              (*covariance)(0,0), 1.47159120e-04, tolerance);
+              (*covariance)(0,0), 1.470995770e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #1_norm_B",
-              postFitErrorsHesse->GetBinContent(2), 9.66679130e-01, tolerance);
+              postFitErrorsHesse->GetBinContent(2), 9.74959268e-01, tolerance);
     TOLERANCE("Check variance for #1_norm_B",
-              (*covariance)(1,1), 1.54976726e-04, tolerance);
+              (*covariance)(1,1), 1.4279848e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #2_spline_C",
-              postFitErrorsHesse->GetBinContent(3), -3.76645381e-02, tolerance);
+              postFitErrorsHesse->GetBinContent(3), -3.14576477e-02, tolerance);
     TOLERANCE("Check variance for #2_spline_C",
-              (*covariance)(2,2), 1.21695737e-04, tolerance);
+              (*covariance)(2,2), 1.15916364e-04, tolerance);
 
     TOLERANCE("Check HESSE value for #3_spline_D",
-              postFitErrorsHesse->GetBinContent(4), 7.52184903e-03, tolerance);
+              postFitErrorsHesse->GetBinContent(4), 3.2245993e-02, tolerance);
     TOLERANCE("Check variance for #3_spline_D",
-              (*covariance)(3,3), 2.31579600e-05, tolerance);
+              (*covariance)(3,3), 1.37589224e-04, tolerance);
 
     file->Close();
 


### PR DESCRIPTION
This merge is fixing several testing bugs, as well as the main purpose of removing compilation warnings seen with NVCC, 

1. Fix a lot of NVCC errors.  There are still some errors in the generic tool kit code, but the problems appear to be coming with code using C functions, so it needs a rewrite.
2. Fix a test that got missed when issue #494 was resolved.
3. Add tests for all hemi.  These are unit tests using googletest and will only be run if googletest is installed on the building machine.  There is also a new upstream version of hemi that we can import later (maybe)
4. Enable checks for valid inputs that had been disabled (probably as part of some past debugging).  The checks should never be triggered, but if they are triggered, the fit will be wrong.