### PR TITLE
Resolve LTS/1.8.x/505: Add "isFixed" option to configuration file

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -2,6 +2,8 @@ Fixes relative to 1.8.2
 
 Issue #506 : Fix output statement in ParameterSet.cpp to remove duplicated output.  
 
+Issue #505 : Add the "isFixed" option for parameters in the configuration file.
+
 Issue #508 : Improve error checking for Cache::Manager.  This makes sure that LogThrow is preferred to std::runtime_error.  There is an issue filed for simple-cpp-logger to make sure that the output is flushed before throwing, so that should make the error output much more readable.
 
 Issue #502 : Update the validation code.  A validation failure caused by the recent corrections to the monotonic spline calculation (#486 and $494) has been fixed.  The expected result has been updated.  Unit testing with GoogleTest has been added and used for the HEMI GPU interface code.  Further tests are being implemented.  

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -19,6 +19,8 @@ void Parameter::readConfigImpl(){
     _isEnabled_ = GenericToolbox::Json::fetchValue(_parameterConfig_, "isEnabled", true);
     if( not _isEnabled_ ) { return; }
 
+    _isFixed_ = GenericToolbox::Json::fetchValue(_parameterConfig_, "isFixed", _isFixed_);
+
     auto priorTypeStr = GenericToolbox::Json::fetchValue(_parameterConfig_, "priorType", "");
     if( not priorTypeStr.empty() ){
       _priorType_ = PriorType::PriorTypeEnumNamespace::toEnum(priorTypeStr);


### PR DESCRIPTION
The Parameter class already supports fixing the parameter, but the interface was not available from the config files.  This lets a parameter be set as "fixed" from the config file.