### PR TITLE
[LTS 1.8.x] Trap NaNs in JointProbability

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,11 @@
 Fixes relative to 1.8.3
 
+Update (Related to #540): Strengthen the NaN trap in the JointProbability calculation.  An NaN there means the fit cannot continue, so throw an error.  Continue to allow INF.
+
+Update (Prompted by #541): Make compilation less alarming by quieting warnings.  They were originally part of debugging.
+
+Issue #536 : Add control over the size of a "kick" when starting a fit.  The starting point can be fluctuated around the prior, and the size of the step is controlled by an optional argument to --kickmc
+
 Issue #534 : Backport CPU and GPU calculation backing from `main`, and add validation that the two calculations agree within machine precision.
 
 Issue #530 : Fix an inefficiency in the summation of the event weights on the GPU and double the speed of the likelihood calculation using the GPU.

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -330,12 +330,13 @@ int main(int argc, char** argv){
   // minimization.  This is not changing the prior value, only the starting
   // point of the fit.  The kick is in units of prior standard deviations
   // about the prior point.
-  double kickMc = 0.0;       // Set the default value
+  double kickMc = 0.0;          // Set the default value without an option
   if (clParser.isOptionTriggered("kickMc")) {
       int values = clParser.getNbValueSet("usingCacheManager");
-      if (values > 0) kickMc = clParser.getOptionVal<double>("kickMc",0);
+      if (values < 1) kickMc = 0.1; // Default without an argument.
+      else kickMc = clParser.getOptionVal<double>("kickMc",0);
   }
-  if( kickMc > 0.01) {
+  if ( kickMc > 0.01 ) {
       LogAlert << "Fit starting point randomized by " << kickMc << " sigma"
                << " around prior values."
                << std::endl;

--- a/src/CacheManager/include/hemi/hemi.h
+++ b/src/CacheManager/include/hemi/hemi.h
@@ -26,9 +26,9 @@
 // device execution on systems with CUDA installed.
 // #define HEMI_CUDA_DISABLE
 
-#ifdef HEMI_CUDA_DISABLE
-#warning HEMI: HEMI_CUDA_DISABLED is defined so CUDA usage is disabled
-#endif
+// #ifdef HEMI_CUDA_DISABLE
+// #warning HEMI: HEMI_CUDA_DISABLED is defined so CUDA usage is disabled
+// #endif
 
 #if !defined(HEMI_CUDA_DISABLE) && defined(__CUDACC__) // CUDA compiler
 

--- a/src/SamplesManager/src/JointProbability.cpp
+++ b/src/SamplesManager/src/JointProbability.cpp
@@ -199,7 +199,7 @@ namespace JointProbability{
     }
 
     if (not std::isfinite(chisq)) [[unlikely]] {
-      LogWarning << "Infinite chi2: " << chisq << std::endl
+      LogWarning << "Non finite chi2: " << chisq << std::endl
                  << " bin " << bin_ << std::endl
                  << GET_VAR_NAME_VALUE(predVal) << std::endl
                  << GET_VAR_NAME_VALUE(dataVal) << std::endl
@@ -216,6 +216,11 @@ namespace JointProbability{
     if(verboseLevel>=3){
       LogTrace << "Bin #" << bin_ << ": chisq(" << chisq << ") / predVal(" << predVal << ") / dataVal(" << dataVal << ")" << std::endl;
     }
+
+    // The chi-squared value must not be NaN.  If it is, then the calculation
+    // should stop since the likelihood and it's derivatives are broken.  This
+    // can only happen with invalid inputs.
+    LogThrowIf(std::isnan(chisq),"Chi2 is NaN");
 
     return chisq;
   }


### PR DESCRIPTION
A NaN (as opposed to an infinity) in JointProbability means that there was a bad parameter passed to the likelihood so that part of the weighting was not applied.  This can only happen when there are bad inputs, so that means it is time to stop the fit.

This merge also includes changes to the amount of warning message produced during compilation and captures a change allowing the --kickmc option to set the size of the kick.