### PR TITLE
Fix the event weight calculation caches

### DIFF
--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -31,7 +31,7 @@ int main(int argc, char** argv){
   GundamApp app{"main fitter"};
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if (Cache::Manager::HasCUDA()){ LogWarning << "CUDA compatible build." << std::endl; }
+  if (Cache::Manager::HasCUDA()){ LogInfo << "CUDA inside" << std::endl; }
 #endif
 
   // --------------------------
@@ -81,8 +81,9 @@ int main(int argc, char** argv){
   clParser.addDummyOption("Runtime/debug options");
 
   clParser.addOption("debugVerbose", {"--debug"}, "Enable debug verbose (can provide verbose level arg)", 1, true);
-  clParser.addTriggerOption("usingCacheManager", {"--cache-manager"}, "Event weight cache handle by the CacheManager");
+  clParser.addTriggerOption("usingCacheManager", {"--cache-manager"}, "Toggle the usage of the CacheManager (i.e. the GPU)");
   clParser.addTriggerOption("usingGpu", {"--gpu"}, "Use GPU parallelization");
+  clParser.addTriggerOption("forceDirect", {"--cpu"}, "Force direct calculation of weights (for debugging)");
   clParser.addOption("overrides", {"-O", "--override"}, "Add a config override [e.g. /fitterEngineConfig/engineType=mcmc)", -1);
   clParser.addOption("overrideFiles", {"-of", "--override-files"}, "Provide config files that will override keys", -1);
 
@@ -119,14 +120,24 @@ int main(int argc, char** argv){
     LogWarning << "Using GPU parallelization." << std::endl;
   }
 
-  // Is build compatible with cache manager option?
-  if( clParser.isOptionTriggered("usingCacheManager") or clParser.isOptionTriggered("usingGpu") ){
+  if (clParser.isOptionTriggered("forceDirect")) GundamGlobals::setForceDirectCalculation(true);
+
+  bool useCache = false;
 #ifdef GUNDAM_USING_CACHE_MANAGER
-    GundamGlobals::setEnableCacheManager(true);
-#else
-    LogThrow("useCacheManager can only be set while GUNDAM is compiled with -D WITH_CACHE_MANAGER=ON cmake option.");
+  useCache = Cache::Parameters::HasGPU(true);
 #endif
-  }
+  if (clParser.isOptionTriggered("usingCacheManager")) useCache = not useCache;
+  if (clParser.isOptionTriggered("usingGpu")) useCache = true;
+
+#ifdef GUNDAM_USING_CACHE_MANAGER
+    GundamGlobals::setEnableCacheManager(useCache);
+    if (not useCache) {
+      LogWarning << "Cache::Manager enabled but turned off for job"
+                 << std::endl;
+    }
+#else
+    LogThrowIf(useCache, "GUNDAM compiled without Cache::Manager");
+#endif
 
   // No cache on dials?
   if( clParser.isOptionTriggered("noDialCache") ){
@@ -156,7 +167,9 @@ int main(int argc, char** argv){
   }
 
   // How many parallel threads?
-  GundamGlobals::getParallelWorker().setNThreads( clParser.getOptionVal("nbThreads", 1) );
+  GundamGlobals::setNumberOfThreads( clParser.getOptionVal("nbThreads", 1) );
+
+  GundamGlobals::getParallelWorker().setNThreads(GundamGlobals::getNumberOfThreads());
   LogInfo << "Running the fitter with " << GundamGlobals::getParallelWorker().getNbThreads() << " parallel threads." << std::endl;
 
   // Reading configuration

--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -30,6 +30,14 @@ private:
     // The accumulated weights for each histogram bin.
     std::unique_ptr<hemi::Array<double>> fSums2;
 
+    // The lower bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fLowerClamp;
+
+    // The upper bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fUpperClamp;
+
     // Cache of whether the result values in memory are valid.
     bool fSumsValid;
 
@@ -53,6 +61,14 @@ public:
 
     // Assigns the bin number that an event will be added to.
     void SetEventIndex(int event, int bin);
+
+    // Set the maximum event weight to be applied as an upper clamp during the
+    // sum.  (Default: infinity).
+    void SetMaximumEventWeight(double maximum);
+
+    // Set the minimum event weight to be applied as an upper clamp during the
+    // sum.  (Default: negative infinity).
+    void SetMinimumEventWeight(double minimum);
 
     /// Return the number of histogram bins that are accumulated.
     std::size_t GetSumCount() const {return fSums->size();}

--- a/src/CacheManager/include/CacheParameters.h
+++ b/src/CacheManager/include/CacheParameters.h
@@ -22,6 +22,7 @@ public:
 
     // Returns true if this is compiled with a CUDA compiler
     static bool UsingCUDA();
+    static bool HasGPU(bool dump = false);
 
     // This is a singleton, so the constructor is private.
     Parameters(std::size_t parameters);

--- a/src/CacheManager/include/WeightCompactSpline.h
+++ b/src/CacheManager/include/WeightCompactSpline.h
@@ -132,20 +132,6 @@ public:
     // Get the function value for a knot in the spline at sIndex
     double GetSplineKnot(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightGeneralSpline.h
+++ b/src/CacheManager/include/WeightGeneralSpline.h
@@ -125,20 +125,6 @@ public:
     double GetSplineKnotValue(int sIndex,int knot);
     double GetSplineKnotSlope(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightMonotonicSpline.h
+++ b/src/CacheManager/include/WeightMonotonicSpline.h
@@ -132,20 +132,6 @@ public:
     // Get the function value for a knot in the spline at sIndex
     double GetSplineKnot(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightUniformSpline.h
+++ b/src/CacheManager/include/WeightUniformSpline.h
@@ -123,20 +123,6 @@ public:
     double GetSplineKnotValue(int sIndex,int knot);
     double GetSplineKnotSlope(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -391,11 +391,11 @@ bool Cache::Manager::Update( SampleSet& sampleList,
 
         event.getCache().index = resultIndex;
         event.getCache().valuePtr = (Cache::Manager::Get()
-                                          ->GetWeightsCache()
-                                          .GetResultPointer(resultIndex));
+                                     ->GetWeightsCache()
+                                     .GetResultPointer(resultIndex));
         event.getCache().isValidPtr = (Cache::Manager::Get()
-                                          ->GetWeightsCache()
-                                          .GetResultValidPointer());
+                                       ->GetWeightsCache()
+                                       .GetResultValidPointer());
         event.getCache().updateCallbackPtr = (
             [](){Cache::Manager::Get()->GetWeightsCache().GetResult(0);});
 
@@ -648,12 +648,6 @@ bool Cache::Manager::Fill() {
     cache->GetWeightsCache().Apply();
     cache->GetHistogramsCache().Apply();
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning CACHE_MANAGER_SLOW_VALIDATION in Cache::Manager::Fill()
-    // Returning false means that the event weights will also be calculated
-    // using the CPU.
-    return false;
-#endif
     return true;
 }
 

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -397,7 +397,10 @@ bool Cache::Manager::Update( SampleSet& sampleList,
                                        ->GetWeightsCache()
                                        .GetResultValidPointer());
         event.getCache().updateCallbackPtr = (
-            [](){Cache::Manager::Get()->GetWeightsCache().GetResult(0);});
+            [](){
+                LogTrace << "Copy event weights from Device to Host" << std::endl;
+                Cache::Manager::Get()->GetWeightsCache().GetResult(0);
+            });
 
         // Get the initial value for this event and save it.
         double initialEventWeight = event.getWeights().base;
@@ -590,6 +593,7 @@ bool Cache::Manager::Update( SampleSet& sampleList,
             .GetSumsValidPointer());
         sample.getMcContainer().setCacheManagerUpdatePointer(
             [](){
+                LogTrace << "Copy histogram content from Device to Host" << std::endl;
                 Cache::Manager::Get()->GetHistogramsCache().GetSum(0);
                 Cache::Manager::Get()->GetHistogramsCache().GetSum2(0);
             });
@@ -624,6 +628,7 @@ bool Cache::Manager::Fill() {
         LogError << "Fill while an update is required" << std::endl;
         LogThrow("Fill while an update is required");
     }
+    LogTrace << "Cache::Manager::Fill -- Fill the GPU cache" << std::endl;
 #define DUMP_FILL_INPUT_PARAMETERS
 #ifdef DUMP_FILL_INPUT_PARAMETERS
     do {

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -70,7 +70,8 @@ double Cache::Weights::GetResult(int i) {
     // finishes before the result is set to be valid.  The use of isnan is
     // to make sure that the optimizer doesn't reorder the statements.
     double value = fResults->hostPtr()[i];
-    if (std::isnan(value)) fResultsValid = true;
+    if (not std::isnan(value)) fResultsValid = true;
+    else LogThrow("Cache::Weights result is nan");
     return value;
 }
 
@@ -79,7 +80,8 @@ double Cache::Weights::GetResultFast(int i) {
     // finishes before the result is set to be valid.  The use of isnan is
     // to make sure that the optimizer doesn't reorder the statements.
     double value = fResults->hostPtr()[i];
-    if (std::isnan(value)) fResultsValid = true;
+    if (not std::isnan(value)) fResultsValid = true;
+    else LogThrow("Cache::Weights result is nan");
     return value;
 }
 

--- a/src/CacheManager/src/WeightGeneralSpline.cpp
+++ b/src/CacheManager/src/WeightGeneralSpline.cpp
@@ -48,14 +48,6 @@ Cache::Weight::GeneralSpline::GeneralSpline(
                    "Invalid space option for compact splines");
     }
 
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
-        // Add validation code for the spline calculation.  This can be rather
-        // slow, so do not use if it is not required.
-    fTotalBytes += GetSplinesReserved()*sizeof(double);
-#endif
-
     LogInfo << "Reserved " << GetName()
             << " Spline Knots: " << GetSplineSpaceReserved()
             << std::endl;
@@ -76,13 +68,6 @@ Cache::Weight::GeneralSpline::GeneralSpline(
         LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
         fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
         LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
-        // Add validation code for the spline calculation.  This can be rather
-        // slow, so do not use if it is not required.
-        fSplineValue.reset(new hemi::Array<double>(GetSplinesReserved(),true));
-#endif
 
         // Get the CPU/GPU memory for the spline knots.  This is copied once
         // during initialization so do not pin the CPU memory into the page
@@ -251,26 +236,6 @@ double Cache::Weight::GeneralSpline::GetSplineKnotPlace(int sIndex, int knot) {
     return fSplineSpace->hostPtr()[knotsIndex+2+3*knot+2];
 }
 
-////////////////////////////////////////////////////////////////////
-// This section is for the validation methods.  They should mostly be
-// NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GetSplineValue
-// Get the intermediate spline result that is used to calculate an event
-// weight.  This can trigger a copy from the GPU to CPU, and must only be
-// enabled during validation.  Using this validation code also significantly
-// increases the amount of GPU memory required.  In a short sentence, "Do not
-// use this method."
-double* Cache::Weight::GeneralSpline::GetCachePointer(int sIndex) {
-    LogThrowIf((sIndex < 0), "GetSplineValue: Spline index invalid");
-    LogThrowIf((GetSplinesUsed() <= sIndex), "GetSplineValue: Spline index invalid");
-    // This can trigger a *slow* copy of the spline values from the GPU to the
-    // CPU.
-    return fSplineValue->hostPtr() + sIndex;
-}
-#endif
-
 // Define CACHE_DEBUG to get lots of output from the host
 #undef CACHE_DEBUG
 #define PRINT_STEP 3
@@ -284,11 +249,6 @@ namespace {
     // must be valid CUDA coda.
     HEMI_KERNEL_FUNCTION(HEMISplinesKernel,
                          double* results,
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::HEMISplinesKernel
-                         // inputs/output for validation
-                         double* splineValues,
-#endif
                          const double* params,
                          const double* lowerClamp,
                          const double* upperClamp,
@@ -343,10 +303,6 @@ namespace {
 #endif
 #endif
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::HEMISplinesKernel
-            splineValues[i] = v;
-#endif
             CacheAtomicMult(&results[rIndex[i]], v);
         }
     }
@@ -366,10 +322,6 @@ bool Cache::Weight::GeneralSpline::Apply() {
     HEMISplinesKernel splinesKernel;
     hemi::launch(splinesKernel,
                  fWeights.writeOnlyPtr(),
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::Apply
-                 fSplineValue->writeOnlyPtr(),
-#endif
                  fParameters.readOnlyPtr(),
                  fLowerClamp.readOnlyPtr(),
                  fUpperClamp.readOnlyPtr(),
@@ -379,11 +331,6 @@ bool Cache::Weight::GeneralSpline::Apply() {
                  fSplineIndex->readOnlyPtr(),
                  GetSplinesUsed()
         );
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION and copying spline values
-    fSplineValue->hostPtr();
-#endif
 
     return true;
 }

--- a/src/DatasetManager/src/DataSetManager.cpp
+++ b/src/DatasetManager/src/DataSetManager.cpp
@@ -55,10 +55,6 @@ void DataSetManager::initializeImpl(){
 void DataSetManager::loadData(){
   LogInfo << "Loading data into the PropagatorEngine..." << std::endl;
 
-  bool cacheManagerState = GundamGlobals::getEnableCacheManager();
-  GundamGlobals::setEnableCacheManager(false);
-
-
   // make sure everything is ready for loading
   _propagator_.clearContent();
 
@@ -193,10 +189,8 @@ void DataSetManager::loadData(){
   // After all the data has been loaded.  Specifically, this must be after
   // the MC has been copied for the Asimov fit, or the "data" use the MC
   // reweighting cache.  This must also be before the first use of
-  // reweightMcEvents.
-  if( cacheManagerState ) {
-    Cache::Manager::Build(_propagator_.getSampleSet(), _propagator_.getEventDialCache());
-  }
+  // reweightMcEvents that is done using the GPU.
+  Cache::Manager::Build(_propagator_.getSampleSet(), _propagator_.getEventDialCache());
 #endif
 
   LogInfo << "Propagating prior parameters on events..." << std::endl;
@@ -250,6 +244,4 @@ void DataSetManager::loadData(){
   /// Propagator needs to be fast, let the workers wait for the signal
   GundamGlobals::getParallelWorker().setCpuTimeSaverIsEnabled(false);
 
-  /// restoring state
-  GundamGlobals::setEnableCacheManager(cacheManagerState);
 }

--- a/src/DialDictionary/DialDefinitions/include/Graph.h
+++ b/src/DialDictionary/DialDefinitions/include/Graph.h
@@ -15,7 +15,7 @@ public:
   Graph() = default;
 
   [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Graph>(*this); }
-  [[nodiscard]] std::string getDialTypeName() const override { return {"Graph"}; }
+  [[nodiscard]] std::string getDialTypeName() const override { return {"TGraph"}; }
   [[nodiscard]] double evalResponse(const DialInputBuffer& input_) const override;
 
   void setAllowExtrapolation(bool allowExtrapolation) override;

--- a/src/DialDictionary/DialDefinitions/src/Graph.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Graph.cpp
@@ -5,7 +5,7 @@
 #include "Graph.h"
 
 LoggerInit([]{
-  Logger::setUserHeaderStr("[Graph]");
+  Logger::setUserHeaderStr("[Graph-ROOT]");
 });
 
 void Graph::setAllowExtrapolation(bool allowExtrapolation) {

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -179,6 +179,7 @@ void Propagator::reweightMcEvents() {
   if( GundamGlobals::getEnableCacheManager() ) {
     Cache::Manager::Update(getSampleSet(), getEventDialCache());
     usedGPU = Cache::Manager::Fill();
+    if (GundamGlobals::getForceDirectCalculation()) usedGPU = false;
   }
 #endif
   if( not usedGPU ){

--- a/src/SamplesManager/include/Event.h
+++ b/src/SamplesManager/include/Event.h
@@ -22,6 +22,9 @@
 #include <string>
 #include <sstream>
 
+
+namespace Cache { class Manager; }
+
 class Event{
 
 public:
@@ -53,7 +56,8 @@ private:
   EventUtils::Variables _variables_{};
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
-public:
+private:
+  friend class Cache::Manager;
   [[nodiscard]] const EventUtils::Cache& getCache() const{ return _cache_; }
   EventUtils::Cache& getCache(){ return _cache_; }
 

--- a/src/SamplesManager/include/EventUtils.h
+++ b/src/SamplesManager/include/EventUtils.h
@@ -107,14 +107,21 @@ namespace EventUtils{
 #ifdef GUNDAM_USING_CACHE_MANAGER
   struct Cache{
     // An "opaque" index into the cache that is used to simplify bookkeeping.
+    // This is actually the index of the result in the buffer filled by the
+    // Cache::Manager (i.e. the index on the GPU).
     int index{-1};
-    // A pointer to the cached result.
+    // A pointer to the cached result.  Will not be a nullptr if the cache is
+    // initialized and should be checked before calling getWeight.  If it is a
+    // nullptr, then that means the cache must not be used.
     const double* valuePtr{nullptr};
-    // A pointer to the cache validity flag.
+    // A pointer to the cache validity flag.  When not nullptr it will point
+    // to the flag for if the cache needs to be updated.  This is only
+    // valid when valuePtr is not null.
     const bool* isValidPtr{nullptr};
-    // A pointer to a callback to force the cache to be updated.
+    // A pointer to a callback to force the cache to be updated.  This will
+    // force the value to be copied from the GPU to the host (if necessary).
     void (*updateCallbackPtr)(){nullptr};
-
+    // Get the value of the weight.
     [[nodiscard]] double getWeight() const;
   };
 #endif

--- a/src/SamplesManager/src/Event.cpp
+++ b/src/SamplesManager/src/Event.cpp
@@ -5,6 +5,7 @@
 #include "Event.h"
 
 #include "GundamGlobals.h"
+#include "GundamAlmostEqual.h"
 
 #include "GenericToolbox.Root.h"
 #include "Logger.h"
@@ -18,8 +19,14 @@ LoggerInit([]{
 // const getters
 double Event::getEventWeight() const {
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if( not GundamGlobals::getForceDirectCalculation()
-      && getCache().valuePtr != nullptr  ){ return getCache().getWeight(); }
+  if( getCache().valuePtr != nullptr  ){
+    double value =  getCache().getWeight();
+    if (not GundamGlobals::getForceDirectCalculation()) return value;
+    LogThrowIf(not GundamUtils::almostEqual(value, _weights_.current),
+               "Inconsistent event weight -- "
+               << " Calculated: " << value
+               << " Cached: " << _weights_.current);
+  }
 #endif
   return _weights_.current;
 }

--- a/src/SamplesManager/src/Event.cpp
+++ b/src/SamplesManager/src/Event.cpp
@@ -4,6 +4,8 @@
 
 #include "Event.h"
 
+#include "GundamGlobals.h"
+
 #include "GenericToolbox.Root.h"
 #include "Logger.h"
 
@@ -13,11 +15,11 @@ LoggerInit([]{
   Logger::setUserHeaderStr("[Event]");
 });
 
-
 // const getters
 double Event::getEventWeight() const {
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if( _cache_.valuePtr != nullptr ){ return _cache_.getWeight(); }
+  if( not GundamGlobals::getForceDirectCalculation()
+      && getCache().valuePtr != nullptr  ){ return getCache().getWeight(); }
 #endif
   return _weights_.current;
 }
@@ -30,7 +32,6 @@ std::string Event::getSummary() const {
   ss << std::endl << "Variables{" << std::endl << _variables_ << std::endl << "}";
   return ss.str();
 }
-
 
 //  A Lesser GNU Public License
 

--- a/src/SamplesManager/src/EventUtils.cpp
+++ b/src/SamplesManager/src/EventUtils.cpp
@@ -162,7 +162,6 @@ namespace EventUtils{
     }
     LogThrowIf(valuePtr == nullptr, "No value cache"); // Trap for bad calls
     LogThrowIf(std::isnan(*valuePtr), "NaN weight");   // Trap for bad calcs.
-    LogError << "Using Cache::Manager for event weight (very slow)" << std::endl;
     return *valuePtr;
   }
 }

--- a/src/SamplesManager/src/EventUtils.cpp
+++ b/src/SamplesManager/src/EventUtils.cpp
@@ -160,55 +160,10 @@ namespace EventUtils{
       // (*_CacheManagerUpdate_)().
       if( updateCallbackPtr != nullptr ){ (*updateCallbackPtr)(); }
     }
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning CACHE_MANAGER_SLOW_VALIDATION used in PhysicsEvent::getEventWeight
-      do {
-          static double maxDelta = 1.0E-20;
-          static double sumDelta = 0.0;
-          static double sum2Delta = 0.0;
-          static long long int numDelta = 0;
-          double res = *_CacheManagerValue_;
-          double avg = 0.5*(std::abs(res) + std::abs(_eventWeight_));
-          if (avg < getTreeWeight()) avg = getTreeWeight();
-          double delta = std::abs(res - _eventWeight_);
-          delta /= avg;
-          maxDelta = std::max(maxDelta,delta);
-          if (delta < 1e-4) {
-              sumDelta += delta;
-              sum2Delta += delta*delta;
-              ++numDelta;
-              if (numDelta < 0) throw std::runtime_error("validation wrap");
-              if ((numDelta % 1000000) == 0) {
-                  LogInfo << "VALIDATION: Average event weight delta: "
-                          << sumDelta/numDelta
-                          << " +/- " << std::sqrt(
-                              sum2Delta/numDelta
-                              - sumDelta*sumDelta/numDelta/numDelta)
-                          << " Maximum: " << maxDelta
-                          << " " << numDelta
-                          << std::endl;
-              }
-          }
-          if (maxDelta < 1E-5) break;
-          if (delta > 100.0*sumDelta/numDelta) break;
-          LogWarning << "WARNING: Event weight difference: " << delta
-                     << " Cache: " << res
-                     << " Dial: " << _eventWeight_
-                     << " Tree: " << getTreeWeight()
-                     << " Delta: " << delta
-                     << " Max: " << maxDelta
-                     << std::endl;
-      } while(false);
-#endif
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning CACHE_MANAGER_SLOW_VALIDATION force CPU _eventWeight_
-      // When the slow validation is running, the "CPU" event weight is
-      // calculated after Cache::Manager::Fill
-      return _eventWeight_;
-#endif
-    LogThrowIf(not std::isfinite(*valuePtr), "NaN weight");
+    LogThrowIf(valuePtr == nullptr, "No value cache"); // Trap for bad calls
+    LogThrowIf(std::isnan(*valuePtr), "NaN weight");   // Trap for bad calcs.
+    LogError << "Using Cache::Manager for event weight (very slow)" << std::endl;
     return *valuePtr;
   }
 }
 #endif
-

--- a/src/SamplesManager/src/SampleElement.cpp
+++ b/src/SamplesManager/src/SampleElement.cpp
@@ -89,12 +89,12 @@ void SampleElement::refillHistogram(int iThread_){
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
   if (_CacheManagerValid_ and not (*_CacheManagerValid_)) {
-      // This can be slowish when data must be copied from the device, but
-      // it makes sure that the results are copied from the device when they
-      // have changed. The values pointed to by _CacheManagerValue_ and
-      // _CacheManagerValid_ are inside the summed index cache (a bit of
-      // evil coding here), and are updated by the cache.  The update is
-      // triggered by (*_CacheManagerUpdate_)().
+      // This can be slow (~10 usec for 5000 bins) when data must be copied
+      // from the device, but it makes sure that the results are copied from
+      // the device when they have changed. The values pointed to by
+      // _CacheManagerValue_ and _CacheManagerValid_ are inside the summed
+      // index cache (a bit of evil coding here), and are updated by the
+      // cache.  The update is triggered by (*_CacheManagerUpdate_)().
       if (_CacheManagerUpdate_) (*_CacheManagerUpdate_)();
   }
 #endif
@@ -114,23 +114,6 @@ void SampleElement::refillHistogram(int iThread_){
       const double ew2 = _CacheManagerValue2_[_CacheManagerIndex_+binPtr->index];
       binPtr->content += ew;
       binPtr->error += ew2;
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-      double content = binContentArray[iBin+1];
-      double slowValue = 0.0;
-      for( auto* eventPtr : perBinEventPtrList.at(iBin)){
-        slowValue += eventPtr->getEventWeight();
-      }
-      double delta = std::abs(slowValue-content);
-      if (delta > 1E-6) {
-        LogInfo << "VALIDATION: Mismatched bin: " << _CacheManagerIndex_
-                << "+" << iBin
-                << "(" << name
-                << ") gpu: " << content
-                << " PhysEvt: " << slowValue
-                << " delta: " << delta
-                << std::endl;
-      }
-#endif // CACHE_MANAGER_SLOW_VALIDATION
     }
     else {
 #endif

--- a/src/SamplesManager/src/SampleElement.cpp
+++ b/src/SamplesManager/src/SampleElement.cpp
@@ -118,6 +118,7 @@ void SampleElement::refillHistogram(int iThread_){
     if (_CacheManagerValue_ !=nullptr and _CacheManagerIndex_ >= 0) {
       value = _CacheManagerValue_[_CacheManagerIndex_+binPtr->index];
       error = _CacheManagerValue2_[_CacheManagerIndex_+binPtr->index];
+      LogThrowIf(std::isnan(value), "Incorrect Cache::Manager initialization");
       binPtr->content = value;
       binPtr->error = error;
       binFilled = not GundamGlobals::getForceDirectCalculation();
@@ -137,13 +138,11 @@ void SampleElement::refillHistogram(int iThread_){
     // Parallel calculations of the histogramming have been run.  Make sure
     // they are the same.
     if (GundamGlobals::getForceDirectCalculation() and filledWithManager) {
-      if (not GundamUtils::almostEqual(value,binPtr->content)
-          || not GundamUtils::almostEqual(error,binPtr->error)) {
-        LogError << "Incorrect weight calculation"
+      LogThrowIf(not GundamUtils::almostEqual(value,binPtr->content)
+                 || not GundamUtils::almostEqual(error,binPtr->error),
+                 "Incorrect histogram content --"
                  << " Content: " << value << "!=" << binPtr->content
-                 << " Error: " << error << "!=" << binPtr->error
-                 << std::endl;
-      }
+                 << " Error: " << error << "!=" << binPtr->error);
     }
 #endif
     binPtr->error = std::sqrt(binPtr->error);

--- a/src/Utils/include/GundamAlmostEqual.h
+++ b/src/Utils/include/GundamAlmostEqual.h
@@ -1,0 +1,60 @@
+#ifndef GundamAlmostEqual_h_seen
+#define GundamAlmostEqual_h_seen
+#include <iostream>
+#include <cmath>
+
+namespace GundamUtils {
+
+    /// Check if two real numbers are close enough to be considered equal.
+    /// This takes into account different effects: 1) precision of the
+    /// underlying numerical representation; 2) the magnitudes of the numbers
+    /// being compared; and 3), the fraction of bits that are expected to have
+    /// been lost during the numeric calculation.  The fractions of bits lost
+    /// will be a number between 0.0 and 1.0, where 0 means no bits are lost
+    /// due to numerical problems, and 1 means all bits are lost.  The number
+    /// of bits grows (very) roughly like the square root of the numbers of
+    /// operations, but depends heavily on the actual sequence of operations.
+    /// Losing 30% of the accuracy is a plausible default bound.
+    ///
+    /// Note: This is intended for testing and debugging.  It is not intended
+    /// for "production", and is written to be painfully clear about it's
+    /// assumptions.
+    template <typename U, typename V>
+    bool almostEqual(U A, V B, double fractionOfBitsLost = 0.3) {
+        // Non-finite numbers are never equal.
+        if (not std::isfinite(A) || not std::isfinite(B)) return false;
+
+        // Internally, operate on actual doubles.  This is for simplicity and
+        // clarity.
+        const double a = A;
+        const double b = B;
+
+        // Find the precision of the least precise value.
+        double epsA = std::numeric_limits<U>::epsilon();
+        double epsB = std::numeric_limits<V>::epsilon();
+        double eps = std::max(epsA, epsB);  // Take the worst precision
+
+        // Reduce the precision:  This accounts for the fraction of bits of
+        // accuracy that has been lost during the calculation.
+        if (fractionOfBitsLost > 0.0) {
+            fractionOfBitsLost = std::min(fractionOfBitsLost, 0.99);
+            eps = std::pow(eps, (1.0-fractionOfBitsLost));
+        }
+
+        // Scale to the value magnitudes.  Don't let the precision become
+        // subnormal.  The standard binary representation for a floating point
+        // number intends to have the first bit be "1" (called normal).  A
+        // subnormal representation means that the first bit is zero.  For
+        // instance (using decimal), 0.00123 has a normal representatin of
+        // 1.23E-3, and (one possible) subnormal representation of 0.0123E-1
+        // (you can find references on the web that are more precise).
+        if (std::isnormal(a*eps)) epsA = std::abs(a*eps);
+        if (std::isnormal(b*eps)) epsB = std::abs(b*eps);
+        double finalEPS = std::max(epsA, epsB);
+
+        // Check that the difference is less than the acceptable precision
+        double diff = std::abs(a - b);
+        return (diff < finalEPS);
+    }
+}
+#endif

--- a/src/Utils/include/GundamGlobals.h
+++ b/src/Utils/include/GundamGlobals.h
@@ -30,12 +30,16 @@ public:
 
   // Setters
   static void setEnableCacheManager(bool enable = true){ _enableCacheManager_ = enable; }
+  static void setNumberOfThreads(int threads=1){ _gundamThreads_ = threads; }
+  static void setForceDirectCalculation(bool enable=false){ _forceDirectCalculation_ = enable; }
   static void setLightOutputMode(bool enable_){ _lightOutputMode_ = enable_; }
   static void setDisableDialCache(bool disableDialCache_){ _disableDialCache_ = disableDialCache_; }
   static void setVerboseLevel(VerboseLevel verboseLevel_);
 
   // Getters
+  static int getNumberOfThreads(){ return _gundamThreads_; }
   static bool getEnableCacheManager(){ return _enableCacheManager_; }
+  static bool getForceDirectCalculation(){ return _forceDirectCalculation_; }
   static bool isDisableDialCache(){ return _disableDialCache_; }
   static bool isLightOutputMode(){ return _lightOutputMode_; }
   static VerboseLevel::EnumType getVerboseLevel(){ return _verboseLevel_.value; }
@@ -44,8 +48,10 @@ public:
 
 private:
 
+  static int _gundamThreads_;
   static bool _disableDialCache_;
   static bool _enableCacheManager_;
+  static bool _forceDirectCalculation_;
   static bool _lightOutputMode_;
   static std::mutex _threadMutex_;
   static VerboseLevel _verboseLevel_;

--- a/src/Utils/src/GundamGlobals.cpp
+++ b/src/Utils/src/GundamGlobals.cpp
@@ -12,8 +12,10 @@ LoggerInit([]{
 });
 
 // statics
+int GundamGlobals::_gundamThreads_{1};
 bool GundamGlobals::_disableDialCache_{false};
 bool GundamGlobals::_enableCacheManager_{false};
+bool GundamGlobals::_forceDirectCalculation_{false};
 bool GundamGlobals::_lightOutputMode_{false};
 std::mutex GundamGlobals::_threadMutex_;
 VerboseLevel GundamGlobals::_verboseLevel_{VerboseLevel::NORMAL_MODE};

--- a/tests/fast-tests/200CovarianceFit-CacheManager.sh
+++ b/tests/fast-tests/200CovarianceFit-CacheManager.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}-CacheManager.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter --cache-manager -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu --cache-manager -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-catmull.sh
+++ b/tests/fast-tests/200CovarianceFit-catmull.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-graph.sh
+++ b/tests/fast-tests/200CovarianceFit-graph.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-graph.yaml
+++ b/tests/fast-tests/200CovarianceFit-graph.yaml
@@ -85,7 +85,7 @@ fitterEngineConfig:
             isEnabled: true
             dialSetDefinitions:
               - dialsType: Graph
-                dialSubType: ROOT
+                # No longer tested -- dialSubType: ROOT
                 dialLeafName: "spline_C"
                 applyOnDataSets: [ "TestSample" ]
                 applyCondition: "[C] > 0"

--- a/tests/fast-tests/200CovarianceFit.sh
+++ b/tests/fast-tests/200CovarianceFit.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200DecompositionFit.sh
+++ b/tests/fast-tests/200DecompositionFit.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200NormalizationAsimov.sh
+++ b/tests/fast-tests/200NormalizationAsimov.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script


### PR DESCRIPTION
This is a rather badly named branch.  It started as just removing some defunct testing code, but there was a problem in how the event weight cache was being filled.  While working on that, I that the Cache::Manager initialization had been disabled.  Reenabling that turned up some places where values hadn't been initialized in the event weight cache and that required a small change in the logic.  That prompted adding the ability to 
mirror the calculation of the likelihood between the CPU and GPU.  

The tests now calculate both likelihoods (simultaneously) and flag when they are different (when enabled, that adds about 10% on top of the CPU only calculation).  When the GPU is available, the mirrored calculation can be turned on using the "--cpu" command line option.  

Only the last few commits actually fix bugs, the rest of the commits setup the testing.
