### PR TITLE
Minimal behavior change to handle ROOT changes

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -36,6 +36,10 @@ if( ROOT_FOUND )
   # Grab functions such as generate dictionary
   include( ${ROOT_USE_FILE} )
 
+  if (ROOT_VERSION VERSION_GREATER_EQUAL 6.30.00)
+    set(ROOT_minuit2_FOUND "yes")
+  endif()
+
 else( ROOT_FOUND )
   cmessage( STATUS "find_package didn't find ROOT. Using shell instead...")
 
@@ -76,6 +80,10 @@ else( ROOT_FOUND )
   add_compile_options("SHELL:${ROOT_CXX_FLAGS}")
   add_link_options("SHELL:${ROOT_LINK_FLAGS}")
 
+  if (ROOT_VERSION VERSION_GREATER_EQUAL 6.30.00)
+    set(ROOT_minuit2_FOUND "yes")
+  endif()
+
 endif( ROOT_FOUND )
 
 # Try to figure out which version of C++ was used to compile ROOT.  ROOT
@@ -95,6 +103,20 @@ execute_process(COMMAND ${ROOT_config_CMD} --has-cxx20 COMMAND grep yes
 execute_process (COMMAND ${ROOT_config_CMD} --prefix
   OUTPUT_VARIABLE CMAKE_ROOTSYS
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Minuit2 wasn't found, but make really sure before giving up.
+if (NOT ROOT_minuit2_FOUND)
+  execute_process (COMMAND ${ROOT_config_CMD} --has-minuit2
+    OUTPUT_VARIABLE ROOT_minuit2_FOUND
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif(NOT ROOT_minuit2_FOUND)
+
+# If we truly don't have minuit2, then complain
+if (NOT ROOT_minuit2_FOUND AND NOT WITH_MINUIT2_MISSING)
+  cmessage(WARNING "[ROOT]: Use >6.30 or rebuild root with -Dminuit2=on")
+  cmessage(WARNING "[ROOT]: Set WITH_MINUIT2_MISSING OFF to disable check")
+  cmessage(FATAL_ERROR "[ROOT]: minuit2 is required")
+endif(NOT ROOT_minuit2_FOUND)
 
 include_directories( ${ROOT_INCLUDE_DIR} )
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -15,6 +15,7 @@ option( WITH_DOXYGEN "Build documentation with doxygen." OFF )
 option( WITH_GUNDAM_ROOT_APP "Build app gundamRoot." ON )
 option( WITH_CACHE_MANAGER "Enable compiling of the cache manager (required for GPU computing)." ON )
 option( WITH_CUDA_LIB "Enable CUDA language check (Cache::Manager requires a GPU if CUDA is found)." OFF )
+option( WITH_MINUIT2_MISSING "Allow MINUIT2 to be missing" OFF )
 
 # compile helper
 option( YAMLCPP_DIR "Set custom path to yaml-cpp lib." OFF )


### PR DESCRIPTION
Here is a compromise solution to allow using ROOT without minuit2, but still be conservative about the checks.  

This adds back the minuit2 check for older versions of ROOT (pre 6.30) where it was an optional component.  After ROOT 6.30, minuit2 is always present, so leave the check, but make sure miniut2 is correctly marked as present.

ROOT 6.30 is a unicorn since it is transitioning to deprecate several long standing features, and doesn't report it's supported features with precision.  That is mostly fixed in ROOT 6.32 and later.  This adds some (trivial) infrastructure to deal with specific ROOT version differences.

Add the cmake option WITH_MINUIT2_MISSING which defaults to OFF.  If a user wants to override the compilation recommendations, so be it!  But, make them do it intentionally.  
