### PR TITLE
Resolve Issue #501: Errors while using gundam-setup.sh and gundam-build.sh

### DIFF
--- a/cmake/scripts/gundam-build.sh
+++ b/cmake/scripts/gundam-build.sh
@@ -8,15 +8,23 @@
 #     force -- Force cmake to ignore the cache
 #     cmake -- Don't compile the source (only run cmake).
 #     clean -- Run clean the build area after running cmake (run make clean)
-#     keep  -- Keep going when there is a compilation error (add -k to make)
+#     keep-going  -- Continue after compilation errors (add -k to make)
+#     ctest -- Run tests directly with ctest
 #     test  -- Run tests after the build
 #     verbose -- Run make with verbose turned on.
 #     help  -- This message
 #
 #     -D<CMAKE_DEFINE> -- Add a definition to the cmake command.
 #
-# Set the GUNDAM_JOBS shell variable to control the number of threads
-# used during the compilation (defaults to 1).
+# Set the GUNDAM_JOBS environment variable (defaults to 1) to control
+# the number of threads used during the compilation.
+#
+# Set the GUNDAM_CMAKE_DEFINES environment variable (defaults to "")
+# to provide default cmake command line definitions.  This can be used
+# to override the defaults set in cmake/options.cmake for a particular
+# system.  e.g. A system that has GPU might want to use:
+#
+# `export GUNDAM_CMAKE_DEFINES="-DWITH_CUDA_LIB=ON"`
 
 # Check that the source root directory is defined.
 if [ ${#GUNDAM_ROOT} == 0 ]; then
@@ -41,6 +49,9 @@ if [ ${#GUNDAM_BUILD} == 0 ]; then
     fi
 else
     BUILD_LOCATION=${GUNDAM_BUILD}
+    echo GUNDAM will be built use specified location
+    echo Build Location: ${BUILD_LOCATION}
+    echo The location must be created before gundam can be built.
 fi
 
 # Make sure the build directory exists (safety check).
@@ -61,6 +72,7 @@ RUN_CLEAN="no"
 RUN_TEST="no"
 DEFINES=" -DCMAKE_INSTALL_PREFIX=${GUNDAM_INSTALL} "
 DEFINES="${DEFINES} -DCMAKE_EXPORT_COMPILE_COMMANDS=1 "
+DEFINES="${GUNDAM_CMAKE_DEFINES} ${DEFINES}"
 if [ "x${GUNDAM_JOBS}" == x ]; then
     GUNDAM_JOBS=1
     echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -96,24 +108,32 @@ while [ "x${1}" != "x" ]; do
             echo Continue on errors
             MAKE_OPTIONS=" -k ${MAKE_OPTIONS}"
             ;;
-        te*) # test
+        ctest*) # test
+            shift
+            echo Run ctest
+            RUN_TEST="ctest"
+            ;;
+        test*) # test
             shift
             echo Run tests
-            RUN_TEST="yes"
+            RUN_TEST="make-test"
             ;;
         ve*) # verbose
             shift
             export VERBOSE=true
             ;;
         he*) # help
-            echo "gundam-build [force] [cmake] [clean] [help] [-D<cmake-define>]"
+            echo 
+            echo "gundam-build [help|force|...] [-D<cmake-definitions>]"
             echo "   force -- Force cmake to ignore the cache"
             echo "   cmake -- Don't build the package (only run cmake)"
             echo "   clean -- Run make clean after cmake"
             echo "   keep  -- Keep going on a compilation error (make -k)"
+            echo "   ctest <ctest-arguments> -- Run ctest on the build"
             echo "   test  -- Run tests after the build"
             echo "   verbose -- Run make with verbose turned on."
             echo "   help  -- This message"
+            echo 
             exit 0
             ;;
         -D*) # Add definitions
@@ -122,21 +142,25 @@ while [ "x${1}" != "x" ]; do
             shift
             ;;
         *)
-            shift
             break
             ;;
     esac
 done
 
-if [ ! -f CMakeCache.txt ]; then
-    echo cmake ${DEFINES} ${GUNDAM_ROOT}
-    cmake ${DEFINES} ${GUNDAM_ROOT}
-fi
-
 if [ ${RUN_CLEAN} = "yes" ]; then
+    if [ ! -f Makefile ]; then
+        echo ERROR: Makefile does not exist -- cannot clean.
+        exit 1;
+    fi
     echo make clean
     make ${MAKE_OPTIONS} clean
     echo Source cleaned.
+    exit 0
+fi
+
+if [ ! -f CMakeCache.txt ]; then
+    echo cmake ${DEFINES} ${GUNDAM_ROOT}
+    cmake ${DEFINES} ${GUNDAM_ROOT}
 fi
 
 if [ ${ONLY_CMAKE} = "yes" ]; then
@@ -148,8 +172,13 @@ make ${MAKE_OPTIONS} || exit 1
 echo make install
 make ${MAKE_OPTIONS} install || exit 1
 
-if [ ${RUN_TEST} = "yes" ]; then
-    echo make test
+if [ ${RUN_TEST} = "ctest" ]; then
+    echo Run ctest $*
+    ctest $* || exit 1
+fi
+
+if [ ${RUN_TEST} = "make-test" ]; then
+    echo Run make test
     make ${MAKE_OPTIONS} test || exit 1
 fi
 

--- a/cmake/scripts/gundam-setup.sh
+++ b/cmake/scripts/gundam-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Setup the GUNDAM directory for development (or simply
 # running the test).  This makes sure that the ROOT environment
@@ -20,6 +20,20 @@
 # cmake -DCMAKE_INSTALL_PREFIX=the-install-directory the-gundam-directory 
 # make
 # make install
+
+if [ "x${BASH_VERSION}" = "x" ]; then
+    echo
+    echo ERROR: Setup script requires bash.  The GUNDAM build can be hand
+    echo configured by setting the environment variables.
+    echo
+    echo GUNDAM_ROOT   -- The root for the gundam source
+    echo GUNDAM_BUILD  -- The location for the build
+    echo GUNDAM_INSTALL -- The location to install gundam - defaults to build
+    echo GUNDAM_JOBS    -- Number of jobs to use during build
+    echo GUNDAM_CMAKE_DEFINES -- Location specific cmake arguments
+    echo
+    return
+fi
 
 echo Setup gundam for development and building
 
@@ -60,11 +74,22 @@ fi
 
 ___gundam_target () {
     target="gundam"
-    compiler=gcc
+    if [ ${#GUNDAM_COMPILER} -gt 0 ]; then
+        echo Using ${GUNDAM_COMPILER}
+        compler=${GUNDAM_COMPILER}
+    elif which gcc >& /dev/null ; then
+        compiler=gcc
+    elif which clang >& /dev/null; then
+        compiler=clang
+    fi
     case ${compiler} in
         gcc)
             compiler_version=$(gcc -dumpversion)
             compiler_machine=$(gcc -dumpmachine)
+            ;;
+        clang)
+            compiler_version=$(clang -dumpversion)
+            compiler_machine=$(clang -dumpmachine)
             ;;
         *)
             compiler_version=unknown


### PR DESCRIPTION
The error hasn't been reproduced, but this includes several safety checks.  This updates gundam-setup.sh to make sure that it is run on bash.  A message is printed if it's on the wrong type of shell.  The gundam-build.sh now checks if it is running with clang and reacts appropriately.