### PR TITLE
Resolve issue #524 : Finish implemenation of the global event weight cap

### DIFF
--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -30,6 +30,14 @@ private:
     // The accumulated weights for each histogram bin.
     std::unique_ptr<hemi::Array<double>> fSums2;
 
+    // The lower bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fLowerClamp;
+
+    // The upper bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fUpperClamp;
+
     // Cache of whether the result values in memory are valid.
     bool fSumsValid;
 
@@ -53,6 +61,14 @@ public:
 
     // Assigns the bin number that an event will be added to.
     void SetEventIndex(int event, int bin);
+
+    // Set the maximum event weight to be applied as an upper clamp during the
+    // sum.  (Default: infinity).
+    void SetMaximumEventWeight(double maximum);
+
+    // Set the minimum event weight to be applied as an upper clamp during the
+    // sum.  (Default: negative infinity).
+    void SetMinimumEventWeight(double minimum);
 
     /// Return the number of histogram bins that are accumulated.
     std::size_t GetSumCount() const {return fSums->size();}

--- a/src/CacheManager/include/WeightCompactSpline.h
+++ b/src/CacheManager/include/WeightCompactSpline.h
@@ -132,20 +132,6 @@ public:
     // Get the function value for a knot in the spline at sIndex
     double GetSplineKnot(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightGeneralSpline.h
+++ b/src/CacheManager/include/WeightGeneralSpline.h
@@ -125,20 +125,6 @@ public:
     double GetSplineKnotValue(int sIndex,int knot);
     double GetSplineKnotSlope(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightMonotonicSpline.h
+++ b/src/CacheManager/include/WeightMonotonicSpline.h
@@ -132,20 +132,6 @@ public:
     // Get the function value for a knot in the spline at sIndex
     double GetSplineKnot(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/WeightUniformSpline.h
+++ b/src/CacheManager/include/WeightUniformSpline.h
@@ -123,20 +123,6 @@ public:
     double GetSplineKnotValue(int sIndex,int knot);
     double GetSplineKnotSlope(int sIndex,int knot);
 
-    ////////////////////////////////////////////////////////////////////
-    // This section is for the validation methods.  They should mostly be
-    // NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-    double* GetCachePointer(int sIndex);
-
-    /// An array of values for the result of each spline.  When this is
-    /// active, it is filled but the kernel, but only copied to the CPU if
-    /// it's access.  NOTE: Enabling this significantly slows the calculation
-    /// since it adds another large copy from the GPU.
-    std::unique_ptr<hemi::Array<double>> fSplineValue;
-#endif
-
 };
 
 // An MIT Style License

--- a/src/CacheManager/src/CacheIndexedSums.cpp
+++ b/src/CacheManager/src/CacheIndexedSums.cpp
@@ -101,6 +101,7 @@ double Cache::IndexedSums::GetSum(int i) {
     // make sure that the optimizer doesn't reorder the statements.
     double value = fSums->hostPtr()[i];
     if (not std::isnan(value)) fSumsValid = true;
+    else LogThrow("Cache::IndexedSums sum is nan");
     return value;
 }
 
@@ -112,6 +113,7 @@ double Cache::IndexedSums::GetSum2(int i) {
     // make sure that the optimizer doesn't reorder the statements.
     double value = fSums2->hostPtr()[i];
     if (not std::isnan(value)) fSumsValid = true;
+    else LogThrow("Cache::IndexedSums sum2 is nan");
     return value;
 }
 

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -30,7 +30,6 @@
 #include "Shift.h"
 
 #include <memory>
-#include <vector>
 #include <set>
 
 LoggerInit([]{

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -620,6 +620,12 @@ bool Cache::Manager::Update(SampleSet& sampleList,
         LogThrow("Histogram cells are missing");
     }
 
+    // If the event weight cap has been set, then pass it along
+    if (std::isfinite(EventDialCache::globalEventReweightCap)) {
+        Cache::Manager::Get()->GetHistogramsCache().SetMaximumEventWeight(
+            EventDialCache::globalEventReweightCap);
+    }
+
     return true;
 }
 

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -70,7 +70,8 @@ double Cache::Weights::GetResult(int i) {
     // finishes before the result is set to be valid.  The use of isnan is
     // to make sure that the optimizer doesn't reorder the statements.
     double value = fResults->hostPtr()[i];
-    if (std::isnan(value)) fResultsValid = true;
+    if (not std::isnan(value)) fResultsValid = true;
+    else LogThrow("Cache::Weights result is nan");
     return value;
 }
 
@@ -79,7 +80,8 @@ double Cache::Weights::GetResultFast(int i) {
     // finishes before the result is set to be valid.  The use of isnan is
     // to make sure that the optimizer doesn't reorder the statements.
     double value = fResults->hostPtr()[i];
-    if (std::isnan(value)) fResultsValid = true;
+    if (not std::isnan(value)) fResultsValid = true;
+    else LogThrow("Cache::Weights result is nan");
     return value;
 }
 

--- a/src/CacheManager/src/WeightGeneralSpline.cpp
+++ b/src/CacheManager/src/WeightGeneralSpline.cpp
@@ -48,14 +48,6 @@ Cache::Weight::GeneralSpline::GeneralSpline(
                    "Invalid space option for compact splines");
     }
 
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
-        // Add validation code for the spline calculation.  This can be rather
-        // slow, so do not use if it is not required.
-    fTotalBytes += GetSplinesReserved()*sizeof(double);
-#endif
-
     LogInfo << "Reserved " << GetName()
             << " Spline Knots: " << GetSplineSpaceReserved()
             << std::endl;
@@ -76,13 +68,6 @@ Cache::Weight::GeneralSpline::GeneralSpline(
         LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
         fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
         LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GeneralSpline
-        // Add validation code for the spline calculation.  This can be rather
-        // slow, so do not use if it is not required.
-        fSplineValue.reset(new hemi::Array<double>(GetSplinesReserved(),true));
-#endif
 
         // Get the CPU/GPU memory for the spline knots.  This is copied once
         // during initialization so do not pin the CPU memory into the page
@@ -251,26 +236,6 @@ double Cache::Weight::GeneralSpline::GetSplineKnotPlace(int sIndex, int knot) {
     return fSplineSpace->hostPtr()[knotsIndex+2+3*knot+2];
 }
 
-////////////////////////////////////////////////////////////////////
-// This section is for the validation methods.  They should mostly be
-// NOOPs and should mostly not be called.
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::GetSplineValue
-// Get the intermediate spline result that is used to calculate an event
-// weight.  This can trigger a copy from the GPU to CPU, and must only be
-// enabled during validation.  Using this validation code also significantly
-// increases the amount of GPU memory required.  In a short sentence, "Do not
-// use this method."
-double* Cache::Weight::GeneralSpline::GetCachePointer(int sIndex) {
-    LogThrowIf((sIndex < 0), "GetSplineValue: Spline index invalid");
-    LogThrowIf((GetSplinesUsed() <= sIndex), "GetSplineValue: Spline index invalid");
-    // This can trigger a *slow* copy of the spline values from the GPU to the
-    // CPU.
-    return fSplineValue->hostPtr() + sIndex;
-}
-#endif
-
 // Define CACHE_DEBUG to get lots of output from the host
 #undef CACHE_DEBUG
 #define PRINT_STEP 3
@@ -284,11 +249,6 @@ namespace {
     // must be valid CUDA coda.
     HEMI_KERNEL_FUNCTION(HEMISplinesKernel,
                          double* results,
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::HEMISplinesKernel
-                         // inputs/output for validation
-                         double* splineValues,
-#endif
                          const double* params,
                          const double* lowerClamp,
                          const double* upperClamp,
@@ -343,10 +303,6 @@ namespace {
 #endif
 #endif
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::HEMISplinesKernel
-            splineValues[i] = v;
-#endif
             CacheAtomicMult(&results[rIndex[i]], v);
         }
     }
@@ -366,10 +322,6 @@ bool Cache::Weight::GeneralSpline::Apply() {
     HEMISplinesKernel splinesKernel;
     hemi::launch(splinesKernel,
                  fWeights.writeOnlyPtr(),
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::Apply
-                 fSplineValue->writeOnlyPtr(),
-#endif
                  fParameters.readOnlyPtr(),
                  fLowerClamp.readOnlyPtr(),
                  fUpperClamp.readOnlyPtr(),
@@ -379,11 +331,6 @@ bool Cache::Weight::GeneralSpline::Apply() {
                  fSplineIndex->readOnlyPtr(),
                  GetSplinesUsed()
         );
-
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-#warning Using SLOW VALIDATION and copying spline values
-    fSplineValue->hostPtr();
-#endif
 
     return true;
 }


### PR DESCRIPTION
Closes #524 

Adds an upper and lower clamp to the Cache::IndexedSums calculation that can be used to implement the global event weight cap.  The upper clamp is set using EventDialCache::globalEventReweightCap.  