### PR TITLE
Resolve Issue #545: Non portable usage of ROOT configuration

### DIFF
--- a/cmake/generated/build_setup.sh.in
+++ b/cmake/generated/build_setup.sh.in
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/bash
+#
+# A minimal setup for bash to run GUNDAM.
 
 source "@CMAKE_ROOTSYS@/bin/thisroot.sh"
 
@@ -9,3 +11,9 @@ fi
 if ! [[ ":$LD_LIBRARY_PATH:" == *":@CMAKE_INSTALL_PREFIX@/lib:"* ]]; then
   export LD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:$LD_LIBRARY_PATH
 fi
+
+if ! [[ ":$DYLD_LIBRARY_PATH:" == *":@CMAKE_INSTALL_PREFIX@/lib:"* ]]; then
+  export DYLD_LIBRARY_PATH=@CMAKE_INSTALL_PREFIX@/lib:$DYLD_LIBRARY_PATH
+fi
+
+


### PR DESCRIPTION
This closes #545.  Mostly this cleans up the usage of the root-config command, but also makes sure that the ROOTSYS is determination is portable.  As a bonus it cleans up how ZLib is found.    