### PR TITLE
Resolve #508 : Confusing Cache::Manager memory allocation error messages

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,7 @@
 Fixes relative to 1.8.2
 
+Issue #508 : Improve error checking for Cache::Manager.  This makes sure that LogThrow is preferred to std::runtime_error.  There is an issue filed for simple-cpp-logger to make sure that the output is flushed before throwing, so that should make the error output much more readable.
+
 Issue #502 : Update the validation code.  A validation failure caused by the recent corrections to the monotonic spline calculation (#486 and $494) has been fixed.  The expected result has been updated.  Unit testing with GoogleTest has been added and used for the HEMI GPU interface code.  Further tests are being implemented.  
 
 Issue #492 : Fix compiler warnings from NVCC.  This is removing some unused variables.  It also fixes a "fix" that applied some correct C++ conventions to code that is aimed at the GPU (the fix produces inefficient code on a SIMD processor, and was primarily aesthetic.

--- a/src/CacheManager/src/CacheIndexedSums.cpp
+++ b/src/CacheManager/src/CacheIndexedSums.cpp
@@ -46,10 +46,6 @@ Cache::IndexedSums::IndexedSums(Cache::Weights::Results& inputs,
         LogThrowIf(not fIndexes, "Bad IndexesAlloc");
 
     }
-    catch (std::bad_alloc&) {
-        LogError << "Failed to allocate memory, so stopping" << std::endl;
-        LogThrow("Failed to allocate memory -- not enough memory available");
-    }
     catch (...) {
         LogError << "Uncaught exception, so stopping" << std::endl;
         LogThrow("Uncaught exception -- not enough memory available");

--- a/src/CacheManager/src/CacheParameters.cpp
+++ b/src/CacheManager/src/CacheParameters.cpp
@@ -38,20 +38,25 @@ Cache::Parameters::Parameters(std::size_t parameters)
         fLowerMirror.reset(new std::vector<double>(
                                GetParameterCount(),
                                std::numeric_limits<double>::lowest()));
+        LogThrowIf(not fLowerMirror, "Bad LowerMirror alloc");
         fUpperMirror.reset(new std::vector<double>(
                                GetParameterCount(),
                                std::numeric_limits<double>::max()));
+        LogThrowIf(not fUpperMirror, "Bad UpperMirror alloc");
 
         // Get CPU/GPU memory for the parameter values.  The mirroring is done
         // to every entry, so its also done on the GPU.  The parameters are
         // copied every iteration, so pin the CPU memory into the page set.
         fParameters.reset(new hemi::Array<double>(GetParameterCount()));
+        LogThrowIf(not fParameters, "Bad Parameters alloc");
         fLowerClamp.reset(new hemi::Array<double>(GetParameterCount(),false));
+        LogThrowIf(not fLowerClamp, "Bad LowerClamp alloc");
         fUpperClamp.reset(new hemi::Array<double>(GetParameterCount(),false));
+        LogThrowIf(not fUpperClamp, "Bad UpperClamp alloc");
     }
     catch (...) {
         LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+        LogThrow("Not enough memory available");
     }
 
     // Initialize the caches.  Don't try to zero everything since the
@@ -77,8 +82,9 @@ double Cache::Parameters::GetParameter(int parIdx) const {
 }
 
 void Cache::Parameters::SetParameter(int parIdx, double value) {
-    if (parIdx < 0) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
     if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     double lm = fLowerMirror->at(parIdx);
     double um = fUpperMirror->at(parIdx);
     // Mirror the input value at lm and um.
@@ -92,50 +98,50 @@ void Cache::Parameters::SetParameter(int parIdx, double value) {
 }
 
 double Cache::Parameters::GetLowerMirror(int parIdx) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     return fLowerMirror->at(parIdx);
 }
 
 void Cache::Parameters::SetLowerMirror(int parIdx, double value) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     fLowerMirror->at(parIdx) = value;
 }
 
 double Cache::Parameters::GetUpperMirror(int parIdx) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     return fUpperMirror->at(parIdx);
 }
 
 void Cache::Parameters::SetUpperMirror(int parIdx, double value) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     fUpperMirror->at(parIdx) = value;
 }
 
 double Cache::Parameters::GetLowerClamp(int parIdx) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     return fLowerClamp->hostPtr()[parIdx];
 }
 
 void Cache::Parameters::SetLowerClamp(int parIdx, double value) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     fLowerClamp->hostPtr()[parIdx] = value;
 }
 
 double Cache::Parameters::GetUpperClamp(int parIdx) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     return fUpperClamp->hostPtr()[parIdx];
 }
 
 void Cache::Parameters::SetUpperClamp(int parIdx, double value) {
-    if (parIdx < 0) throw;
-    if (GetParameterCount() <= parIdx) throw;
+    LogThrowIf((parIdx < 0), "Parameter index out of range");
+    LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     fUpperClamp->hostPtr()[parIdx] = value;
 }
 

--- a/src/CacheManager/src/CacheParameters.cpp
+++ b/src/CacheManager/src/CacheParameters.cpp
@@ -83,7 +83,6 @@ double Cache::Parameters::GetParameter(int parIdx) const {
 
 void Cache::Parameters::SetParameter(int parIdx, double value) {
     LogThrowIf((parIdx < 0), "Parameter index out of range");
-    if (GetParameterCount() <= parIdx) throw;
     LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
     double lm = fLowerMirror->at(parIdx);
     double um = fUpperMirror->at(parIdx);

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -19,7 +19,7 @@ LoggerInit([]{
 // The constructor
 Cache::Weights::Weights(std::size_t results)
     : fTotalBytes(0), fResultCount(results) {
-    if (fResultCount<1) throw std::runtime_error("No results in weight cache");
+    LogThrowIf((fResultCount<1),"No results in weight cache");
 
     LogInfo << "Cached Weights -- output results reserved: "
            << GetResultCount()
@@ -37,12 +37,14 @@ Cache::Weights::Weights(std::size_t results)
         // set.  The initial values are seldom changed, so they are not
         // pinned.
         fResults.reset(new hemi::Array<double>(GetResultCount(),true));
+        LogThrowIf(not fResults, "Bad Results alloc");
         fInitialValues.reset(new hemi::Array<double>(GetResultCount(),false));
+        LogThrowIf(not fInitialValues, "Bad InitialValues alloc");
 
     }
-    catch (std::bad_alloc&) {
+    catch (...) {
         LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+        LogThrow("Not enough memory available");
     }
 
     // Initialize the caches.  Don't try to zero everything since the
@@ -62,8 +64,8 @@ void Cache::Weights::Reset() {
 }
 
 double Cache::Weights::GetResult(int i) {
-    if (i < 0) throw;
-    if (GetResultCount() <= i) throw;
+    LogThrowIf((i<0), "Index out of range");
+    LogThrowIf((GetResultCount() <= i), "Index out of range");
     // This odd ordering is to make sure the thread-safe hostPtr update
     // finishes before the result is set to be valid.  The use of isfinite is
     // to make sure that the optimizer doesn't reorder the statements.
@@ -82,14 +84,14 @@ double Cache::Weights::GetResultFast(int i) {
 }
 
 void Cache::Weights::SetResult(int i, double v) {
-    if (i < 0) throw;
-    if (GetResultCount() <= i) throw;
+    LogThrowIf((i<0), "Index out of range");
+    LogThrowIf((GetResultCount() <= i), "Index out of range");
     fResults->hostPtr()[i] = v;
 }
 
 double* Cache::Weights::GetResultPointer(int i) {
-    if (i < 0) throw;
-    if (GetResultCount() <= i) throw;
+    LogThrowIf((i<0), "Index out of range");
+    LogThrowIf((GetResultCount() <= i), "Index out of range");
     return (fResults->hostPtr() + i);
 }
 
@@ -98,14 +100,14 @@ bool* Cache::Weights::GetResultValidPointer() {
 }
 
 double  Cache::Weights::GetInitialValue(int i) {
-    if (i < 0) throw;
-    if (GetResultCount() <= i) throw;
+    LogThrowIf((i<0), "Index out of range");
+    LogThrowIf((GetResultCount() <= i), "Index out of range");
     return fInitialValues->hostPtr()[i];
 }
 
 void Cache::Weights::SetInitialValue(int i, double v) {
-    if (i < 0) throw;
-    if (GetResultCount() <= i) throw;
+    LogThrowIf((i<0), "Index out of range");
+    LogThrowIf((GetResultCount() <= i), "Index out of range");
     fInitialValues->hostPtr()[i] = v;
 }
 

--- a/src/CacheManager/src/WeightGeneralSpline.cpp
+++ b/src/CacheManager/src/WeightGeneralSpline.cpp
@@ -70,9 +70,12 @@ Cache::Weight::GeneralSpline::GeneralSpline(
         // copied once during initialization so do not pin the CPU memory into
         // the page set.
         fSplineResult.reset(new hemi::Array<int>(GetSplinesReserved(),false));
+        LogThrowIf(not fSplineResult, "Bad SplineResult alloc");
         fSplineParameter.reset(
             new hemi::Array<short>(GetSplinesReserved(),false));
+        LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
         fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
+        LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
@@ -86,10 +89,11 @@ Cache::Weight::GeneralSpline::GeneralSpline(
         // set.
         fSplineSpace.reset(
             new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSplineSpaceReserved(),false));
+        LogThrowIf(not fSplineSpace, "Bad SplineSpacealloc");
     }
-    catch (std::bad_alloc&) {
+    catch (...) {
         LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+        LogThrow("Not enough memory available");
     }
 
     // Initialize the caches.  Don't try to zero everything since the
@@ -110,54 +114,54 @@ void Cache::Weight::GeneralSpline::AddSpline(int resIndex, int parIndex,
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Negative result index");
+        LogThrow("Negative result index");
     }
     if (fWeights.size() <= resIndex) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Result index out of bounds");
+        LogThrow("Result index out of bounds");
     }
     if (parIndex < 0) {
         LogError << "Invalid parameter index"
                << std::endl;
-        throw std::runtime_error("Negative parameter index");
+        LogThrow("Negative parameter index");
     }
     if (fParameters.size() <= parIndex) {
         LogError << "Invalid parameter index " << parIndex
                << std::endl;
-        throw std::runtime_error("Parameter index out of bounds");
+        LogThrow("Parameter index out of bounds");
     }
     if (splineData.size() < 11) {
         LogError << "Insufficient points in spline " << splineData.size()
                << std::endl;
-        throw std::runtime_error("Invalid number of spline points");
+        LogThrow("Invalid number of spline points");
     }
     int knots = (splineData.size()-2)/3;
     if (15 < knots) {
         LogError << "Up to 15 knots supported by GeneralSpline " << knots
                  << std::endl;
-        throw std::runtime_error("Invalid number of spline points");
+        LogThrow("Invalid number of spline points");
     }
 
     int newIndex = fSplinesUsed++;
     if (fSplinesUsed > fSplinesReserved) {
         LogError << "Not enough space reserved for splines"
                   << std::endl;
-        throw std::runtime_error("Not enough space reserved for splines");
+        LogThrow("Not enough space reserved for splines");
     }
     fSplineResult->hostPtr()[newIndex] = resIndex;
     fSplineParameter->hostPtr()[newIndex] = parIndex;
     if (fSplineIndex->hostPtr()[newIndex] != fSplineSpaceUsed) {
         LogError << "Last spline knot index should be at old end of splines"
                   << std::endl;
-        throw std::runtime_error("Problem with control indices");
+        LogThrow("Problem with control indices");
     }
     int knotIndex = fSplineSpaceUsed;
     fSplineSpaceUsed += splineData.size();
     if (fSplineSpaceUsed > fSplineSpaceReserved) {
         LogError << "Not enough space reserved for spline knots"
                << std::endl;
-        throw std::runtime_error("Not enough space reserved for spline knots");
+        LogThrow("Not enough space reserved for spline knots");
     }
     fSplineIndex->hostPtr()[newIndex+1] = fSplineSpaceUsed;
     for (std::size_t i = 0; i<splineData.size(); ++i) {
@@ -167,55 +171,35 @@ void Cache::Weight::GeneralSpline::AddSpline(int resIndex, int parIndex,
 }
 
 int Cache::Weight::GeneralSpline::GetSplineParameterIndex(int sIndex) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     return fSplineParameter->hostPtr()[sIndex];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineParameter(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
-    if (i<0) {
-        throw std::runtime_error("Spline parameter index out of bounds");
-    }
-    if (fParameters.size() <= i) {
-        throw std::runtime_error("Spline parameter index out of bounds");
-    }
+    LogThrowIf((i<0), "Spline parameter index out of bounds");
+    LogThrowIf((fParameters.size() <= i), "Spline parameter index out of bounds");
     return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::GeneralSpline::GetSplineKnotCount(int sIndex) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int k = fSplineIndex->hostPtr()[sIndex+1]-fSplineIndex->hostPtr()[sIndex]-2;
     return k/2;
 }
 
 double Cache::Weight::GeneralSpline::GetSplineLowerBound(int sIndex) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     return fSplineSpace->hostPtr()[knotsIndex];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineUpperBound(int sIndex) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int knotCount = GetSplineKnotCount(sIndex);
     double lower = GetSplineLowerBound(sIndex);
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
@@ -225,77 +209,45 @@ double Cache::Weight::GeneralSpline::GetSplineUpperBound(int sIndex) {
 
 double Cache::Weight::GeneralSpline::GetSplineLowerClamp(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
-    if (i<0) {
-        throw std::runtime_error("Spline lower clamp index out of bounds");
-    }
-    if (fLowerClamp.size() <= i) {
-        throw std::runtime_error("Spline lower clamp index out of bounds");
-    }
+    LogThrowIf((i<0), "Spline lower clamp index out of bounds");
+    LogThrowIf((fLowerClamp.size() <= i), "Spline lower clamp index out of bounds");
     return fLowerClamp.hostPtr()[i];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineUpperClamp(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
-    if (i<0) {
-        throw std::runtime_error("Spline upper clamp index out of bounds");
-    }
-    if (fUpperClamp.size() <= i) {
-        throw std::runtime_error("Spline upper clamp index out of bounds");
-    }
+    LogThrowIf((i<0), "Spline upper clamp index out of bounds");
+    LogThrowIf((fUpperClamp.size() <= i), "Spline upper clamp index out of bounds");
     return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineKnotValue(int sIndex, int knot) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     int count = GetSplineKnotCount(sIndex);
-    if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
-    }
-    if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
-    }
+    LogThrowIf((knot < 0), "Knot index invalid");
+    LogThrowIf((count <= knot), "Knot index invalid");
     return fSplineSpace->hostPtr()[knotsIndex+2+3*knot];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineKnotSlope(int sIndex, int knot) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     int count = GetSplineKnotCount(sIndex);
-    if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
-    }
-    if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
-    }
+    LogThrowIf((knot < 0), "Knot index invalid");
+    LogThrowIf((count <= knot), "Knot index invalid");
     return fSplineSpace->hostPtr()[knotsIndex+2+3*knot+1];
 }
 
 double Cache::Weight::GeneralSpline::GetSplineKnotPlace(int sIndex, int knot) {
-    if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     int count = GetSplineKnotCount(sIndex);
-    if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
-    }
-    if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
-    }
+    LogThrowIf((knot < 0), "Knot index invalid");
+    LogThrowIf((count <= knot), "Knot index invalid");
     return fSplineSpace->hostPtr()[knotsIndex+2+3*knot+2];
 }
 
@@ -311,12 +263,8 @@ double Cache::Weight::GeneralSpline::GetSplineKnotPlace(int sIndex, int knot) {
 // increases the amount of GPU memory required.  In a short sentence, "Do not
 // use this method."
 double* Cache::Weight::GeneralSpline::GetCachePointer(int sIndex) {
-    if (sIndex < 0) {
-        throw std::runtime_error("GetSplineValue: Spline index invalid");
-    }
-    if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("GetSplineValue: Spline index invalid");
-    }
+    LogThrowIf((sIndex < 0), "GetSplineValue: Spline index invalid");
+    LogThrowIf((GetSplinesUsed() <= sIndex), "GetSplineValue: Spline index invalid");
     // This can trigger a *slow* copy of the spline values from the GPU to the
     // CPU.
     return fSplineValue->hostPtr() + sIndex;

--- a/src/CacheManager/src/WeightGraph.cpp
+++ b/src/CacheManager/src/WeightGraph.cpp
@@ -52,19 +52,23 @@ Cache::Weight::Graph::Graph(
         // copied once during initialization so do not pin the CPU memory into
         // the page set.
         fGraphResult.reset(new hemi::Array<int>(GetGraphsReserved(),false));
+        LogThrowIf(not fGraphResult, "GraphResult not allocated");
         fGraphParameter.reset(
             new hemi::Array<short>(GetGraphsReserved(),false));
+        LogThrowIf(not fGraphParameter, "GraphParameter not allocated");
         fGraphIndex.reset(new hemi::Array<int>(1+GetGraphsReserved(),false));
+        LogThrowIf(not fGraphIndex, "GraphIndex not allocated");
 
         // Get the CPU/GPU memory for the graph space.  This is copied once
         // during initialization so do not pin the CPU memory into the page
         // set.
         fGraphSpace.reset(
             new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetGraphSpaceReserved(),false));
+        LogThrowIf(not fGraphSpace, "GraphSpace not allocated");
     }
-    catch (std::bad_alloc&) {
-        LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+    catch (...) {
+        LogError << "Uncaught exception in WeightGraph" << std::endl;
+        LogThrow("WeightGraph -- uncaught exception");
     }
 
     // Initialize the caches.  Don't try to zero everything since the
@@ -81,54 +85,54 @@ void Cache::Weight::Graph::AddGraph(int resIndex, int parIndex,
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Negative result index");
+        LogThrow("Negative result index");
     }
     if (fWeights.size() <= resIndex) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Result index out of bounds");
+        LogThrow("Result index out of bounds");
     }
     if (parIndex < 0) {
         LogError << "Invalid parameter index"
                << std::endl;
-        throw std::runtime_error("Negative parameter index");
+        LogThrow("Negative parameter index");
     }
     if (fParameters.size() <= parIndex) {
         LogError << "Invalid parameter index " << parIndex
                << std::endl;
-        throw std::runtime_error("Parameter index out of bounds");
+        LogThrow("Parameter index out of bounds");
     }
     if (graphData.size() < 2) {
         LogError << "Insufficient points in graph " << graphData.size()
                << std::endl;
-        throw std::runtime_error("Invalid number of graph points");
+        LogThrow("Invalid number of graph points");
     }
     int knots = (graphData.size())/2;
     if (15 < knots) {
         LogError << "Up to 15 knots supported by Graph " << knots
                  << std::endl;
-        throw std::runtime_error("Invalid number of graph points");
+        LogThrow("Invalid number of graph points");
     }
 
     int newIndex = fGraphsUsed++;
     if (fGraphsUsed > fGraphsReserved) {
         LogError << "Not enough space reserved for graphs"
                   << std::endl;
-        throw std::runtime_error("Not enough space reserved for graphs");
+        LogThrow("Not enough space reserved for graphs");
     }
     fGraphResult->hostPtr()[newIndex] = resIndex;
     fGraphParameter->hostPtr()[newIndex] = parIndex;
     if (fGraphIndex->hostPtr()[newIndex] != fGraphSpaceUsed) {
         LogError << "Last graph knot index should be at old end of graphs"
                   << std::endl;
-        throw std::runtime_error("Problem with control indices");
+        LogThrow("Problem with control indices");
     }
     int knotIndex = fGraphSpaceUsed;
     fGraphSpaceUsed += graphData.size();
     if (fGraphSpaceUsed > fGraphSpaceReserved) {
         LogError << "Not enough space reserved for graph space"
                << std::endl;
-        throw std::runtime_error("Not enough space reserved for graph space");
+        LogThrow("Not enough space reserved for graph space");
     }
     fGraphIndex->hostPtr()[newIndex+1] = fGraphSpaceUsed;
     for (std::size_t i = 0; i<graphData.size(); ++i) {
@@ -139,10 +143,10 @@ void Cache::Weight::Graph::AddGraph(int resIndex, int parIndex,
 
 int Cache::Weight::Graph::GetGraphParameterIndex(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     return fGraphParameter->hostPtr()[sIndex];
 }
@@ -150,20 +154,20 @@ int Cache::Weight::Graph::GetGraphParameterIndex(int sIndex) {
 double Cache::Weight::Graph::GetGraphParameter(int sIndex) {
     int i = GetGraphParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Graph parameter index out of bounds");
+        LogThrow("Graph parameter index out of bounds");
     }
     if (fParameters.size() <= i) {
-        throw std::runtime_error("Graph parameter index out of bounds");
+        LogThrow("Graph parameter index out of bounds");
     }
     return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::Graph::GetGraphKnotCount(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     int k = fGraphIndex->hostPtr()[sIndex+1]-fGraphIndex->hostPtr()[sIndex];
     return k/2;
@@ -171,10 +175,10 @@ int Cache::Weight::Graph::GetGraphKnotCount(int sIndex) {
 
 double Cache::Weight::Graph::GetGraphLowerBound(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     int spaceIndex = fGraphIndex->hostPtr()[sIndex];
     return fGraphSpace->hostPtr()[spaceIndex];
@@ -182,10 +186,10 @@ double Cache::Weight::Graph::GetGraphLowerBound(int sIndex) {
 
 double Cache::Weight::Graph::GetGraphUpperBound(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     int knotCount = GetGraphKnotCount(sIndex);
     double lower = GetGraphLowerBound(sIndex);
@@ -197,10 +201,10 @@ double Cache::Weight::Graph::GetGraphUpperBound(int sIndex) {
 double Cache::Weight::Graph::GetGraphLowerClamp(int sIndex) {
     int i = GetGraphParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Graph lower clamp index out of bounds");
+        LogThrow("Graph lower clamp index out of bounds");
     }
     if (fLowerClamp.size() <= i) {
-        throw std::runtime_error("Graph lower clamp index out of bounds");
+        LogThrow("Graph lower clamp index out of bounds");
     }
     return fLowerClamp.hostPtr()[i];
 }
@@ -208,46 +212,46 @@ double Cache::Weight::Graph::GetGraphLowerClamp(int sIndex) {
 double Cache::Weight::Graph::GetGraphUpperClamp(int sIndex) {
     int i = GetGraphParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Graph upper clamp index out of bounds");
+        LogThrow("Graph upper clamp index out of bounds");
     }
     if (fUpperClamp.size() <= i) {
-        throw std::runtime_error("Graph upper clamp index out of bounds");
+        LogThrow("Graph upper clamp index out of bounds");
     }
     return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::Graph::GetGraphKnotValue(int sIndex, int knot) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     int spaceIndex = fGraphIndex->hostPtr()[sIndex];
     int count = GetGraphKnotCount(sIndex);
     if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     return fGraphSpace->hostPtr()[spaceIndex+2+2*knot];
 }
 
 double Cache::Weight::Graph::GetGraphKnotPlace(int sIndex, int knot) {
     if (sIndex < 0) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     if (GetGraphsUsed() <= sIndex) {
-        throw std::runtime_error("Graph index invalid");
+        LogThrow("Graph index invalid");
     }
     int spaceIndex = fGraphIndex->hostPtr()[sIndex];
     int count = GetGraphKnotCount(sIndex);
     if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     return fGraphSpace->hostPtr()[spaceIndex+2+2*knot+1];
 }

--- a/src/CacheManager/src/WeightMonotonicSpline.cpp
+++ b/src/CacheManager/src/WeightMonotonicSpline.cpp
@@ -56,7 +56,7 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
     LogInfo << "Reserved " << GetName()
             << " Spline Knots: " << GetSplineSpaceReserved()
             << std::endl;
-    fTotalBytes += GetSplineSpaceReserved()*sizeof(WEIGHT_BUFFER_FLOAT);  // fSpineKnots
+    fTotalBytes += GetSplineSpaceReserved()*sizeof(WEIGHT_BUFFER_FLOAT);  // fSplineKnots
 
 
     LogInfo << "Approximate Memory Size for " << GetName()
@@ -68,15 +68,19 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
         // copied once during initialization so do not pin the CPU memory into
         // the page set.
         fSplineResult.reset(new hemi::Array<int>(GetSplinesReserved(),false));
+        LogThrowIf(not fSplineResult, "Bad SplineResult alloc");
         fSplineParameter.reset(
             new hemi::Array<short>(GetSplinesReserved(),false));
+        LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
         fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
+        LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::MonotonicSpline::MonotonicSpline
         // Add validation code for the spline calculation.  This can be rather
         // slow, so do not use if it is not required.
         fSplineValue.reset(new hemi::Array<double>(GetSplinesReserved(),true));
+        LogThrowIf(not fSplineValue, "Bad SplineValue alloc");
 #endif
 
         // Get the CPU/GPU memory for the spline knots.  This is copied once
@@ -84,10 +88,11 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
         // set.
         fSplineSpace.reset(
             new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSplineSpaceReserved(),false));
+        LogThrowIf(not fSplineSpace, "Bad SplineSpace alloc");
     }
-    catch (std::bad_alloc&) {
-        LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+    catch (...) {
+        LogError << "Uncaught exception in WeightGraph" << std::endl;
+        LogThrow("WeightGraph -- uncaught exception");
     }
 
     // Initialize the caches.  Don't try to zero everything since the
@@ -109,28 +114,28 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Negative result index");
+        LogThrow("Negative result index");
     }
     if (fWeights.size() <= resIndex) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Result index out of bounds");
+        LogThrow("Result index out of bounds");
     }
     if (parIndex < 0) {
         LogError << "Invalid parameter index"
                << std::endl;
-        throw std::runtime_error("Negative parameter index");
+        LogThrow("Negative parameter index");
     }
     if (fParameters.size() <= parIndex) {
         LogError << "Invalid parameter index: " << parIndex
                  << " out of " << fParameters.size()
                  << std::endl;
-        throw std::runtime_error("Parameter index out of bounds");
+        LogThrow("Parameter index out of bounds");
     }
     if (splineData.size() < 5) {
         LogError << "Insufficient points in spline: " << splineData.size()
                << std::endl;
-        throw std::runtime_error("Invalid number of spline points");
+        LogThrow("Invalid number of spline points");
     }
     int newIndex = fSplinesUsed++;
     if (fSplinesUsed > fSplinesReserved) {
@@ -138,14 +143,14 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
                  << " Reserved: " << fSplinesReserved
                  << " Used: " << fSplinesUsed
                  << std::endl;
-        throw std::runtime_error("Not enough space reserved for splines");
+        LogThrow("Not enough space reserved for splines");
     }
     fSplineResult->hostPtr()[newIndex] = resIndex;
     fSplineParameter->hostPtr()[newIndex] = parIndex;
     if (fSplineIndex->hostPtr()[newIndex] != fSplineSpaceUsed) {
         LogError << "Last spline knot index should be at old end of splines"
                   << std::endl;
-        throw std::runtime_error("Problem with control indices");
+        LogThrow("Problem with control indices");
     }
     int knotIndex = fSplineSpaceUsed;
     fSplineSpaceUsed += splineData.size();
@@ -154,7 +159,7 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
                  << " Reserved: " << fSplineSpaceReserved
                  << " Used: " << fSplineSpaceUsed
                  << std::endl;
-        throw std::runtime_error("Not enough space reserved for spline knots");
+        LogThrow("Not enough space reserved for spline knots");
     }
     fSplineIndex->hostPtr()[newIndex+1] = fSplineSpaceUsed;
     for (std::size_t i = 0; i<splineData.size(); ++i) {
@@ -191,10 +196,10 @@ void Cache::Weight::MonotonicSpline::SetSplineKnot(
 
 int Cache::Weight::MonotonicSpline::GetSplineParameterIndex(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     return fSplineParameter->hostPtr()[sIndex];
 }
@@ -202,30 +207,30 @@ int Cache::Weight::MonotonicSpline::GetSplineParameterIndex(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineParameter(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Spine parameter index out of bounds");
+        LogThrow("Spline parameter index out of bounds");
     }
     if (fParameters.size() <= i) {
-        throw std::runtime_error("Spine parameter index out of bounds");
+        LogThrow("Spline parameter index out of bounds");
     }
     return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::MonotonicSpline::GetSplineKnotCount(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     return fSplineIndex->hostPtr()[sIndex+1]-fSplineIndex->hostPtr()[sIndex]-2;
 }
 
 double Cache::Weight::MonotonicSpline::GetSplineLowerBound(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     return fSplineSpace->hostPtr()[knotsIndex];
@@ -233,10 +238,10 @@ double Cache::Weight::MonotonicSpline::GetSplineLowerBound(int sIndex) {
 
 double Cache::Weight::MonotonicSpline::GetSplineUpperBound(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     int knotCount = GetSplineKnotCount(sIndex);
     double lower = GetSplineLowerBound(sIndex);
@@ -248,10 +253,10 @@ double Cache::Weight::MonotonicSpline::GetSplineUpperBound(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineLowerClamp(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Spine lower clamp index out of bounds");
+        LogThrow("Spline lower clamp index out of bounds");
     }
     if (fLowerClamp.size() <= i) {
-        throw std::runtime_error("Spine lower clamp index out of bounds");
+        LogThrow("Spline lower clamp index out of bounds");
     }
     return fLowerClamp.hostPtr()[i];
 }
@@ -259,28 +264,28 @@ double Cache::Weight::MonotonicSpline::GetSplineLowerClamp(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineUpperClamp(int sIndex) {
     int i = GetSplineParameterIndex(sIndex);
     if (i<0) {
-        throw std::runtime_error("Spine upper clamp index out of bounds");
+        LogThrow("Spline upper clamp index out of bounds");
     }
     if (fUpperClamp.size() <= i) {
-        throw std::runtime_error("Spine upper clamp index out of bounds");
+        LogThrow("Spline upper clamp index out of bounds");
     }
     return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::MonotonicSpline::GetSplineKnot(int sIndex, int knot) {
     if (sIndex < 0) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("Spline index invalid");
+        LogThrow("Spline index invalid");
     }
     int knotsIndex = fSplineIndex->hostPtr()[sIndex];
     int count = GetSplineKnotCount(sIndex);
     if (knot < 0) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     if (count <= knot) {
-        throw std::runtime_error("Knot index invalid");
+        LogThrow("Knot index invalid");
     }
     return fSplineSpace->hostPtr()[knotsIndex+2+knot];
 }
@@ -298,10 +303,10 @@ double Cache::Weight::MonotonicSpline::GetSplineKnot(int sIndex, int knot) {
 // use this method."
 double* Cache::Weight::MonotonicSpline::GetCachePointer(int sIndex) {
     if (sIndex < 0) {
-        throw std::runtime_error("GetSplineValue: Spline index invalid");
+        LogThrow("GetSplineValue: Spline index invalid");
     }
     if (GetSplinesUsed() <= sIndex) {
-        throw std::runtime_error("GetSplineValue: Spline index invalid");
+        LogThrow("GetSplineValue: Spline index invalid");
     }
     // This can trigger a *slow* copy of the spline values from the GPU to the
     // CPU.
@@ -396,7 +401,7 @@ bool Cache::Weight::MonotonicSpline::Apply() {
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
     // This MUST be done for slow validation.
-#warning Using SLOW VALIDATION and copying spine values
+#warning Using SLOW VALIDATION and copying spline values
     fSplineValue->hostPtr();
 #endif
 

--- a/src/CacheManager/src/WeightNormalization.cpp
+++ b/src/CacheManager/src/WeightNormalization.cpp
@@ -39,11 +39,13 @@ Cache::Weight::Normalization::Normalization(
         // are copied once during initialization so do not pin the CPU memory
         // into the page set.
         fNormResult.reset(new hemi::Array<int>(GetNormsReserved(),false));
+        LogThrowIf(not fNormResult, "Bad NormResult Alloc");
         fNormParameter.reset(new hemi::Array<short>(GetNormsReserved(),false));
+        LogThrowIf(not fNormParameter, "Bad NormParameter Alloc");
     }
-    catch (std::bad_alloc&) {
-        LogError << "Failed to allocate memory, so stopping" << std::endl;
-        throw std::runtime_error("Not enough memory available");
+    catch (...) {
+        LogError << "Uncaught exception, so stopping" << std::endl;
+        LogThrow("WeightNormalization -- Uncaught exception");
     }
 
     Reset();
@@ -57,22 +59,22 @@ int Cache::Weight::Normalization::ReserveNorm(int resIndex, int parIndex) {
     if (resIndex < 0) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Negative result index");
+        LogThrow("Negative result index");
     }
     if (fWeights.size() <= resIndex) {
         LogError << "Invalid result index"
                << std::endl;
-        throw std::runtime_error("Result index out of bounds");
+        LogThrow("Result index out of bounds");
     }
     if (parIndex < 0) {
         LogError << "Invalid parameter index"
                << std::endl;
-        throw std::runtime_error("Negative parameter index");
+        LogThrow("Negative parameter index");
     }
     if (fParameters.size() <= parIndex) {
         LogError << "Invalid parameter index"
                << std::endl;
-        throw std::runtime_error("Parameter index out of bounds");
+        LogThrow("Parameter index out of bounds");
     }
     int newIndex = fNormsUsed++;
     if (fNormsUsed > fNormsReserved) {
@@ -80,7 +82,7 @@ int Cache::Weight::Normalization::ReserveNorm(int resIndex, int parIndex) {
                  << " Reserved: " << fNormsReserved
                  << " Requested: " << fNormsUsed
                  << std::endl;
-        throw std::runtime_error("Not enough space reserved for results");
+        LogThrow("Not enough space reserved for results");
     }
     fNormResult->hostPtr()[newIndex] = resIndex;
     fNormParameter->hostPtr()[newIndex] = parIndex;


### PR DESCRIPTION
Resolve #508 : This uses LogThrow (and family) everyplace in Cache::Manager in preference to std::runtime_error.  This needs a companion fix in simple-cpp-logger to completely fix the issue.  This closes #508. 