### PR TITLE
Reconsider --cache-manager option

### DIFF
--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -81,7 +81,7 @@ int main(int argc, char** argv){
   clParser.addDummyOption("Runtime/debug options");
 
   clParser.addOption("debugVerbose", {"--debug"}, "Enable debug verbose (can provide verbose level arg)", 1, true);
-  clParser.addTriggerOption("usingCacheManager", {"--cache-manager"}, "Toggle the usage of the CacheManager (i.e. the GPU)");
+  clParser.addOption("usingCacheManager", {"--cache-manager"}, "Toggle the usage of the CacheManager (i.e. the GPU)",1,true);
   clParser.addTriggerOption("usingGpu", {"--gpu"}, "Use GPU parallelization");
   clParser.addTriggerOption("forceDirect", {"--cpu"}, "Force direct calculation of weights (for debugging)");
   clParser.addOption("overrides", {"-O", "--override"}, "Add a config override [e.g. /fitterEngineConfig/engineType=mcmc)", -1);
@@ -126,7 +126,15 @@ int main(int argc, char** argv){
 #ifdef GUNDAM_USING_CACHE_MANAGER
   useCache = Cache::Parameters::HasGPU(true);
 #endif
-  if (clParser.isOptionTriggered("usingCacheManager")) useCache = not useCache;
+  if (clParser.isOptionTriggered("usingCacheManager")) {
+      int values = clParser.getNbValueSet("usingCacheManager");
+      if (values < 1) useCache = not useCache;
+      else if ("on" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = true;
+      else if ("off" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = false;
+      else {
+          LogThrow("Invalid --cache-manager argument: must be empty, 'on' or 'off'");
+      }
+  }
   if (clParser.isOptionTriggered("usingGpu")) useCache = true;
 
 #ifdef GUNDAM_USING_CACHE_MANAGER


### PR DESCRIPTION
The --cache-manager option was a trigger that toggled the state of the Cache::Manager, but now the default is set by the presence of a GPU, so it's less deterministic.  This leaves the default behavior alone, but adds optional "on" and "off" arguments.