### PR TITLE
Use root-config to find root variables

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -37,13 +37,14 @@ if( ROOT_FOUND )
 
   if (NOT ROOT_minuit2_FOUND)
     # Minuit2 wasn't found, but make really sure before giving up.
-    execute_process (COMMAND ${ROOT_INCLUDE_DIRS}/../bin/root-config --has-minuit2
+    execute_process (COMMAND ${ROOT_root_CMD}-config --has-minuit2
         OUTPUT_VARIABLE ROOT_minuit2_FOUND
         OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif(NOT ROOT_minuit2_FOUND)
 
-  # inc dir is $ROOTSYS/include/root
-  set(CMAKE_ROOTSYS ${ROOT_INCLUDE_DIRS}/..)
+  execute_process (COMMAND ${ROOT_root_CMD}-config --prefix
+          OUTPUT_VARIABLE CMAKE_ROOTSYS
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 else( ROOT_FOUND )
   cmessage( STATUS "find_package didn't find ROOT. Using shell instead...")

--- a/cmake/generated/build_setup.sh.in
+++ b/cmake/generated/build_setup.sh.in
@@ -9,3 +9,8 @@ fi
 if ! [[ ":$LD_LIBRARY_PATH:" == *":@CMAKE_INSTALL_PREFIX@/lib:"* ]]; then
   export LD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:$LD_LIBRARY_PATH
 fi
+
+
+if ! [[ ":$DYLD_LIBRARY_PATH:" == *":@CMAKE_INSTALL_PREFIX@/lib:"* ]]; then
+  export DYLD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:$DYLD_LIBRARY_PATH
+fi


### PR DESCRIPTION
On mac, the include direction is include/root so the current implementation creates issues with the setup.sh file