### PR TITLE
Ensure parameter validity

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,3 +1,7 @@
+Fixes relative to 1.8.4
+
+Fixes: Guarrantee that all parameter value access is through the setter and getter so that the validity checks are correctly applied.
+
 Fixes relative to 1.8.3
 
 Issue #545 : Make the handling of ROOT config information portable between linux and macos.  This no longer assumes how ROOT is installed, and uses root-config portably.

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -42,14 +42,53 @@ public:
   void setIsFree(bool isFree){ _isFree_ = isFree; }
   void setParameterIndex(int parameterIndex){ _parameterIndex_ = parameterIndex; }
   void setStepSize(double stepSize){ _stepSize_ = stepSize; }
+
+  /// Set the minimum value for this parameter.  Parameter values less than
+  /// this value are illegal, and the likelihood is undefined.  The job will
+  /// terminate when it encounters an illegal parameter value.  Note: Using a
+  /// minimum value when also using eigenvalue decomposition, or PCA results
+  /// in undefined behavior because the decomposition will not honor the
+  /// boundaries and may set take values that are out of bounds.  In this
+  /// case, the job will stop.  Note: If the minimum value is not set, then
+  /// the bound is a negative infinity.
   void setMinValue(double minValue){ _minValue_ = minValue; }
+
+  /// Set the maximum value for this parameter.  Parameter values more than
+  /// this value are illegal, and the likelihood is undefined. The job will
+  /// terminate when it encounters an illegal parameter value.  Note: Using a
+  /// minimum value when also using eigenvalue decomposition, or PCA results
+  /// in undefined behavior because the decomposition will not honor the
+  /// boundaries and may set take values that are out of bounds.  In this
+  /// case, the job will stop.  Note: If the maximum value is not set, then
+  /// the bound is at positive infinity.
   void setMaxValue(double maxValue){ _maxValue_ = maxValue; }
-  // Record the mirroring being used by any dials.
+
+  /// Record the minimum mirroring boundary being used by any dials for this
+  /// parameter.  If this is set, then GUNDAM will constrain the parameter
+  /// value passed to the likelihood to be greater than the mirror boundary,
+  /// while the input parameter value can continue outside of the bounds.
   void setMinMirror(double minMirror);
+
+  /// Record the maximum mirroring boundary being used by any dials for this
+  /// parameter.  If this is set, then GUNDAM will constrain the parameter
+  /// value passed to the likelihood to be less than the mirror boundary,
+  /// while the input parameter value can continue outside of the bounds.
   void setMaxMirror(double maxMirror);
-  // Record the physical bounds for the parameter.  This is the range where
-  // the parameter has a physically meaningful value.
+
+  /// Record the physical minimum bound for the parameter.  This is the range
+  /// where the parameter has a physically meaningful value.  Because of
+  /// numeric continuation, the likelihood may have a finite value outside of
+  /// the physical range.  From a mathmatical perspective, the value of the
+  /// LLH is infinite below the physical minimum.  This can be enforced
+  /// using the Likelihood::SetParameterValidity() method.
   void setMinPhysical(double minPhysical){ _minPhysical_ = minPhysical; }
+
+  /// Record the physical maximum bound for the parameter.  This is the range
+  /// where the parameter has a physically meaningful value.  Because of
+  /// numeric continuation, the likelihood may have a finite value outside of
+  /// the physical range.  From a mathmatical perspective, the value of the
+  /// LLH is infinite below the physical minimum.  This can be enforced
+  /// using the Likelihood::SetParameterValidity() method.
   void setMaxPhysical(double maxPhysical){ _maxPhysical_ = maxPhysical; }
   void setPriorValue(double priorValue){ _priorValue_ = priorValue; }
   void setThrowValue(double throwValue){ _throwValue_ = throwValue; }
@@ -69,13 +108,19 @@ public:
   [[nodiscard]] bool gotUpdated() const { return _gotUpdated_; }
   [[nodiscard]] int getParameterIndex() const{ return _parameterIndex_; }
   [[nodiscard]] double getStepSize() const{ return _stepSize_; }
+  /// See setMinValue() for documentation.
   [[nodiscard]] double getMinValue() const{ return _minValue_; }
+  /// See setMaxValue() for documentation.
   [[nodiscard]] double getMaxValue() const{ return _maxValue_; }
+  /// See setMinMirror for documentation.
   [[nodiscard]] double getMinMirror() const{ return _minMirror_; }
+  /// See setMaxMirror for documentation.
   [[nodiscard]] double getMaxMirror() const{ return _maxMirror_; }
   [[nodiscard]] double getPriorValue() const{ return _priorValue_; }
   [[nodiscard]] double getThrowValue() const{ return _throwValue_; }
+  /// See setMinPhysical for documentation.
   [[nodiscard]] double getMinPhysical() const{ return _minPhysical_; }
+  /// See setMinPhysical for documentation.
   [[nodiscard]] double getMaxPhysical() const{ return _maxPhysical_; }
   [[nodiscard]] double getStdDevValue() const{ return _stdDevValue_; }
   [[nodiscard]] double getParameterValue() const;
@@ -84,11 +129,23 @@ public:
   [[nodiscard]] const ParameterSet *getOwner() const{ return _owner_; }
   [[nodiscard]] PriorType::PriorType getPriorType() const{ return _priorType_; }
 
-  // Core
+  /// Copy the prior value of the parameter into the current value.  This will
+  /// fail if the prior value has not been set.
   void setValueAtPrior();
+
+  /// Copy the current value of the parameter into the prior value.
   void setCurrentValueAsPrior();
+
+  /// Check that the parameter value is between the minimum and maximum bound
+  /// for the parameter (could be +/- infinity).  Note: Since a NaN is not a
+  /// number, it is not within the bounds.
   [[nodiscard]] bool isValueWithinBounds() const;
-  [[nodiscard]] double getDistanceFromNominal() const; // in unit of sigmas
+
+  /// Return the difference between the current parameter value and the prior
+  /// parameter value in units of standard deviations (defined by
+  /// setStdDevvalue()).  This is a signed difference.
+  [[nodiscard]] double getDistanceFromNominal() const;
+
   [[nodiscard]] std::string getSummary(bool shallow_=false) const;
   [[nodiscard]] std::string getTitle() const;
   [[nodiscard]] std::string getFullTitle() const;

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -25,6 +25,9 @@ namespace PriorType{
 
 class ParameterSet;
 
+/// Hold a Parameter that is a member of a ParameterSet to be used in the fit.
+/// Parameters are always owned by a ParameterSet, and the instantiation
+/// resides in the ParameterSet.
 class Parameter : public JsonBaseClass {
 
 protected:

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -78,7 +78,7 @@ public:
   [[nodiscard]] double getMinPhysical() const{ return _minPhysical_; }
   [[nodiscard]] double getMaxPhysical() const{ return _maxPhysical_; }
   [[nodiscard]] double getStdDevValue() const{ return _stdDevValue_; }
-  [[nodiscard]] double getParameterValue() const{ return _parameterValue_; }
+  [[nodiscard]] double getParameterValue() const;
   [[nodiscard]] const std::string &getName() const{ return _name_; }
   [[nodiscard]] const nlohmann::json &getDialDefinitionsList() const{ return _dialDefinitionsList_; }
   [[nodiscard]] const ParameterSet *getOwner() const{ return _owner_; }

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -70,19 +70,23 @@ public:
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
 
   /// Get the vector of parameters for this parameter set in the real
-  /// parameter space.  These parameters are not eigendecomposed.
+  /// parameter space.  These parameters are not eigendecomposed.  WARNING:
+  /// While the parameters are provided as a vector, elements must not be
+  /// added or removed from the vector.  But, the value of the elements may be
+  /// changed, so `getParameterList().front().setParameterValue(0)' is OK, but
+  /// 'getParameterList().emplace_back(Parameter())' is NOT OK.
   [[nodiscard]] const std::vector<Parameter> &getParameterList() const{ return _parameterList_; }
   [[nodiscard]] std::vector<Parameter> &getParameterList(){ return _parameterList_; }
 
   /// Get the vector of parameters for this parameter set in the
-  /// eigendecomposed basis.
+  /// eigendecomposed basis.  WARNING: See warning for getParameterList().
   [[nodiscard]] const std::vector<Parameter> &getEigenParameterList() const{ return _eigenParameterList_; }
   [[nodiscard]] std::vector<Parameter> &getEigenParameterList(){ return _eigenParameterList_; }
 
   /// Get the vector of parameters for this parameter set that is applicable
   /// for the current stage of the fit.  This will either be the
   /// eigendecomposed parameters, or the parameters in the non-decomposed
-  /// basis.
+  /// basis.  WARNING: See warning for getParameterList().
   [[nodiscard]] const std::vector<Parameter>& getEffectiveParameterList() const;
   [[nodiscard]] std::vector<Parameter>& getEffectiveParameterList();
 

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -68,22 +68,44 @@ public:
   [[nodiscard]] const std::vector<nlohmann::json>& getCustomFitParThrow() const{ return _customFitParThrow_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCorrelationMatrix() const{ return _priorCorrelationMatrix_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+
+  /// Get the vector of parameters for this parameter set in the real
+  /// parameter space.  These parameters are not eigendecomposed.
   [[nodiscard]] const std::vector<Parameter> &getParameterList() const{ return _parameterList_; }
+  [[nodiscard]] std::vector<Parameter> &getParameterList(){ return _parameterList_; }
+
+  /// Get the vector of parameters for this parameter set in the
+  /// eigendecomposed basis.
+  [[nodiscard]] const std::vector<Parameter> &getEigenParameterList() const{ return _eigenParameterList_; }
+  [[nodiscard]] std::vector<Parameter> &getEigenParameterList(){ return _eigenParameterList_; }
+
+  /// Get the vector of parameters for this parameter set that is applicable
+  /// for the current stage of the fit.  This will either be the
+  /// eigendecomposed parameters, or the parameters in the non-decomposed
+  /// basis.
   [[nodiscard]] const std::vector<Parameter>& getEffectiveParameterList() const;
+  [[nodiscard]] std::vector<Parameter>& getEffectiveParameterList();
 
-  // non-const Getters
-  std::vector<Parameter> &getParameterList(){ return _parameterList_; }
-  std::vector<Parameter> &getEigenParameterList(){ return _eigenParameterList_; }
-  std::vector<Parameter>& getEffectiveParameterList();
-
-  // Core
   double getPenaltyChi2();
 
-  // Throw / Shifts
+  /// Set all of the parameters to their prior values.
   void moveFitParametersToPrior();
+
+  /// Set the parameter values based on a random throw with fluctuations
+  /// determined by the striped covariance matrix.  If the first parameter,
+  /// rethrowIfNotInbounds, is true, then the throw is retried untill all of
+  /// the parameters are within the allowed bounds.  if the second parameter,
+  /// gain_, is set, it determines the variance of the thrown distribution
+  /// relative to the stripped covariance matrix.  A value larger than one
+  /// will increase the thrown variance.
   void throwFitParameters(bool rethrowIfNotInbounds_ = true, double gain_ = 1);
 
+  /// Update the parameter values in the set based on the parameter values in
+  /// the eigen decomposed basis.
   void propagateEigenToOriginal();
+
+  /// Update the parameters in the eigen decomposed basis based on the
+  /// parameter values in non-decomposed basis.
   void propagateOriginalToEigen();
 
   // Misc

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -88,12 +88,34 @@ void Parameter::setMaxMirror(double maxMirror) {
   _maxMirror_ = maxMirror;
 }
 void Parameter::setParameterValue(double parameterValue) {
-  LogThrowIf( std::isnan(parameterValue), "Attempting to set NaN value for par:" << std::endl << this->getSummary() );
+  if( std::isnan(parameterValue) ) {
+    LogError << "Attempting to set NaN for parameter" << std::endl;
+    LogError << "Summary: " << getSummary() << std::endl;
+    LogThrow("Setting parameter to a NaN value");
+  }
+  if ( not std::isnan(_minValue_) and parameterValue < _minValue_ ) {
+    LogError << "Attempting to set parameter below minimum" << std::endl;
+    LogError << "Summary: " << getSummary() << std::endl;
+    LogThrow("Setting parameter below minimum");
+  }
+  if ( not std::isnan(_maxValue_) and parameterValue > _maxValue_ ) {
+    LogError << "Attempting to set parameter above the maximum" << std::endl;
+    LogError << "Summary: " << getSummary() << std::endl;
+    LogThrow("Setting parameter above maximum");
+  }
   if( _parameterValue_ != parameterValue ){
     _gotUpdated_ = true;
     _parameterValue_ = parameterValue;
   }
   else{ _gotUpdated_ = false; }
+}
+double Parameter::getParameterValue() const {
+  if ( not isValueWithinBounds() ) {
+    LogError << "Getting parameter value that is out of bounds" << std::endl;
+    LogError << "Summary: " << getSummary() << std::endl;
+    LogThrow("Getting invalid parameter value");
+  }
+  return _parameterValue_;
 }
 void Parameter::setDialSetConfig(const nlohmann::json &jsonConfig_) {
   auto jsonConfig = jsonConfig_;
@@ -109,19 +131,20 @@ void Parameter::setParameterDefinitionConfig(const nlohmann::json &config_){
 }
 
 void Parameter::setValueAtPrior(){
-  _parameterValue_ = _priorValue_;
+  setParameterValue(getPriorValue());
 }
 void Parameter::setCurrentValueAsPrior(){
-  _priorValue_ = _parameterValue_;
+  setPriorValue(getParameterValue());
 }
 
 bool Parameter::isValueWithinBounds() const{
+  if( std::isnan(_parameterValue_) ) return false;
   if( not std::isnan(_minValue_) and _parameterValue_ < _minValue_ ) return false;
   if( not std::isnan(_maxValue_) and _parameterValue_ > _maxValue_ ) return false;
   return true;
 }
 double Parameter::getDistanceFromNominal() const{
-  return (_parameterValue_ - _priorValue_) / _stdDevValue_;
+  return (getParameterValue() - getPriorValue()) / _stdDevValue_;
 }
 std::string Parameter::getTitle() const {
   std::stringstream ss;
@@ -147,6 +170,7 @@ std::string Parameter::getSummary(bool shallow_) const {
   if( std::isnan(_maxValue_) ) ss << "+inf";
   else ss << _maxValue_;
   ss << " ]";
+  if (not isValueWithinBounds()) ss << " out of bounds";
 
   return ss.str();
 }

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -300,14 +300,14 @@ void ParameterSet::processCovarianceMatrix(){
 
 // Getters
 const std::vector<Parameter>& ParameterSet::getEffectiveParameterList() const{
-  if( _useEigenDecompInFit_ ) return _eigenParameterList_;
-  return _parameterList_;
+  if( _useEigenDecompInFit_ ) return getEigenParameterList();
+  return getParameterList();
 }
 
 // non const getters
 std::vector<Parameter>& ParameterSet::getEffectiveParameterList(){
-  if( _useEigenDecompInFit_ ) return _eigenParameterList_;
-  return _parameterList_;
+  if( _useEigenDecompInFit_ ) return getEigenParameterList();
+  return getParameterList();
 }
 
 // Core
@@ -358,7 +358,6 @@ void ParameterSet::moveFitParametersToPrior(){
 void ParameterSet::throwFitParameters(bool rethrowIfNotInbounds_, double gain_){
 
   LogThrowIf(_strippedCovarianceMatrix_==nullptr, "No covariance matrix provided");
-
 
   TVectorD throwsList{_strippedCovarianceMatrix_->GetNrows()};
 


### PR DESCRIPTION
This makes sure that the parameter value is alway accessed or changed through the getter and setter (getParameterValue and setParameterValue).  As part of the access, there are checks that the parameter values are valid (a number, and inside the allowed range).