### PR TITLE
LTS/1.8.x : Resolve Issue #534 -- validate dial cache calculations

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,6 +1,8 @@
 Fixes relative to 1.8.3
 
-Issue # 530 : Fix an inefficiency in the summation of the event weights on the GPU and double the speed of the likelihood calculation using the GPU.
+Issue #534 : Backport CPU and GPU calculation backing from `main`, and add validation that the two calculations agree within machine precision.
+
+Issue #530 : Fix an inefficiency in the summation of the event weights on the GPU and double the speed of the likelihood calculation using the GPU.
 
 Issue # 524 : Apply the global event weight cap when using the Cache::Manager to calculate the likelihood.
 

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -79,7 +79,7 @@ int main(int argc, char** argv){
   clParser.addDummyOption("Runtime/debug options");
 
   clParser.addOption("debugVerbose", {"--debug"}, "Enable debug verbose (can provide verbose level arg)", 1, true);
-  clParser.addTriggerOption("usingCacheManager", {"--cache-manager"}, "Toggle the usage of the CacheManager (i.e. the GPU)");
+  clParser.addOption("usingCacheManager", {"--cache-manager"}, "Toggle the usage of the CacheManager (i.e. the GPU) [empty, 'on', or 'off']",1,true);
   clParser.addTriggerOption("usingGpu", {"--gpu"}, "Use GPU parallelization");
   clParser.addTriggerOption("forceDirect", {"--cpu"}, "Force direct calculation of weights (for debugging)");
   clParser.addOption("overrides", {"-O", "--override"}, "Add a config override [e.g. /fitterEngineConfig/engineType=mcmc)", -1);
@@ -124,7 +124,15 @@ int main(int argc, char** argv){
 #ifdef GUNDAM_USING_CACHE_MANAGER
   useCache = Cache::Parameters::HasGPU(true);
 #endif
-  if (clParser.isOptionTriggered("usingCacheManager")) useCache = not useCache;
+  if (clParser.isOptionTriggered("usingCacheManager")) {
+      int values = clParser.getNbValueSet("usingCacheManager");
+      if (values < 1) useCache = not useCache;
+      else if ("on" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = true;
+      else if ("off" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = false;
+      else {
+          LogThrow("Invalid --cache-manager argument: must be empty, 'on' or 'off'");
+      }
+  }
   if (clParser.isOptionTriggered("usingGpu")) useCache = true;
 
 #ifdef GUNDAM_USING_CACHE_MANAGER

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -56,8 +56,13 @@ public:
     /// parameter isn't defined, this will return a negative value.
     static int ParameterIndex(const Parameter* fp);
 
-    /// Return true if a GPU is available.
+    /// Return true if CUDA was used during compilation.  Necessary for
+    /// running a GPU.
     static bool HasCUDA();
+
+    /// Return true if a GPU is available at runtime.  Must have also been
+    // compiled using CUDA
+    static bool HasGPU(bool dump = false);
 
     /// Return the approximate allocated memory (e.g. on the GPU).
     std::size_t GetResidentMemory() const {return fTotalBytes;}

--- a/src/CacheManager/include/CacheParameters.h
+++ b/src/CacheManager/include/CacheParameters.h
@@ -22,6 +22,7 @@ public:
 
     // Returns true if this is compiled with a CUDA compiler
     static bool UsingCUDA();
+    static bool HasGPU(bool dump = false);
 
     // This is a singleton, so the constructor is private.
     Parameters(std::size_t parameters);

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -144,6 +144,10 @@ bool Cache::Manager::HasCUDA() {
     return Cache::Parameters::UsingCUDA();
 }
 
+bool Cache::Manager::HasGPU(bool dump) {
+    return Cache::Parameters::HasGPU(dump);
+}
+
 bool Cache::Manager::Build(SampleSet& sampleList,
                            EventDialCache& eventDials) {
     LogInfo << "Build the internal caches " << std::endl;

--- a/src/CacheManager/src/CacheParameters.cpp
+++ b/src/CacheManager/src/CacheParameters.cpp
@@ -21,6 +21,67 @@ bool Cache::Parameters::UsingCUDA() {
 #endif
 }
 
+#ifdef __CUDACC__
+#include <cuda_runtime_api.h>
+#endif
+
+bool Cache::Parameters::HasGPU(bool dump) {
+#ifndef __CUDACC__
+    return false;
+#else
+    cudaError_t status;
+    int devCount;
+    status = cudaGetDeviceCount(&devCount);
+    if (status != cudaSuccess) {
+        if (dump) LogInfo << "CUDA DEVICE COUNT: No Device" << std::endl;
+        return false;
+    }
+
+    int devId;
+    status = cudaGetDevice(&devId);
+    if (status != cudaSuccess) {
+        if (dump) LogInfo << "CUDA DEVICE COUNT: No Device" << std::endl;
+        return false;
+    }
+
+    cudaDeviceProp prop;
+    status = cudaGetDeviceProperties(&prop, devId);
+    if (status != cudaSuccess) {
+        if (dump) LogInfo << "CUDA DEVICE COUNT: No Device" << std::endl;
+        return false;
+    }
+
+    if (dump) {
+        LogInfo << "CUDA DEVICE COUNT:         " << devCount << std::endl;
+        LogInfo << "CUDA DEVICE ID:            " << devId << std::endl;
+        LogInfo << "CUDA DEVICE NAME:          " << prop.name << std::endl;
+        LogInfo << "CUDA COMPUTE CAPABILITY:   " << prop.major << "." << prop.minor << std::endl;
+        LogInfo << "CUDA PROCESSORS:           " << prop.multiProcessorCount << std::endl;
+        LogInfo << "CUDA PROCESSOR THREADS:    " << prop.maxThreadsPerMultiProcessor << std::endl;
+        LogInfo << "CUDA MAX THREADS:          " << prop.maxThreadsPerMultiProcessor*prop.multiProcessorCount << std::endl;
+        LogInfo << "CUDA THREADS PER BLOCK:    " << prop.maxThreadsPerBlock << std::endl;
+        LogInfo << "CUDA BLOCK MAX DIM:        " << "X:" << prop.maxThreadsDim[0]
+                  << " Y:" << prop.maxThreadsDim[1]
+                  << " Z:" << prop.maxThreadsDim[2] << std::endl;
+        LogInfo << "CUDA GRID MAX DIM:         " << "X:" << prop.maxGridSize[0]
+                  << " Y:" << prop.maxGridSize[1]
+                  << " Z:" << prop.maxGridSize[2] << std::endl;
+        LogInfo << "CUDA WARP:                 " << prop.warpSize << std::endl;
+        LogInfo << "CUDA CLOCK:                " << prop.clockRate << std::endl;
+        LogInfo << "CUDA GLOBAL MEM:           " << prop.totalGlobalMem << std::endl;
+        LogInfo << "CUDA SHARED MEM:           " << prop.sharedMemPerBlock << std::endl;
+        LogInfo << "CUDA L2 CACHE MEM:         " << prop.l2CacheSize << std::endl;
+        LogInfo << "CUDA CONST MEM:            " << prop.totalConstMem << std::endl;
+        LogInfo << "CUDA MEM PITCH:            " << prop.memPitch << std::endl;
+        LogInfo << "CUDA REGISTERS:            " << prop.regsPerBlock << std::endl;
+    }
+    if (prop.totalGlobalMem < 1) return false;
+    if (prop.multiProcessorCount < 1) return false;
+    if (prop.maxThreadsPerBlock < 1) return false;
+    return true;
+#endif
+}
+
 Cache::Parameters::Parameters(std::size_t parameters)
 : fParameterCount{parameters} {
     LogInfo << "Cached Parameters -- input parameter count: "

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -571,6 +571,7 @@ void Propagator::reweightMcEvents() {
   if(GundamGlobals::getEnableCacheManager()) {
     Cache::Manager::Update(getFitSampleSet(), getEventDialCache());
     usedGPU = Cache::Manager::Fill();
+    if (GundamGlobals::getForceDirectCalculation()) usedGPU = false;
   }
 #endif
   if( not usedGPU ){

--- a/src/Utils/include/GundamAlmostEqual.h
+++ b/src/Utils/include/GundamAlmostEqual.h
@@ -2,6 +2,7 @@
 #define GundamAlmostEqual_h_seen
 #include <iostream>
 #include <cmath>
+#include <limits>
 
 namespace GundamUtils {
 

--- a/src/Utils/include/GundamAlmostEqual.h
+++ b/src/Utils/include/GundamAlmostEqual.h
@@ -1,0 +1,60 @@
+#ifndef GundamAlmostEqual_h_seen
+#define GundamAlmostEqual_h_seen
+#include <iostream>
+#include <cmath>
+
+namespace GundamUtils {
+
+    /// Check if two real numbers are close enough to be considered equal.
+    /// This takes into account different effects: 1) precision of the
+    /// underlying numerical representation; 2) the magnitudes of the numbers
+    /// being compared; and 3), the fraction of bits that are expected to have
+    /// been lost during the numeric calculation.  The fractions of bits lost
+    /// will be a number between 0.0 and 1.0, where 0 means no bits are lost
+    /// due to numerical problems, and 1 means all bits are lost.  The number
+    /// of bits grows (very) roughly like the square root of the numbers of
+    /// operations, but depends heavily on the actual sequence of operations.
+    /// Losing 30% of the accuracy is a plausible default bound.
+    ///
+    /// Note: This is intended for testing and debugging.  It is not intended
+    /// for "production", and is written to be painfully clear about it's
+    /// assumptions.
+    template <typename U, typename V>
+    bool almostEqual(U A, V B, double fractionOfBitsLost = 0.3) {
+        // Non-finite numbers are never equal.
+        if (not std::isfinite(A) || not std::isfinite(B)) return false;
+
+        // Internally, operate on actual doubles.  This is for simplicity and
+        // clarity.
+        const double a = A;
+        const double b = B;
+
+        // Find the precision of the least precise value.
+        double epsA = std::numeric_limits<U>::epsilon();
+        double epsB = std::numeric_limits<V>::epsilon();
+        double eps = std::max(epsA, epsB);  // Take the worst precision
+
+        // Reduce the precision:  This accounts for the fraction of bits of
+        // accuracy that has been lost during the calculation.
+        if (fractionOfBitsLost > 0.0) {
+            fractionOfBitsLost = std::min(fractionOfBitsLost, 0.99);
+            eps = std::pow(eps, (1.0-fractionOfBitsLost));
+        }
+
+        // Scale to the value magnitudes.  Don't let the precision become
+        // subnormal.  The standard binary representation for a floating point
+        // number intends to have the first bit be "1" (called normal).  A
+        // subnormal representation means that the first bit is zero.  For
+        // instance (using decimal), 0.00123 has a normal representatin of
+        // 1.23E-3, and (one possible) subnormal representation of 0.0123E-1
+        // (you can find references on the web that are more precise).
+        if (std::isnormal(a*eps)) epsA = std::abs(a*eps);
+        if (std::isnormal(b*eps)) epsB = std::abs(b*eps);
+        double finalEPS = std::max(epsA, epsB);
+
+        // Check that the difference is less than the acceptable precision
+        double diff = std::abs(a - b);
+        return (diff < finalEPS);
+    }
+}
+#endif

--- a/src/Utils/include/GundamGlobals.h
+++ b/src/Utils/include/GundamGlobals.h
@@ -2,8 +2,8 @@
 // Created by Nadrino on 11/02/2021.
 //
 
-#ifndef GUNDAM_GUNDAMGLOBALS_H
-#define GUNDAM_GUNDAMGLOBALS_H
+#ifndef GUNDAM_GUNDAM_GLOBALS_H
+#define GUNDAM_GUNDAM_GLOBALS_H
 
 #include "GenericToolbox.ParallelWorker.h"
 #include "GenericToolbox.h"
@@ -42,13 +42,17 @@ public:
 
   // Setters
   static void setEnableCacheManager(bool enable = true){ _enableCacheManager_ = enable; }
+  static void setNumberOfThreads(int threads=1){ _gundamThreads_ = threads; }
+  static void setForceDirectCalculation(bool enable=false){ _forceDirectCalculation_ = enable; }
   static void setLightOutputMode(bool enable_){ _lightOutputMode_ = enable_; }
   static void setDisableDialCache(bool disableDialCache_){ _disableDialCache_ = disableDialCache_; }
   static void setVerboseLevel(VerboseLevel verboseLevel_);
   static void setVerboseLevel(int verboseLevel_);
 
   // Getters
+  static int getNumberOfThreads(){ return _gundamThreads_; }
   static bool getEnableCacheManager(){ return _enableCacheManager_; }
+  static bool getForceDirectCalculation(){ return _forceDirectCalculation_; }
   static bool isDisableDialCache(){ return _disableDialCache_; }
   static bool isLightOutputMode(){ return _lightOutputMode_; }
   static VerboseLevel getVerboseLevel(){ return _verboseLevel_; }
@@ -57,8 +61,10 @@ public:
 
 private:
 
+  static int _gundamThreads_;
   static bool _disableDialCache_;
   static bool _enableCacheManager_;
+  static bool _forceDirectCalculation_;
   static bool _lightOutputMode_;
   static std::mutex _threadMutex_;
   static VerboseLevel _verboseLevel_;
@@ -67,4 +73,4 @@ private:
 
 };
 
-#endif
+#endif // GUNDAM_GUNDAM_GLOBALS_H

--- a/src/Utils/src/GundamGlobals.cpp
+++ b/src/Utils/src/GundamGlobals.cpp
@@ -12,8 +12,10 @@ LoggerInit([]{
 });
 
 // statics
+int GundamGlobals::_gundamThreads_{1};
 bool GundamGlobals::_disableDialCache_{false};
 bool GundamGlobals::_enableCacheManager_{false};
+bool GundamGlobals::_forceDirectCalculation_{false};
 bool GundamGlobals::_lightOutputMode_{false};
 std::mutex GundamGlobals::_threadMutex_;
 VerboseLevel GundamGlobals::_verboseLevel_{NORMAL_MODE};

--- a/tests/fast-tests/200CovarianceFit-CacheManager.sh
+++ b/tests/fast-tests/200CovarianceFit-CacheManager.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}-CacheManager.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter --cache-manager -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu --cache-manager -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-catmull.sh
+++ b/tests/fast-tests/200CovarianceFit-catmull.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-graph.sh
+++ b/tests/fast-tests/200CovarianceFit-graph.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200CovarianceFit-graph.yaml
+++ b/tests/fast-tests/200CovarianceFit-graph.yaml
@@ -85,7 +85,7 @@ fitterEngineConfig:
             isEnabled: true
             dialSetDefinitions:
               - dialsType: Graph
-                dialSubType: ROOT
+                # No longer tested -- dialSubType: ROOT
                 dialLeafName: "spline_C"
                 applyOnDataSets: [ "TestSample" ]
                 applyCondition: "[C] > 0"

--- a/tests/fast-tests/200CovarianceFit.sh
+++ b/tests/fast-tests/200CovarianceFit.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200DecompositionFit.sh
+++ b/tests/fast-tests/200DecompositionFit.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script

--- a/tests/fast-tests/200NormalizationAsimov.sh
+++ b/tests/fast-tests/200NormalizationAsimov.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script


### PR DESCRIPTION
This backports the GPU/CPU calculation backing functionality from main into the LTS branch.  When the `--cpu` option is set from the command line, and the GPU is available, the likelihood will be calculated simultaneously by the GPU and the CPU.  This results in a small slow-down relative to the CPU only calculation, but adds the functionality that the two calculations are directly checked.  This is mostly used by the validation code.  

Spoiler Alert: The two calculations are the same in the LTS.
