### PR TITLE
Resolve #506 : Fix ParameterSet to correctly print limits

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,7 @@
 Fixes relative to 1.8.2
 
+Issue #506 : Fix output statement in ParameterSet.cpp to remove duplicated output.  
+
 Issue #502 : Update the validation code.  A validation failure caused by the recent corrections to the monotonic spline calculation (#486 and $494) has been fixed.  The expected result has been updated.  Unit testing with GoogleTest has been added and used for the HEMI GPU interface code.  Further tests are being implemented.  
 
 Issue #492 : Fix compiler warnings from NVCC.  This is removing some unused variables.  It also fixes a "fix" that applied some correct C++ conventions to code that is aimed at the GPU (the fix produces inefficient code on a SIMD processor, and was primarily aesthetic.

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -62,7 +62,7 @@ void ParameterSet::readConfigImpl(){
       auto eigenLimits = GenericToolbox::Json::fetchValue(_config_, "eigenParBounds", nlohmann::json());
       _eigenParBounds_.first = GenericToolbox::Json::fetchValue(eigenLimits, "minValue", _eigenParBounds_.first);
       _eigenParBounds_.second = GenericToolbox::Json::fetchValue(eigenLimits, "maxValue", _eigenParBounds_.second);
-      LogInfo << "Using eigen parameter limits: [ " << _eigenParBounds_.first << ", " << _eigenParBounds_.first << "]" << std::endl;
+      LogInfo << "Using eigen parameter limits: [ " << _eigenParBounds_.first << ", " << _eigenParBounds_.second << "]" << std::endl;
     }
 
     _devUseParLimitsOnEigen_ = GenericToolbox::Json::fetchValue(_config_, "devUseParLimitsOnEigen", _devUseParLimitsOnEigen_);
@@ -968,5 +968,3 @@ void ParameterSet::fillDeltaParameterList(){
     }
   }
 }
-
-


### PR DESCRIPTION
Closes #506.  There was a small mistake when the parameter limits are printed.  This prints the low and high bounds, instead of printing the low bound twice.