### PR TITLE
Resolve Issue 490: NAN should not be saved in the output histograms

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -8,6 +8,8 @@ Issue #502 : Update the validation code.  A validation failure caused by the rec
 
 Issue #492 : Fix compiler warnings from NVCC.  This is removing some unused variables.  It also fixes a "fix" that applied some correct C++ conventions to code that is aimed at the GPU (the fix produces inefficient code on a SIMD processor, and was primarily aesthetic.
 
+Issue #490 : Don't set the value for disabled parameters in the output histograms.  This will prevent uninitialized values (i.e. NAN) from appearing in plots.
+
 Fixes relative to 1.8.1
 
 Issue #499 : Update to a new version of the cpp-generic-toolkit submodule. The cpp-generic-toolkit fix sets the branch status to enable branches that are used for the data.

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -940,27 +940,28 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
             preFitErrorHist->GetXaxis()->SetBinLabel(1 + par.getParameterIndex(), par.getTitle().c_str());
 
             if(not isNorm_){
-              postFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getParameterValue());
-              postFitErrorHist->SetBinError( 1 + par.getParameterIndex(), TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]));
+              if (par.isEnabled()) {
+                postFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getParameterValue());
+                postFitErrorHist->SetBinError( 1 + par.getParameterIndex(),
+                                               TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]));
+              }
               preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getPriorValue() );
-
               if( par.isEnabled() and not par.isFixed() and not par.isFree() ){
                 preFitErrorHist->SetBinError( 1 + par.getParameterIndex(), par.getStdDevValue() );
               }
             }
             else{
-              postFitErrorHist->SetBinContent(
+              if (par.isEnabled()) {
+                postFitErrorHist->SetBinContent(
                   1 + par.getParameterIndex(),
-                  ParameterSet::toNormalizedParValue(par.getParameterValue(), par)
-              );
-              preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), 0 );
-
-              postFitErrorHist->SetBinError(
+                  ParameterSet::toNormalizedParValue(par.getParameterValue(), par));
+                postFitErrorHist->SetBinError(
                   1 + par.getParameterIndex(),
                   ParameterSet::toNormalizedParRange(
-                      TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]), par
-                  )
-              );
+                    TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]), par));
+              }
+
+              preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), 0 );
               if( par.isEnabled() and not par.isFixed() and not par.isFree() ){
                 preFitErrorHist->SetBinError( 1 + par.getParameterIndex(), 1 );
               }

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -934,6 +934,19 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
           legend->AddEntry(postFitErrorHist.get(),"Post-fit values","ep");
 
           for( const auto& par : parList_ ){
+            if (par.isEnabled()) {
+              if (std::isnan(par.getParameterValue())) {
+                LogError << "Parameter with invalid value: "
+                         << par.getTitle() << std::endl;
+              }
+              if (std::isnan((*covMatrix_)
+                             [par.getParameterIndex()]
+                             [par.getParameterIndex()])) {
+                LogError << "Parameter error with invalid value: "
+                         << par.getTitle() << std::endl;
+              }
+            }
+
             longestTitleSize = std::max(longestTitleSize, par.getTitle().size());
 
             postFitErrorHist->GetXaxis()->SetBinLabel(1 + par.getParameterIndex(), par.getTitle().c_str());
@@ -941,9 +954,13 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
 
             if(not isNorm_){
               if (par.isEnabled()) {
-                postFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getParameterValue());
-                postFitErrorHist->SetBinError( 1 + par.getParameterIndex(),
-                                               TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]));
+                postFitErrorHist->SetBinContent( 1 + par.getParameterIndex(),
+                                                 par.getParameterValue());
+                postFitErrorHist->SetBinError(
+                  1 + par.getParameterIndex(),
+                  TMath::Sqrt((*covMatrix_)
+                              [par.getParameterIndex()]
+                              [par.getParameterIndex()]));
               }
               preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getPriorValue() );
               if( par.isEnabled() and not par.isFixed() and not par.isFree() ){
@@ -954,11 +971,14 @@ void MinimizerInterface::writePostFitData(TDirectory* saveDir_) {
               if (par.isEnabled()) {
                 postFitErrorHist->SetBinContent(
                   1 + par.getParameterIndex(),
-                  ParameterSet::toNormalizedParValue(par.getParameterValue(), par));
+                  ParameterSet::toNormalizedParValue(par.getParameterValue(),
+                                                     par));
                 postFitErrorHist->SetBinError(
                   1 + par.getParameterIndex(),
                   ParameterSet::toNormalizedParRange(
-                    TMath::Sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]), par));
+                    TMath::Sqrt((*covMatrix_)
+                                [par.getParameterIndex()]
+                                [par.getParameterIndex()]), par));
               }
 
               preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), 0 );


### PR DESCRIPTION
Changes how the output histograms are filled so that disabled parameters are skipped.  If an
enabled parameter has an NAN value, then this will print an error message.