### PR TITLE
Preprocessor supports lowest common denominator

### DIFF
--- a/src/CacheManager/src/CacheAtomicCAS.cpp
+++ b/src/CacheManager/src/CacheAtomicCAS.cpp
@@ -33,89 +33,174 @@ namespace {
 // without some fancy footwork in the call.  This is an easier way for people
 // to understand.
 int CacheAtomicCAS(double *variable, double *expected, double update) {
-#define USE_CACHE_ATOMIC_CAS_WITH_MUTEX /* as a last resort */
-#if defined(__has_builtin) && __has_builtin(__atomic_compare_exchange)
-// #warning CacheAtomicCAS -- Using builtin __atomic_compare_exchange
-     return __atomic_compare_exchange(
-         variable, expected, &update, 0,
-         __ATOMIC_SEQ_CST,
-         __ATOMIC_SEQ_CST);
-#elif __GNUC_PREREQ(5,0)
-// #warning CacheAtomicCAS -- Using GCC >5 builtin __atomic_compare_exchange
-     return __atomic_compare_exchange(
-         variable, expected, &update, 0,
-         __ATOMIC_SEQ_CST,
-         __ATOMIC_SEQ_CST);
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-// #warning CacheAtomicCAS -- Using C11 atomic_compare_exchange_strong_explicit
-     return atomic_compare_exchange_strong_explicit(
-         variable, expected, update,
-         memory_order_seq_cst,
-         memory_order_seq_cst);
-#elif defined(USE_CACHE_ATOMIC_CAS_WITH_MUTEX)
-// #warning CacheAtomicCAS -- Using MutEx to implement Compare and Set.
-     std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
-     double expectation = *expected;
-     *expected = *variable;
-     if (*variable == expectation) {
-         *variable = update;
-         return true;
-     }
-     return false;
-#else
-#error CacheAtomicCAS -- Atomic operations not supported.
+#ifdef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#error internal definition TEMP_CACHE_ATOMIC_CAS_MANAGED must be undefined
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 #endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __has_builtin
+#if __has_builtin(__atomic_compare_exchange)
+    // #warning CacheAtomicCAS -- Using builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __GNUC__
+#include <features.h>
+#if __GNUC_PREREQ(5,0)
+    // #warning CacheAtomicCAS -- Using GCC >5 builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __STDC_VERSION__
+#if __STDC_VERSION__ >= 201112L
+// #warning CacheAtomicCAS -- Using C11 atomic_compare_exchange_strong_explicit
+    return atomic_compare_exchange_strong_explicit(
+        variable, expected, update,
+        memory_order_seq_cst,
+        memory_order_seq_cst);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#warning CacheAtomicCAS -- Using MutEx to implement Compare and Set for doubles
+    std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
+    double expectation = *expected;
+    *expected = *variable;
+    if (*variable == expectation) {
+        *variable = update;
+        return true;
+    }
+    return false;
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 }
 
 // See documentation for CasheAtomicCAS_double
 int CacheAtomicCAS(float *variable, float *expected, float update) {
-#if defined(__has_builtin) && __has_builtin(__atomic_compare_exchange)
-    return __atomic_compare_exchange(
-        variable, expected, &update, 0,
-        __ATOMIC_SEQ_CST,
-        __ATOMIC_SEQ_CST);
-#elif __GNUC_PREREQ(5,0)
-    return __atomic_compare_exchange(
-        variable, expected, &update, 0,
-        __ATOMIC_SEQ_CST,
-        __ATOMIC_SEQ_CST);
-#else
-     std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
-     float old = *expected;
-     *expected = *variable;
-     if (*variable == old) {
-         *variable = update;
-         return true;
-     }
-     return false;
+#ifdef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#error internal definition TEMP_CACHE_ATOMIC_CAS_MANAGED must be undefined
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 #endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __has_builtin
+#if __has_builtin(__atomic_compare_exchange)
+    // #warning CacheAtomicCAS -- Using builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __GNUC__
+#include <features.h>
+#if __GNUC_PREREQ(5,0)
+    // #warning CacheAtomicCAS -- Using GCC >5 builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __STDC_VERSION__
+#if __STDC_VERSION__ >= 201112L
+// #warning CacheAtomicCAS -- Using C11 atomic_compare_exchange_strong_explicit
+    return atomic_compare_exchange_strong_explicit(
+        variable, expected, update,
+        memory_order_seq_cst,
+        memory_order_seq_cst);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#warning CacheAtomicCAS -- Using MutEx to implement Compare and Set for floats
+    std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
+    float expectation = *expected;
+    *expected = *variable;
+    if (*variable == expectation) {
+        *variable = update;
+        return true;
+    }
+    return false;
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 }
 
 // See documentation for CacheAtomicCAS_double
 int CacheAtomicCAS(int *variable, int *expected, int update) {
-#if defined(__has_builtin) && __has_builtin(__atomic_compare_exchange)
-     return __atomic_compare_exchange(
-         variable, expected, &update, 0,
-         __ATOMIC_SEQ_CST,
-         __ATOMIC_SEQ_CST);
-#elif __GNUC_PREREQ(5,0)
-     return __atomic_compare_exchange(
-         variable, expected, &update, 0,
-         __ATOMIC_SEQ_CST,
-         __ATOMIC_SEQ_CST);
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-     return atomic_compare_exchange_strong_explicit(
-          variable, expected, update,
-          memory_order_seq_cst,
-          memory_order_seq_cst);
-#else
-     std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
-     int old = *expected;
-     *expected = *variable;
-     if (*variable == old) {
-         *variable = update;
-         return true;
-     }
-     return false;
+#ifdef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#error internal definition TEMP_CACHE_ATOMIC_CAS_MANAGED must be undefined
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 #endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __has_builtin
+#if __has_builtin(__atomic_compare_exchange)
+    // #warning CacheAtomicCAS -- Using builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __GNUC__
+#include <features.h>
+#if __GNUC_PREREQ(5,0)
+    // #warning CacheAtomicCAS -- Using GCC >5 builtin __atomic_compare_exchange
+    return __atomic_compare_exchange(
+        variable, expected, &update, 0,
+        __ATOMIC_SEQ_CST,
+        __ATOMIC_SEQ_CST);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#ifdef __STDC_VERSION__
+#if __STDC_VERSION__ >= 201112L
+// #warning CacheAtomicCAS -- Using C11 atomic_compare_exchange_strong_explicit
+    return atomic_compare_exchange_strong_explicit(
+        variable, expected, update,
+        memory_order_seq_cst,
+        memory_order_seq_cst);
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#endif
+#endif
+#ifndef TEMP_CACHE_ATOMIC_CAS_MANAGED
+#warning CacheAtomicCAS -- Using MutEx to implement Compare and Set for integers
+    std::lock_guard<std::mutex> lock(cacheAtomicCASMutEx);
+    int expectation = *expected;
+    *expected = *variable;
+    if (*variable == expectation) {
+        *variable = update;
+        return true;
+    }
+    return false;
+#define TEMP_CACHE_ATOMIC_CAS_MANAGED
+#endif
+#undef TEMP_CACHE_ATOMIC_CAS_MANAGED
 }


### PR DESCRIPTION
Make sure that the preprocessor directives support older preprocessor syntax.  It looks like pre GCC10 doesn't support sequential evaluation of preprocessor expressions, so break things into direct ifdef and nested control directives.