### PR TITLE
LTS 1.8.x: Resolve Issue 530 -- GPU sum efficiency

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,7 @@
 Fixes relative to 1.8.3
 
+Issue # 530 : Fix an inefficiency in the summation of the event weights on the GPU and double the speed of the likelihood calculation using the GPU.
+
 Issue # 524 : Apply the global event weight cap when using the Cache::Manager to calculate the likelihood.
 
 Fixes relative to 1.8.2

--- a/src/CacheManager/CMakeLists.txt
+++ b/src/CacheManager/CMakeLists.txt
@@ -17,6 +17,7 @@ set( HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WeightGraph.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/WeightBase.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/CacheIndexedSums.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/CacheRecursiveSums.h
 )
 
 set( SRC_FILE_EXT "cpp" )
@@ -36,6 +37,7 @@ list( APPEND SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/src/WeightBase.${SRC_FILE_EXT}
 list( APPEND SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/src/CacheParameters.${SRC_FILE_EXT} )
 list( APPEND SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/src/CacheWeights.${SRC_FILE_EXT} )
 list( APPEND SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/src/CacheIndexedSums.${SRC_FILE_EXT} )
+list( APPEND SRCFILES ${CMAKE_CURRENT_SOURCE_DIR}/src/CacheRecursiveSums.${SRC_FILE_EXT} )
 
 if( USE_STATIC_LINKS )
   add_library(GundamCache STATIC ${SRCFILES})

--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -12,9 +12,16 @@ namespace Cache {
     class IndexedSums;
 }
 
-/// A class to calculate and cache a bunch of events weights.  This is where
-/// the actual calculation is controled for the GPU.  It's used by the cache
-/// manager when the GPU needs to be fired up.
+/// A class to accumulate the sum of event weights into the histogram bins on
+/// the GPU (or CPU).  This provides a parallel reduction (a sum) by using
+/// attomic operations when adding values.  On a GPU, this can result in a lot
+/// of collisions since the additions are happening in a large number of
+/// (almost) synchronized threads.
+///
+/// The accumulation runs the "sum" kernel once, so conceptually each thread
+/// adds one number to a sum, but the atomic operation will take O(N) attempts
+/// to finish the addition where N is the number of entries in the maximum
+/// histogram bin.
 class Cache::IndexedSums {
 private:
     // Save the event weight cache reference for later use

--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -56,6 +56,9 @@ public:
     /// does not deallocate any memory.
     void Reset();
 
+    /// Dummy to match interface with CacheRecursiveSums.
+    void Initialize() {}
+
     /// Return the approximate allocated memory (e.g. on the GPU).
     std::size_t GetResidentMemory() const {return fTotalBytes;}
 

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -11,7 +11,21 @@
 #include "WeightGeneralSpline.h"
 #include "WeightGraph.h"
 
+#ifdef CACHE_MANAGER_USE_INDEXED_SUMS
+// An older implementation of the histogram summing that may be faster for
+// some (peculiar) data sets.
 #include "CacheIndexedSums.h"
+namespace Cache {
+    using HistogramSum = Cache::IndexedSums;
+}
+#else
+// A GPU optimized implementation of histogram summing that will be faster
+// for most data sets.
+#include "CacheRecursiveSums.h"
+namespace Cache {
+    using HistogramSum = Cache::RecursiveSums;
+}
+#endif
 
 #include "SampleSet.h"
 #include "EventDialCache.h"
@@ -107,7 +121,7 @@ private:
     std::unique_ptr<Cache::Weight::Graph> fGraphs;
 
     /// The cache for the summed histgram weights
-    std::unique_ptr<Cache::IndexedSums> fHistogramsCache;
+    std::unique_ptr<Cache::HistogramSum> fHistogramsCache;
 
     // The rough size of all the caches.
     std::size_t fTotalBytes;
@@ -119,7 +133,7 @@ public:
     // implementation, and should be ignored by most people.
     Cache::Parameters& GetParameterCache() {return *fParameterCache;}
     Cache::Weights&    GetWeightsCache() {return *fWeightsCache;}
-    Cache::IndexedSums& GetHistogramsCache() {return *fHistogramsCache;}
+    Cache::HistogramSum& GetHistogramsCache() {return *fHistogramsCache;}
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/CacheRecursiveSums.h
+++ b/src/CacheManager/include/CacheRecursiveSums.h
@@ -1,0 +1,164 @@
+#ifndef CacheRecursiveSums_h_seen
+#define CacheRecursiveSums_h_seen
+
+#include "CacheWeights.h"
+
+#include "hemi/array.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace Cache {
+    class RecursiveSums;
+}
+
+/// A class to accumulate the sum of event weights into the histogram bins on
+/// the GPU (or CPU).  This provides a parallel reduction (a sum) without
+/// using atomic operations by interleaving pairwise sums and "recursively"
+/// calling the kernel.  On a GPU, it results in about a x10 speed up over a
+/// naive sum using atomic operations, but requires more GPU global memory
+/// since it uses an internal work space.
+///
+/// The accumulation runs the "sum" kernel O(log N) times where N is the
+/// number of entries in the maximum histogram bin.  The sum is "logically"
+/// recursive, but the code actually iterates by calling the summing kernel
+/// multiple times.
+class Cache::RecursiveSums {
+private:
+    // Save the event weight cache reference for later use.  This is provided
+    // to the constructor.
+    Cache::Weights::Results& fEventWeights;
+
+    // The histogram bin index for each entry in the fWeights array (this is
+    // the same size as fEventWeights.  This is filled before initialization.
+    std::unique_ptr<hemi::Array<short>> fIndexes;
+
+    // An internal buffer holding the offset of each histogram bin in the
+    // event index array.  The start of the events in bin "N" will be
+    // fBinOffsets[N], and the end will be fBinOffsets[N+1], so looping over
+    // the events will be "for(i=fBinOffsets[N]; i<fBinOffsets[N+1]; ++i)"
+    std::unique_ptr<hemi::Array<int>> fBinOffsets;
+
+    // An internal buffer storing the index of each entry associated in the
+    // fWeights array associated with the histogram bin.  The fBinOffsets
+    // field defines which bin the entries are associated with.
+    std::unique_ptr<hemi::Array<int>> fEventIndexes;
+
+    // An internal buffer used to do the recursive sum.  This starts as a copy
+    // of the fEventWeights input array (reordered by bin index), and is
+    // mutated until the sums can be read.
+    std::unique_ptr<hemi::Array<double>> fWorkBuffer;
+
+    // An internal buffer used to map the fWorkBuffer index to the histogram
+    // bin index.
+    std::unique_ptr<hemi::Array<short>> fBinIndexes;
+
+    // The maximum number of entries in any bin. This will determine the number
+    // of iterations needed to calculate the sum.
+    int fMaxEntries;
+
+    // The accumulated weights for each histogram bin.
+    std::unique_ptr<hemi::Array<double>> fSums;
+
+    // The accumulated weights for each histogram bin.
+    std::unique_ptr<hemi::Array<double>> fSums2;
+
+    // The lower bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fLowerClamp;
+
+    // The upper bound for any individual entry in the fWeights array.  This
+    // is a global event weight clamp.
+    double fUpperClamp;
+
+    // Cache of whether the result values in memory are valid.
+    bool fSumsValid;
+
+    /// The (approximate) amount of memory required on the GPU.
+    std::size_t fTotalBytes{};
+
+public:
+    RecursiveSums(Cache::Weights::Results& eventWeight,
+                  std::size_t bins);
+
+    /// Deconstruct the class.  This should deallocate all the memory
+    /// everyplace.
+    virtual ~RecursiveSums();
+
+    /// Reinitialize the cache.  This puts it into a state to be refilled, but
+    /// does not deallocate any memory.
+    void Reset();
+
+    /// Initialize the internal buffers for the cache for all of the events.
+    /// This builds all the maps between histogram bin and event index (and
+    /// counts the number of entries in each bin.
+    void Initialize();
+
+    /// Return the approximate allocated memory (e.g. on the GPU).
+    std::size_t GetResidentMemory() const {return fTotalBytes;}
+
+    // Assigns the bin number that an event will be added to.
+    void SetEventIndex(int event, int bin);
+
+    // Set the maximum event weight to be applied as an upper clamp during the
+    // sum.  (Default: infinity).
+    void SetMaximumEventWeight(double maximum);
+
+    // Set the minimum event weight to be applied as an upper clamp during the
+    // sum.  (Default: negative infinity).
+    void SetMinimumEventWeight(double minimum);
+
+    /// Return the number of histogram bins that are accumulated.
+    std::size_t GetSumCount() const {return fSums->size();}
+
+    /// Calculate the results and save them for later use.  This copies the
+    /// results from the GPU to the CPU.
+    virtual bool Apply();
+
+    /// Get the sum for index i from host memory.  This might trigger a copy
+    /// from the device if that is necessary.
+    double GetSum(int i);
+
+    /// Get the sum squared for index i from host memory.  This might trigger
+    /// a copy from the device if that is necessary.
+    double GetSum2(int i);
+
+    /// The pointer to the array of sums on the host.
+    const double* GetSumsPointer();
+
+    /// The pointer to the array of sums squared on the host.
+    const double* GetSums2Pointer();
+
+    /// A pointer to the validity flag.
+    bool* GetSumsValidPointer();
+
+};
+
+// An MIT Style License
+
+// Copyright (c) 2024 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:
+#endif

--- a/src/CacheManager/src/CacheRecursiveSums.cpp
+++ b/src/CacheManager/src/CacheRecursiveSums.cpp
@@ -1,0 +1,371 @@
+#include "CacheRecursiveSums.h"
+#include "CacheWeights.h"
+
+#include <iostream>
+#include <exception>
+#include <cmath>
+#include <memory>
+#include <limits>
+
+#include <hemi/hemi_error.h>
+#include <hemi/launch.h>
+#include <hemi/grid_stride_range.h>
+
+#include "Logger.h"
+
+LoggerInit([]{
+  Logger::setUserHeaderStr("[Cache::RecursiveSums]");
+});
+
+// The constructor
+Cache::RecursiveSums::RecursiveSums(Cache::Weights::Results& inputs,
+                                    std::size_t bins)
+    : fEventWeights(inputs),
+      fLowerClamp(-std::numeric_limits<double>::infinity()),
+      fUpperClamp(std::numeric_limits<double>::infinity()) {
+    LogThrowIf((inputs.size()<1), "No bins to sum");
+    LogThrowIf((bins<1), "No bins to sum");
+
+    LogInfo << "Cached RecursiveSums -- bins reserved: "
+           << bins
+           << std::endl;
+    fTotalBytes += bins*sizeof(double);                   // fSums
+    fTotalBytes += bins*sizeof(double);                   // fSums2
+    fTotalBytes += fEventWeights.size()*sizeof(short);    // fIndexes;
+    fTotalBytes += (bins+1)*sizeof(int);                  // fBinOffsets
+    fTotalBytes += fEventWeights.size()*sizeof(int);      // fEventIndexes
+    fTotalBytes += fEventWeights.size()*sizeof(double);   // fWorkBuffer
+    fTotalBytes += fEventWeights.size()*sizeof(short);    // fBinIndexes
+
+    LogInfo << "Cached RecursiveSums -- approximate memory size: "
+            << double(fTotalBytes)/1E+6
+            << " MB" << std::endl;
+
+    try {
+        // Get CPU/GPU memory for the results and their initial values.  The
+        // results are copied every time, so pin the CPU memory into the page
+        // set.  The initial values are seldom changed, so they are not
+        // pinned.
+        fSums = std::make_unique<hemi::Array<double>>(bins,true);
+        LogThrowIf(not fSums, "Bad Sums Alloc");
+        fSums2 = std::make_unique<hemi::Array<double>>(bins,true);
+        LogThrowIf(not fSums2, "Bad Sums2 Alloc");
+
+        fIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
+        LogThrowIf(not fIndexes, "Bad Indexes Alloc");
+        fBinOffsets = std::make_unique<hemi::Array<int>>(bins+1,false);
+        LogThrowIf(not fBinOffsets, "Bad BinOffsets Alloc");
+        fEventIndexes = std::make_unique<hemi::Array<int>>(fEventWeights.size(),false);
+        LogThrowIf(not fEventIndexes,"Bad EventIndexes Alloc");
+        fWorkBuffer = std::make_unique<hemi::Array<double>>(fEventWeights.size(),false);
+        LogThrowIf(not fWorkBuffer,"Bad WorkBuffer Alloc");
+        fBinIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
+        LogThrowIf(not fBinIndexes,"Bad BinIndexes Alloc");
+    }
+    catch (...) {
+        LogError << "Uncaught exception, so stopping" << std::endl;
+        LogThrow("Uncaught exception -- not enough memory available");
+    }
+
+    // Place the cache into a default state.
+    Reset();
+
+    // Initialize the caches.  Don't try to zero everything since the
+    // caches can be huge.
+    std::fill(fSums->hostPtr(),
+              fSums->hostPtr() + fSums->size(),
+              0.0);
+    std::fill(fSums2->hostPtr(),
+              fSums2->hostPtr() + fSums2->size(),
+              0.0);
+}
+
+// The destructor
+Cache::RecursiveSums::~RecursiveSums() = default;
+
+/// Reset the index sum cache to it's state immediately after construction.
+void Cache::RecursiveSums::Reset() {
+    // Very little to do here since the indexed sum cache is zeroed with it is
+    // filled.  Mark it as invalid out of an abundance of caution!
+    fSumsValid = false;
+}
+
+/// Build the internal tables after all the events are filled.  This can be
+/// slow, but only happens once, and isn't slow on the time scale of start-up.
+void Cache::RecursiveSums::Initialize() {
+
+    // Zero the number of entries in each bin.  This makes sure that all
+    // bins are represented, even if they don't have events.
+    std::map<int,int> binEntryCount;
+    for (int b = 0; b < fSums->size(); ++b) binEntryCount[b] = 0;
+
+    // Count the number of entries in each bin
+    short* idx = fIndexes->hostPtr();
+    for (int e = 0; e < fIndexes->size(); ++e) {
+        ++binEntryCount[idx[e]];
+    }
+
+    // Find the maximum number of entries in any bin.
+    fMaxEntries = 0;
+    for (std::map<int,int>::iterator count = binEntryCount.begin();
+         count != binEntryCount.end(); ++count) {
+        fMaxEntries = std::max(fMaxEntries, count->second);
+    }
+
+    // Fill the offsets for each histogram bin.  This also makes sure that all
+    // the bins exist.  There will be a problem in one of the bins is empty.
+    {
+        int bin = 0;
+        int offset = 0;
+        for (std::map<int,int>::iterator count = binEntryCount.begin();
+             count != binEntryCount.end(); ++count) {
+            LogThrowIf(bin != count->first, "Bin number mismatch");
+            fBinOffsets->hostPtr()[bin] = offset;
+            offset += count->second;
+            ++bin;
+        }
+        fBinOffsets->hostPtr()[bin] = offset;
+    }
+
+    // Build a simple lookup associating each entry in the fWorkBuffer with
+    // a histogram bin.
+    for (int bin = 0; bin < fBinOffsets->size()-1; ++bin) {
+        for (int i = fBinOffsets->hostPtr()[bin];
+             i < fBinOffsets->hostPtr()[bin+1]; ++i) {
+            fBinIndexes->hostPtr()[i] = bin;
+        }
+    }
+
+    // Build the map between the work buffer entry and the weight entry.
+    for (int b = 0; b < fSums->size(); ++b) binEntryCount[b] = 0;
+    for (int entry = 0; entry < fIndexes->size(); ++entry) {
+        int bin = fIndexes->hostPtr()[entry];
+        int offset = fBinOffsets->hostPtr()[bin] + binEntryCount[bin];
+        fEventIndexes->hostPtr()[offset] = entry;
+        ++binEntryCount[bin];
+    }
+
+}
+
+void Cache::RecursiveSums::SetEventIndex(int event, int bin) {
+    LogThrowIf((event < 0), "Event index out of range");
+    LogThrowIf((fEventWeights.size() <= event), "Event index out of range");
+    LogThrowIf((bin<0), "Bin is out of range");
+    LogThrowIf((fSums->size() <= bin), "Bin is out of range");
+    fIndexes->hostPtr()[event] = bin;
+}
+
+void Cache::RecursiveSums::SetMaximumEventWeight(double maximum) {
+    fUpperClamp = maximum;
+}
+
+void Cache::RecursiveSums::SetMinimumEventWeight(double minimum) {
+    fLowerClamp = minimum;
+}
+
+double Cache::RecursiveSums::GetSum(int i) {
+    LogThrowIf(i<0, "Sum index out of range");
+    LogThrowIf((fSums->size() <= i), "Sum index out of range");
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the sum is set to be valid.  The use of isnan is to
+    // make sure that the optimizer doesn't reorder the statements.
+    double value = fSums->hostPtr()[i];
+    if (not std::isnan(value)) fSumsValid = true;
+    else LogThrow("Cache::RecursiveSums sum is nan");
+    return value;
+}
+
+double Cache::RecursiveSums::GetSum2(int i) {
+    LogThrowIf((i<0), "Sum2 index out of range");
+    LogThrowIf((fSums2->size()<= i), "Sum2 index out of range");
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the sum is set to be valid.  The use of isfinite is to
+    // make sure that the optimizer doesn't reorder the statements.
+    double value = fSums2->hostPtr()[i];
+    if (not std::isnan(value)) fSumsValid = true;
+    else LogThrow("Cache::RecursiveSums sum2 is nan");
+    return value;
+}
+
+const double* Cache::RecursiveSums::GetSumsPointer() {
+    return fSums->hostPtr();
+}
+
+const double* Cache::RecursiveSums::GetSums2Pointer() {
+    return fSums2->hostPtr();
+}
+
+bool* Cache::RecursiveSums::GetSumsValidPointer() {
+    return &fSumsValid;
+}
+
+// Define CACHE_DEBUG to get lots of output from the host
+#undef CACHE_DEBUG
+
+#include "CacheAtomicAdd.h"
+
+namespace {
+    // A function to copy the event weights into the internal work buffer
+    HEMI_KERNEL_FUNCTION(HEMIFillWorkBuffer,
+                         double* buffer,
+                         const double* inputs,
+                         const int* indexes,
+                         const double lowerClamp,
+                         const double upperClamp,
+                         const int NP) {
+        for (int i : hemi::grid_stride_range(0,NP)) {
+            double weight = inputs[indexes[i]];
+            if (weight < lowerClamp) weight = lowerClamp;
+            if (weight > upperClamp) weight = upperClamp;
+            buffer[i] = weight;
+        }
+    }
+
+    // A function to copy the squared event weights into the internal work
+    // buffer
+    HEMI_KERNEL_FUNCTION(HEMIFillWorkBuffer2,
+                         double* buffer,
+                         const double* inputs,
+                         const int* indexes,
+                         const double lowerClamp,
+                         const double upperClamp,
+                         const int NP) {
+        for (int i : hemi::grid_stride_range(0,NP)) {
+            double weight = inputs[indexes[i]];
+            if (weight < lowerClamp) weight = lowerClamp;
+            if (weight > upperClamp) weight = upperClamp;
+            buffer[i] = weight*weight;
+        }
+    }
+
+    // Add pairs of values together.  This doesn't need a lock!  It is called
+    // with ever decreasing strides from twice the number of entries in the
+    // maximum bin down to one.  The stride is always a power of two.  During
+    // the first call, the threads will be close to fully occupied, but
+    // eventually the thread efficiency drops (by half) at each iteration.
+    HEMI_KERNEL_FUNCTION(HEMIStridingSum,
+                         double* buffer,
+                         const short* binIndexes,
+                         const int* binOffsets,
+                         int NP,
+                         int stride) {
+        for (int i : hemi::grid_stride_range(0,NP)) {
+            const int bin = binIndexes[i];
+            const int binOffset = binOffsets[bin];
+            const int binMax = binOffsets[bin+1];
+            const int binAdd = i+stride;
+            if (binAdd < binMax && binAdd < binOffset+2*stride) {
+                buffer[i] += buffer[binAdd];
+            }
+        }
+    }
+
+    // A function to copy the final sums into the output.
+    HEMI_KERNEL_FUNCTION(HEMICopyResults,
+                         double* sums,
+                         const double* buffer,
+                         const int* offsets,
+                         int NB) {
+        for (int i : hemi::grid_stride_range(0, NB)) {
+            sums[i] = buffer[offsets[i]];
+        }
+    }
+}
+
+bool Cache::RecursiveSums::Apply() {
+    // Mark the results has having changed.
+    fSumsValid = false;
+
+    ///////////////////////////////////////////////////
+    // Calculate the sum
+    ///////////////////////////////////////////////////
+    HEMIFillWorkBuffer fillWorkBuffer;
+    hemi::launch(fillWorkBuffer,
+                 fWorkBuffer->writeOnlyPtr(),
+                 fEventWeights.readOnlyPtr(),
+                 fEventIndexes->readOnlyPtr(),
+                 fLowerClamp, fUpperClamp,
+                 fEventWeights.size());
+
+    // Find the maximum stride that will be needed to handle the bin with the
+    // most entries.
+    int stride = 1;
+    while (2*stride < fMaxEntries) stride *= 2;
+
+    // Sum pairs of weights until there is only one.  There can be only one.
+    HEMIStridingSum stridingSum;
+    while (stride > 0) {
+        hemi::launch(stridingSum,
+                     fWorkBuffer->writeOnlyPtr(),
+                     fBinIndexes->readOnlyPtr(),
+                     fBinOffsets->readOnlyPtr(),
+                     fWorkBuffer->size(),
+                     stride);
+        stride /= 2;
+    }
+
+    // Copy the sums into the output.
+    HEMICopyResults copyResults;
+    hemi::launch(copyResults,
+                 fSums->writeOnlyPtr(),
+                 fWorkBuffer->readOnlyPtr(),
+                 fBinOffsets->readOnlyPtr(),
+                 fSums->size());
+
+    ///////////////////////////////////////////////////
+    // Calculate the sum squared (almost copy and paste).
+    ///////////////////////////////////////////////////
+    HEMIFillWorkBuffer2 fillWorkBuffer2;
+    hemi::launch(fillWorkBuffer2,
+                 fWorkBuffer->writeOnlyPtr(),
+                 fEventWeights.readOnlyPtr(),
+                 fEventIndexes->readOnlyPtr(),
+                 fLowerClamp, fUpperClamp,
+                 fEventWeights.size());
+    stride = 1;
+    while (2*stride < fMaxEntries) stride *= 2;
+    while (stride > 0) {
+        hemi::launch(stridingSum,
+                     fWorkBuffer->writeOnlyPtr(),
+                     fBinIndexes->readOnlyPtr(),
+                     fBinOffsets->readOnlyPtr(),
+                     fWorkBuffer->size(),
+                     stride);
+        stride /= 2;
+    }
+    hemi::launch(copyResults,
+                 fSums2->writeOnlyPtr(),
+                 fWorkBuffer->readOnlyPtr(),
+                 fBinOffsets->readOnlyPtr(),
+                 fSums2->size());
+
+    return true;
+}
+
+// An MIT Style License
+
+// Copyright (c) 2024 Clark McGrew
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
+// End:

--- a/src/CacheManager/src/CacheRecursiveSums.cu
+++ b/src/CacheManager/src/CacheRecursiveSums.cu
@@ -1,0 +1,1 @@
+#include "CacheRecursiveSums.cpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(GTEST_FOUND)
   add_executable(hemiTest_host.exe
     GTests/hemiArrayTest.cpp
     GTests/hemiExecutionPolicyTest.cpp
+    GTests/cachedSumsTest.cpp
     GTests/hemiExternals.cpp)
   target_link_libraries(hemiTest_host.exe GTest::gtest_main)
   target_link_libraries(hemiTest_host.exe GundamCache)
@@ -49,6 +50,7 @@ if(GTEST_FOUND)
       GTests/hemiArrayTest.cu
       GTests/hemiExecutionPolicyTest.cu
       GTests/hemiLaunch.cu
+      GTests/cachedSumsTest.cu
       GTests/hemiExternals.cpp)
     target_link_libraries(hemiTest_device.exe GTest::gtest_main)
     target_link_libraries(hemiTest_device.exe GundamCache)

--- a/tests/GTests/cachedSumsTest.cpp
+++ b/tests/GTests/cachedSumsTest.cpp
@@ -1,0 +1,130 @@
+#include <iostream>
+#include <limits>
+
+#include <TRandom.h>
+
+#include "Logger.h"
+
+#include "CacheIndexedSums.h"
+#include "CacheRecursiveSums.h"
+
+#include "gtest/gtest.h"
+
+#ifdef HEMI_CUDA_COMPILER
+#define ASSERT_SUCCESS(res) ASSERT_EQ(cudaSuccess, (res));
+#define ASSERT_FAILURE(res) ASSERT_NE(cudaSuccess, (res));
+#define cachedSumsTest cachedSumsTestDevice
+#else
+#define ASSERT_SUCCESS(res)
+#define ASSERT_FAILURE(res)
+#define cachedSumsTest cachedSumsTestHost
+#endif
+
+TEST(cachedSumsTest, IndexedSums)
+{
+    int entries = 100;
+    int bins = 10;
+    int N = bins*entries;
+    hemi::Array<double> weights(N);
+    for (int e=0; e<N; ++e) {
+        weights.hostPtr()[e] = 1.0;
+    }
+
+    Cache::IndexedSums indexedSums(weights,bins);
+    for (int e=0; e<N; ++e) {
+        int bin = e/entries;
+        indexedSums.SetEventIndex(e,bin);
+    }
+
+    indexedSums.Initialize();
+
+    for (int i=0; i<100; ++i) {
+        indexedSums.Reset();
+        indexedSums.Apply();
+    }
+
+    hemi::deviceSynchronize();
+
+    for (int b = 0; b < bins; ++b) {
+        EXPECT_EQ(indexedSums.GetSum(b), entries)
+            << "IndexedSums bin " << b << " is wrong";
+    }
+
+}
+
+TEST(cachedSumsTest, RecursiveSums)
+{
+    int entries = 100;
+    int bins = 10;
+    int N = bins*entries;
+    hemi::Array<double> weights(N);
+    for (int e=0; e<N; ++e) {
+        weights.hostPtr()[e] = 1.0;
+    }
+
+    Cache::RecursiveSums recursiveSums(weights,bins);
+    for (int e=0; e<N; ++e) {
+        int bin = e/entries;
+        recursiveSums.SetEventIndex(e,bin);
+    }
+
+    recursiveSums.Initialize();
+
+    for (int i=0; i<100; ++i) {
+        recursiveSums.Reset();
+        recursiveSums.Apply();
+    }
+
+    hemi::deviceSynchronize();
+
+    for (int b = 0; b < bins; ++b) {
+        EXPECT_EQ(recursiveSums.GetSum(b), entries)
+            << "RecursiveSums bin " << b << " is wrong";
+    }
+
+}
+
+TEST(cachedSumsTest, CompareSums)
+{
+    int entries = 100;
+    int bins = 10;
+    int N = bins*entries;
+    hemi::Array<double> weights(N);
+    for (int e=0; e<N; ++e) {
+        weights.hostPtr()[e] = 1.0;
+    }
+
+    gRandom->SetSeed(0);
+
+    Cache::IndexedSums indexedSums(weights,bins);
+    Cache::RecursiveSums recursiveSums(weights,bins);
+
+    for (int e=0; e<N; ++e) {
+        int bin = e/entries;
+        indexedSums.SetEventIndex(e,bin);
+        recursiveSums.SetEventIndex(e,bin);
+    }
+
+    indexedSums.Initialize();
+    recursiveSums.Initialize();
+
+    for (int i=0; i<100; ++i) {
+        for (int e=0; e<N; ++e) {
+            weights.hostPtr()[e] = gRandom->Gaus(1.0,0.1);
+        }
+        indexedSums.Reset();
+        indexedSums.Apply();
+        recursiveSums.Reset();
+        recursiveSums.Apply();
+        for (int b = 0; b < bins; ++b) {
+            // Estimate how close the two results should be.  This needs
+            // to allow for numeric precision, and the magnitude of the
+            // values.  Most bugs will be "large" mistakes.
+            double err = 100*std::numeric_limits<double>::epsilon()
+                *(indexedSums.GetSum(b)+recursiveSums.GetSum(b));
+            EXPECT_NEAR(indexedSums.GetSum(b), recursiveSums.GetSum(b), err)
+                << "Mismatch between indexed and recursive sum in bin " << b;
+        }
+    }
+
+}

--- a/tests/GTests/cachedSumsTest.cu
+++ b/tests/GTests/cachedSumsTest.cu
@@ -1,0 +1,4 @@
+#ifndef __CUDACC__
+#error NOT A CUDA COMPILER
+#endif
+#include "cachedSumsTest.cpp"


### PR DESCRIPTION
This is a "low hanging fruit" fix that doubles the speed of the likelihood calculation using the GPU.  The fix is that the old histogram summing algorithm used atomic addition (not recommended on a GPU) since it's very simple.  The new code applies a more standard, but more complex, algorithm to use interleaved sums.  The raw algorithm is about x10 faster, but results in an overall doubling in the speed.

Note: The new code is still limited by the global memory bandwidth and doesn't make efficient use of the GPU blocks and warps.  It could be optimized at the expense of complexity.  However, since the sum is no longer a bottleneck this keeps the code simple.