### PR TITLE
Feature/expand tabulated dial arguments

### DIFF
--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -68,12 +68,16 @@ TabulatedDialFactory::TabulatedDialFactory(const JsonType& config_) {
                      << std::endl;
             std::exit(EXIT_FAILURE); // Exit, not throw!
         }
+        std::vector<std::string> argv_buffer;
+        for (std::string arg : getInitializationArguments()) {
+            argv_buffer.push_back(GenericToolbox::expandEnvironmentVariables(arg));
+        }
+        std::vector<const char*> argv;
+        for (std::string& arg : argv_buffer) argv.push_back(arg.c_str());
         _initFunc_
             = reinterpret_cast<
                 int(*)(const char* name,int argc, const char* argv[], int bins)
             >(initFunc);
-        std::vector<const char*> argv;
-        for (const std::string& arg : getInitializationArguments()) argv.push_back(arg.c_str());
         int result = _initFunc_(_name_.c_str(),(int) argv.size(), argv.data(), bins);
         if (result < 1) {
             LogError << "Error calling initialization function: "

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -136,9 +136,11 @@ DialBase* TabulatedDialFactory::makeDial(const Event& event) {
                                (int) _variables_.size(), _variables_.data(),
                                (int) _table_.size());
 
+    if (bin < 0.0) return nullptr;
+
     // Determine the bin index and the fractional part of the bin.
     int iBin = bin;
-    if (iBin < 0) iBin = 0;
+    if (iBin < 0) iBin = 0;     // Shouldn't happen, but just in case.
     if (iBin > _table_.size()-1) iBin = _table_.size()-1;
     double fracBin = bin - iBin;
     if (fracBin < 0.0) fracBin = 0.0;

--- a/tests/fast-tests/200TabulatedAsimov-config.yaml
+++ b/tests/fast-tests/200TabulatedAsimov-config.yaml
@@ -91,7 +91,18 @@ fitterEngineConfig:
               name: "AB Oscillation"
               libraryPath: "${DATA_DIR}/200TabulatedAsimov.so"
               initFunction: "initializeTable"
-              initArguments: ["one", "two", "three", "four"]
+              initArguments:
+                - "NEUTRINO_TYPES 6"
+                - "BINS 100"
+                - "MIN_ENERGY 0.05"
+                - "MAX_PATH 295.0"
+                - "PARAMETERS ${CONFIG_DIR}/200TabulatedAzimov-parameters.txt"
+                - "FLUX ${DATA_DIR}/nue.txt"
+                - "FLUX ${DATA_DIR}/nuebar.txt"
+                - "FLUX ${DATA_DIR}/numu.txt"
+                - "FLUX ${DATA_DIR}/numubar.txt"
+                - "FLUX ${DATA_DIR}/nutau.txt"
+                - "FLUX ${DATA_DIR}/nutaubar.txt"
               updateFunction: "updateTable"
               binningFunction: "binTable"
               variables: ["At", "Bt"]

--- a/tests/fast-tests/200TabulatedAsimov-config.yaml
+++ b/tests/fast-tests/200TabulatedAsimov-config.yaml
@@ -96,7 +96,7 @@ fitterEngineConfig:
                 - "BINS 100"
                 - "MIN_ENERGY 0.05"
                 - "MAX_PATH 295.0"
-                - "PARAMETERS ${CONFIG_DIR}/200TabulatedAzimov-parameters.txt"
+                - "PARAMETERS ${CONFIG_DIR}/200TabulatedAsimov-parameters.txt"
                 - "FLUX ${DATA_DIR}/nue.txt"
                 - "FLUX ${DATA_DIR}/nuebar.txt"
                 - "FLUX ${DATA_DIR}/numu.txt"

--- a/tests/fast-tests/200TabulatedAsimov.C
+++ b/tests/fast-tests/200TabulatedAsimov.C
@@ -9,7 +9,7 @@
 extern "C"
 int initializeTable(const char* name, int argc, const char* argv[],
                     int bins) {
-#undef LOUD_AND_PROUD
+#define LOUD_AND_PROUD
 #ifdef LOUD_AND_PROUD
     std::cout << LIB_NAME << "INITIALIZE TABLE" << std::endl;
     std::cout << LIB_NAME << "name: " << name << std::endl;
@@ -19,6 +19,7 @@ int initializeTable(const char* name, int argc, const char* argv[],
     }
     std::cout << LIB_NAME << "bins: " << bins << std::endl;
 #endif
+#undef LOUD_AND_PROUD
     return 100;
 }
 
@@ -26,6 +27,7 @@ extern "C"
 int updateTable(const char* name,
                 double table[], int bins,
                 const double par[], int npar) {
+#undef LOUD_AND_PROUD
 #ifdef LOUD_AND_PROUD
     std::cout << LIB_NAME << "UPDATE TABLE" << std::endl;
     std::cout << LIB_NAME << "name: " << name << std::endl;
@@ -35,6 +37,7 @@ int updateTable(const char* name,
         std::cout << LIB_NAME << "par[" << i << "]: " << par[i] << std::endl;
     }
 #endif
+#undef LOUD_AND_PROUD
     for (int i = 0; i<npar; ++i) {
         if (not std::isnan(par[i])) continue;
         std::cerr << LIB_NAME << ": " << name
@@ -63,6 +66,7 @@ double binTable(const char* name,
         std::cout << LIB_NAME << "varv[" << i << "]: " << varv[i] << std::endl;
     }
 #endif
+#undef LOUD_AND_PROUD
     double value = 0.0;
     for (int i = 0; i<varc; ++i) {
         value += 10.0*varv[i]*varv[i];


### PR DESCRIPTION
For tabulated dials, the library is called with a sequence of strings provided in the initArguments field.  Since these arguments will often be file names, expand any environments in the strings before passing them to the library initFunction.