### PR TITLE
Resolve LTS Issue #578: Clean up parameter bounds handling

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,7 @@
 Fixes relative to 1.8.4
 
+Issue #578: Apply cleanups to make sure that eigendecoposition and parameter throwing honor the parameter boundaries.  
+
 Fixes: Guarrantee that all parameter value access is through the setter and getter so that the validity checks are correctly applied.
 
 Fixes relative to 1.8.3

--- a/src/Fitter/include/MinimizerInterface.h
+++ b/src/Fitter/include/MinimizerInterface.h
@@ -58,7 +58,14 @@ protected:
 
 private:
 
-  // Parameters
+  // Dump the Math::Minimizer table of parameter settings.  This is mostly
+  // useful for debugging.
+  void dumpFitParameterSettings();
+
+  // Dump the ROOT::Minuit2::MnUserParameterState.  This is mostly useful
+  // for debugging.
+  void dumpMinuit2State();
+
   bool _enableSimplexBeforeMinimize_{false};
   // bool _enablePostFitErrorEval_{true};
   bool _restoreStepSizeBeforeHesse_{false};

--- a/src/Fitter/src/MinimizerBase.cpp
+++ b/src/Fitter/src/MinimizerBase.cpp
@@ -93,7 +93,9 @@ void MinimizerBase::printMinimizerFitParameters () {
 
       t.addTableLine({
                          par.getTitle(),
-                         std::to_string( par.getParameterValue() ),
+                         std::to_string( par.isValueWithinBounds() ?
+                                         par.getParameterValue()
+                                         : std::nan("Invalid")),
                          std::to_string( par.getPriorValue() ),
                          std::to_string( par.getStdDevValue() ),
                          std::to_string( par.getMinValue() ),

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -86,40 +86,40 @@ void MinimizerInterface::initializeImpl(){
     auto& fitPar = *(getMinimizerFitParameterPtr()[iFitPar]);
 
     if( not getLikelihood().getUseNormalizedFitSpace() ){
-      LogDebug << "MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
-      LogDebug << " Starting value: " << fitPar.getParameterValue();
-      LogDebug << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
+      LogInfo << "MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
+      LogInfo << " Starting value: " << fitPar.getParameterValue();
+      LogInfo << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
       _minimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),fitPar.getParameterValue(),fitPar.getStepSize()*_stepSizeScaling_);
       if( not std::isnan( fitPar.getMinValue() ) ){
-        LogDebug << " Min: " << fitPar.getMinValue();
+        LogInfo << " Min: " << fitPar.getMinValue();
         _minimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue());
       }
       if( not std::isnan( fitPar.getMaxValue() ) ){
-        LogDebug << " Max: " << fitPar.getMaxValue();
+        LogInfo << " Max: " << fitPar.getMaxValue();
         _minimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue());
       }
-      LogDebug << std::endl;
+      LogInfo << std::endl;
       // Changing the boundaries, change the value/step size?
       _minimizer_->SetVariableValue(iFitPar, fitPar.getParameterValue());
       _minimizer_->SetVariableStepSize(iFitPar, fitPar.getStepSize()*_stepSizeScaling_);
     }
     else{
-      LogDebug << "Normalized MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
-      LogDebug << " Starting value: " << fitPar.getParameterValue();
-      LogDebug << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
+      LogInfo << "Normalized MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
+      LogInfo << " Starting value: " << fitPar.getParameterValue();
+      LogInfo << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
       _minimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),
                                ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar),
                                ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar)
       );
       if( not std::isnan( fitPar.getMinValue() ) ){
-        LogDebug << " Min: " << fitPar.getMinValue();
+        LogInfo << " Min: " << fitPar.getMinValue();
         _minimizer_->SetVariableLowerLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar));
       }
       if( not std::isnan( fitPar.getMaxValue() ) ){
-        LogDebug << " Max: " << fitPar.getMaxValue();
+        LogInfo << " Max: " << fitPar.getMaxValue();
         _minimizer_->SetVariableUpperLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar));
       }
-      LogDebug << std::endl;
+      LogInfo << std::endl;
       // Changing the boundaries, change the value/step size?
       _minimizer_->SetVariableValue(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar));
       _minimizer_->SetVariableStepSize(iFitPar, ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar));

--- a/src/Fitter/src/MinimizerInterface.cpp
+++ b/src/Fitter/src/MinimizerInterface.cpp
@@ -86,20 +86,40 @@ void MinimizerInterface::initializeImpl(){
     auto& fitPar = *(getMinimizerFitParameterPtr()[iFitPar]);
 
     if( not getLikelihood().getUseNormalizedFitSpace() ){
+      LogDebug << "MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
+      LogDebug << " Starting value: " << fitPar.getParameterValue();
+      LogDebug << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
       _minimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),fitPar.getParameterValue(),fitPar.getStepSize()*_stepSizeScaling_);
-      if( not std::isnan( fitPar.getMinValue() ) ){ _minimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue()); }
-      if( not std::isnan( fitPar.getMaxValue() ) ){ _minimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue()); }
+      if( not std::isnan( fitPar.getMinValue() ) ){
+        LogDebug << " Min: " << fitPar.getMinValue();
+        _minimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue());
+      }
+      if( not std::isnan( fitPar.getMaxValue() ) ){
+        LogDebug << " Max: " << fitPar.getMaxValue();
+        _minimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue());
+      }
+      LogDebug << std::endl;
       // Changing the boundaries, change the value/step size?
       _minimizer_->SetVariableValue(iFitPar, fitPar.getParameterValue());
       _minimizer_->SetVariableStepSize(iFitPar, fitPar.getStepSize()*_stepSizeScaling_);
     }
     else{
+      LogDebug << "Normalized MINUIT #" << iFitPar << " --> " << fitPar.getFullTitle();
+      LogDebug << " Starting value: " << fitPar.getParameterValue();
+      LogDebug << " Step: " << fitPar.getStepSize()*_stepSizeScaling_;
       _minimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),
                                ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar),
                                ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar)
       );
-      if( not std::isnan( fitPar.getMinValue() ) ){ _minimizer_->SetVariableLowerLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar)); }
-      if( not std::isnan( fitPar.getMaxValue() ) ){ _minimizer_->SetVariableUpperLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar)); }
+      if( not std::isnan( fitPar.getMinValue() ) ){
+        LogDebug << " Min: " << fitPar.getMinValue();
+        _minimizer_->SetVariableLowerLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar));
+      }
+      if( not std::isnan( fitPar.getMaxValue() ) ){
+        LogDebug << " Max: " << fitPar.getMaxValue();
+        _minimizer_->SetVariableUpperLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar));
+      }
+      LogDebug << std::endl;
       // Changing the boundaries, change the value/step size?
       _minimizer_->SetVariableValue(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar));
       _minimizer_->SetVariableStepSize(iFitPar, ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar));

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -96,7 +96,11 @@ public:
   void setPriorValue(double priorValue){ _priorValue_ = priorValue; }
   void setThrowValue(double throwValue){ _throwValue_ = throwValue; }
   void setStdDevValue(double stdDevValue){ _stdDevValue_ = stdDevValue; }
-  void setParameterValue(double parameterValue);
+
+  /// Set the parameter value.  This always checks the parameter validity, but
+  /// if force is true, then it will only print warnings, otherwise it stops
+  /// with EXIT_FAILURE.
+  void setParameterValue(double parameterValue, bool force=false);
   void setName(const std::string &name){ _name_ = name; }
   void setDialSetConfig(const nlohmann::json &jsonConfig_);
   void setParameterDefinitionConfig(const nlohmann::json &config_);

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -174,6 +174,7 @@ private:
   int _nbEnabledEigen_{0};
   bool _enablePca_{false};
   bool _useEigenDecompInFit_{false};
+  bool _allowEigenDecompWithBounds_{false};
   bool _useOnlyOneParameterPerEvent_{false};
   std::vector<Parameter> _eigenParameterList_{};
   std::shared_ptr<TMatrixDSymEigen> _eigenDecomp_{nullptr};

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -26,6 +26,7 @@ public:
 
   // setters
   void setReThrowParSetIfOutOfBounds(bool reThrowParSetIfOutOfBounds_){ _reThrowParSetIfOutOfBounds_ = reThrowParSetIfOutOfBounds_; }
+  void setReThrowParSetIfOutOfPhysical(bool reThrowParSetIfOutOfPhysical_){ _reThrowParSetIfOutOfPhysical_ = reThrowParSetIfOutOfPhysical_; }
   void setThrowToyParametersWithGlobalCov(bool throwToyParametersWithGlobalCov_){ _throwToyParametersWithGlobalCov_ = throwToyParametersWithGlobalCov_; }
   void setGlobalCovarianceMatrix(const std::shared_ptr<TMatrixD> &globalCovarianceMatrix){ _globalCovarianceMatrix_ = globalCovarianceMatrix; }
 
@@ -49,14 +50,15 @@ public:
   void throwParametersFromParSetCovariance();
   void throwParametersFromGlobalCovariance(bool quietVerbose_ = true);
   ParameterSet* getFitParameterSetPtr(const std::string& name_);
-  
+
   // Logger related
   static void muteLogger();
   static void unmuteLogger();
 
 private:
   // config
-  bool _reThrowParSetIfOutOfBounds_{true};
+  bool _reThrowParSetIfOutOfBounds_{true}; // NO LONGER USED.  CAN NEVER BE FALSE.
+  bool _reThrowParSetIfOutOfPhysical_{false};
   bool _throwToyParametersWithGlobalCov_{false};
 
   // internals

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -9,6 +9,8 @@
 #include "GenericToolbox.Json.h"
 #include "Logger.h"
 
+#include "GundamBacktrace.h"
+
 #include <sstream>
 
 LoggerInit([]{ Logger::setUserHeaderStr("[Parameter]"); });
@@ -87,25 +89,31 @@ void Parameter::setMaxMirror(double maxMirror) {
   }
   _maxMirror_ = maxMirror;
 }
-void Parameter::setParameterValue(double parameterValue) {
+void Parameter::setParameterValue(double parameterValue, bool force) {
   if( std::isnan(parameterValue) ) {
     LogError << "Attempting to set NaN for parameter" << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
-    LogThrow("Setting parameter to a NaN value");
+    LogError << GundamUtils::Backtrace;
+    if (not force) std::exit(EXIT_FAILURE);
+    else LogAlert << "Forced continuation with invalid parameter" << std::endl;
   }
   if ( not std::isnan(_minValue_) and parameterValue < _minValue_ ) {
     LogError << "Attempting to set parameter below minimum"
              << " -- New value: " << parameterValue
              << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
-    LogThrow("Setting parameter below minimum");
+    LogError << GundamUtils::Backtrace;
+    if (not force) std::exit(EXIT_FAILURE);
+    else LogAlert << "Forced continuation with invalid parameter" << std::endl;
   }
   if ( not std::isnan(_maxValue_) and parameterValue > _maxValue_ ) {
     LogError << "Attempting to set parameter above the maximum"
              << " -- New value: " << parameterValue
              << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
-    LogThrow("Setting parameter above maximum");
+    LogError << GundamUtils::Backtrace;
+    if (not force) std::exit(EXIT_FAILURE);
+    else LogAlert << "Forced continuation with invalid parameter" << std::endl;
   }
   if( _parameterValue_ != parameterValue ){
     _gotUpdated_ = true;
@@ -115,9 +123,9 @@ void Parameter::setParameterValue(double parameterValue) {
 }
 double Parameter::getParameterValue() const {
   if ( not isValueWithinBounds() ) {
-    LogError << "Getting parameter value that is out of bounds" << std::endl;
-    LogError << "Summary: " << getSummary() << std::endl;
-    if (isEnabled()) abort();
+    LogWarning << "Getting out of bounds parameter: "
+               << getSummary() << std::endl;
+    LogDebug << GundamUtils::Backtrace;
   }
   return _parameterValue_;
 }

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -94,12 +94,16 @@ void Parameter::setParameterValue(double parameterValue) {
     LogThrow("Setting parameter to a NaN value");
   }
   if ( not std::isnan(_minValue_) and parameterValue < _minValue_ ) {
-    LogError << "Attempting to set parameter below minimum" << std::endl;
+    LogError << "Attempting to set parameter below minimum"
+             << " -- New value: " << parameterValue
+             << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
     LogThrow("Setting parameter below minimum");
   }
   if ( not std::isnan(_maxValue_) and parameterValue > _maxValue_ ) {
-    LogError << "Attempting to set parameter above the maximum" << std::endl;
+    LogError << "Attempting to set parameter above the maximum"
+             << " -- New value: " << parameterValue
+             << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
     LogThrow("Setting parameter above maximum");
   }
@@ -113,7 +117,7 @@ double Parameter::getParameterValue() const {
   if ( not isValueWithinBounds() ) {
     LogError << "Getting parameter value that is out of bounds" << std::endl;
     LogError << "Summary: " << getSummary() << std::endl;
-    LogThrow("Getting invalid parameter value");
+    if (isEnabled()) abort();
   }
   return _parameterValue_;
 }

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -635,7 +635,12 @@ std::string ParameterSet::getSummary() const {
         if( not par.isEnabled() ) { statusStr = "Disabled"; colorStr = GenericToolbox::ColorCodes::yellowBackground; }
         else if( par.isFixed() )  { statusStr = "Fixed";    colorStr = GenericToolbox::ColorCodes::redBackground; }
         else if( par.isFree() )   { statusStr = "Free";     colorStr = GenericToolbox::ColorCodes::blueBackground; }
-        else                      { statusStr = "Fit"; }
+        else                      {
+          statusStr = "Fit";
+          if( not par.isValueWithinBounds() ) {
+            colorStr = GenericToolbox::ColorCodes::redBackground;
+          }
+        }
 
 #ifdef NOCOLOR
         colorStr = "";
@@ -643,7 +648,9 @@ std::string ParameterSet::getSummary() const {
 
         t.addTableLine({
                            par.getTitle(),
-                           std::to_string( par.getParameterValue() ),
+                           std::to_string( par.isValueWithinBounds() ?
+                                           par.getParameterValue()
+                                           : std::nan("Invalid") ),
                            std::to_string( par.getPriorValue() ),
                            std::to_string( par.getStdDevValue() ),
                            std::to_string( par.getMinValue() ),

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -590,7 +590,7 @@ void ParameterSet::propagateOriginalToEigen(){
 
   // Propagate back to eigen parameters
   for( int iEigen = 0 ; iEigen < _eigenParBuffer_->GetNrows() ; iEigen++ ){
-    _eigenParameterList_[iEigen].setParameterValue((*_eigenParBuffer_)[iEigen]);
+    _eigenParameterList_[iEigen].setParameterValue((*_eigenParBuffer_)[iEigen], true);
   }
 }
 void ParameterSet::propagateEigenToOriginal(){
@@ -607,7 +607,7 @@ void ParameterSet::propagateEigenToOriginal(){
   int iParOffSet{0};
   for( auto& par : _parameterList_ ){
     if( par.isFixed() or not par.isEnabled() ) continue;
-    par.setParameterValue((*_originalParBuffer_)[iParOffSet++]);
+    par.setParameterValue((*_originalParBuffer_)[iParOffSet++], true);
   }
 }
 

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -25,7 +25,8 @@ void ParametersManager::unmuteLogger(){ Logger::setIsMuted( false ); }
 // config
 void ParametersManager::readConfigImpl(){
 
-  _reThrowParSetIfOutOfBounds_ = GenericToolbox::Json::fetchValue(_config_, "reThrowParSetIfOutOfBounds", _reThrowParSetIfOutOfBounds_);
+  // _reThrowParSetIfOutOfBounds_ = GenericToolbox::Json::fetchValue(_config_, "reThrowParSetIfOutOfBounds", _reThrowParSetIfOutOfBounds_);
+  _reThrowParSetIfOutOfPhysical_ = GenericToolbox::Json::fetchValue(_config_, "reThrowParSetIfOutOfPhysical", _reThrowParSetIfOutOfPhysical_);
   _throwToyParametersWithGlobalCov_ = GenericToolbox::Json::fetchValue(_config_, "throwToyParametersWithGlobalCov", _throwToyParametersWithGlobalCov_);
 
 }
@@ -151,7 +152,7 @@ void ParametersManager::throwParametersFromParSetCovariance(){
     if( parSet.getPriorCovarianceMatrix() != nullptr ){
       LogWarning << parSet.getName() << ": throwing correlated parameters..." << std::endl;
       LogScopeIndent;
-      parSet.throwFitParameters(_reThrowParSetIfOutOfBounds_);
+      parSet.throwFitParameters(_reThrowParSetIfOutOfPhysical_);
     } // throw?
     else{
       LogAlert << "No correlation matrix defined for " << parSet.getName() << ". NOT THROWING. (dev: could throw only with sigmas?)" << std::endl;
@@ -200,82 +201,82 @@ void ParametersManager::throwParametersFromGlobalCovariance(bool quietVerbose_){
     );
   }
 
-  bool keepThrowing{true};
   int throwNb{0};
-
-  while( keepThrowing ){
+  while( true ) {
     throwNb++;
     bool rethrow{false};
     auto throws = GenericToolbox::throwCorrelatedParameters(_choleskyMatrix_.get());
     for( int iPar = 0 ; iPar < _choleskyMatrix_->GetNrows() ; iPar++ ){
       auto* parPtr = _strippedParameterList_[iPar];
-      parPtr->setParameterValue( parPtr->getPriorValue() + throws[iPar] );
-      if( _reThrowParSetIfOutOfBounds_ ){
-        if      ( not std::isnan(parPtr->getMinValue()) and parPtr->getParameterValue() < parPtr->getMinValue() ){
-          rethrow = true;
-          LogAlert << GenericToolbox::ColorCodes::redLightText << "thrown value lower than min bound -> " << GenericToolbox::ColorCodes::resetColor
-                   << parPtr->getSummary(true) << std::endl;
-        }
-        else if( not std::isnan(parPtr->getMaxValue()) and parPtr->getParameterValue() > parPtr->getMaxValue() ){
-          rethrow = true;
-          LogAlert << GenericToolbox::ColorCodes::redLightText <<"thrown value higher than max bound -> " << GenericToolbox::ColorCodes::resetColor
-                   << parPtr->getSummary(true) << std::endl;
-        }
+      parPtr->setThrowValue(parPtr->getPriorValue() + throws[iPar]);
+      if ( not std::isnan(parPtr->getMinValue()) and parPtr->getThrowValue() < parPtr->getMinValue()) {
+        LogAlert << "Thrown value lower than min bound -> " << parPtr->getSummary(true) << std::endl;
+        rethrow = true;
+        break;
+      }
+      if ( not std::isnan(parPtr->getMaxValue()) and parPtr->getThrowValue() > parPtr->getMaxValue()) {
+        LogAlert << "Thrown value lower than max bound -> " << parPtr->getSummary(true) << std::endl;
+        rethrow = true;
+        break;
+      }
+      parPtr->setParameterValue( parPtr->getThrowValue() );
+      if( not _reThrowParSetIfOutOfPhysical_ ) continue;
+      if( not std::isnan(parPtr->getMinPhysical()) and parPtr->getParameterValue() < parPtr->getMinPhysical() ){
+        rethrow = true;
+        LogAlert << "thrown value lower than physical min bound -> "
+                 << parPtr->getSummary(true) << std::endl;
+        break;
+      }
+      if( not std::isnan(parPtr->getMaxPhysical()) and parPtr->getParameterValue() > parPtr->getMaxPhysical() ){
+        rethrow = true;
+        LogAlert << "thrown value higher than physical max bound -> "
+                 << parPtr->getSummary(true) << std::endl;
+        break;
       }
     }
 
     // Making sure eigen decomposed parameters get the conversion done
-    for( auto& parSet : _parameterSetList_ ){
+    for( auto& parSet : _parameterSetList_ ) {
+      if (rethrow) break;  // short circuit if we are already rethrowing.
       if( not parSet.isEnabled() ) continue;
-      if( parSet.isUseEigenDecompInFit() ){
-        parSet.propagateOriginalToEigen();
-
-        // also check the bounds of real parameter space
-        if( _reThrowParSetIfOutOfBounds_ ){
-          for( auto& par : parSet.getEigenParameterList() ){
-            if( not par.isEnabled() ) continue;
-            if( not par.isValueWithinBounds() ){
-              // re-do the throwing
-              rethrow = true;
-              break;
-            }
-          }
-        }
+      if( not parSet.isUseEigenDecompInFit() ) continue;
+      parSet.propagateOriginalToEigen();
+      // also check the bounds of real parameter space
+      for( auto& par : parSet.getEigenParameterList() ){
+        if( not par.isEnabled() ) continue;
+        if( par.isValueWithinBounds() ) continue;
+        // re-do the throwing
+        rethrow = true;
+        break;
       }
     }
 
-
-    if( rethrow ){
+    if( rethrow ) {
+      LogThrowIf( throwNb > 10000, "To many throw attempts")
       // wrap back to the while loop
-      LogWarning << "Re-throwing attempt #" << throwNb << std::endl;
+      LogWarning << "Rethrowing after attempt #" << throwNb << std::endl;
       continue;
     }
-    else{
-      for( auto& parSet : _parameterSetList_ ){
-        LogInfo << parSet.getName() << ":" << std::endl;
-        for( auto& par : parSet.getParameterList() ){
-          LogScopeIndent;
-          if( ParameterSet::isValidCorrelatedParameter(par) ){
-            par.setThrowValue( par.getParameterValue() );
-            LogInfo << "Thrown par " << par.getFullTitle() << ": " << par.getPriorValue();
-            LogInfo << " → " << par.getParameterValue() << std::endl;
-          }
-        }
-        if( parSet.isUseEigenDecompInFit() ){
-          LogInfo << "Translated to eigen space:" << std::endl;
-          for( auto& eigenPar : parSet.getEigenParameterList() ){
-            LogScopeIndent;
-            eigenPar.setThrowValue( eigenPar.getParameterValue() );
-            LogInfo << "Eigen par " << eigenPar.getFullTitle() << ": " << eigenPar.getPriorValue();
-            LogInfo << " → " << eigenPar.getParameterValue() << std::endl;
-          }
+
+    for( auto& parSet : _parameterSetList_ ){
+      LogInfo << parSet.getName() << ":" << std::endl;
+      for( auto& par : parSet.getParameterList() ){
+        LogScopeIndent;
+        if( ParameterSet::isValidCorrelatedParameter(par) ){
+          par.setThrowValue( par.getParameterValue() );
+          LogInfo << "Thrown par " << par.getFullTitle() << ": " << par.getPriorValue();
+          LogInfo << " becomes " << par.getParameterValue() << std::endl;
         }
       }
-
+      if( not parSet.isUseEigenDecompInFit() ) continue;
+      LogInfo << "Translated to eigen space:" << std::endl;
+      for( auto& eigenPar : parSet.getEigenParameterList() ){
+        LogScopeIndent;
+        eigenPar.setThrowValue( eigenPar.getParameterValue() );
+        LogInfo << "Eigen par " << eigenPar.getFullTitle() << ": " << eigenPar.getPriorValue();
+        LogInfo << " becomes " << eigenPar.getParameterValue() << std::endl;
+      }
     }
-
-    // reached this point: all parameters are within bounds
-    keepThrowing = false;
   }
 }
 void ParametersManager::injectParameterValues(const nlohmann::json &config_) {
@@ -300,4 +301,3 @@ void ParametersManager::injectParameterValues(const nlohmann::json &config_) {
 ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& name_){
   return const_cast<ParameterSet*>(const_cast<const ParametersManager*>(this)->getFitParameterSetPtr(name_));
 }
-

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ConfigUtils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamUtils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamApp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamBacktrace.h
     )
 
 
@@ -75,4 +76,3 @@ install(TARGETS GundamUtils DESTINATION lib)
 #        COMPONENT
 #        libraries
 #)
-

--- a/src/Utils/include/GundamBacktrace.h
+++ b/src/Utils/include/GundamBacktrace.h
@@ -1,0 +1,53 @@
+#ifndef GUNDAM_Backtrace_h_seen
+#define GUNDAM_Backtrace_h_seen
+
+#include <ostream>
+
+// Backtrace depends on execinfo.h being available.  This is only available on
+// linux.
+//
+// Note: Rumor has it that this can be tested using CMake (FindBacktrace), but
+// that has not been well tested (remove this comment if it gets implemented)!
+//
+// Note: Rumor has it that Macs have it after Mac OS X 10.5, but I can't test
+// that so for now it's not included.
+//
+// Note: This is a candidate for the generic tool kit, or simple cpp logger.
+#if defined(__linux__)
+#include <execinfo.h>
+#include <cstdlib>
+#else
+#warning Backtrace is not available
+#endif
+
+namespace GundamUtils {
+    // When possible, print a backtrace for the current call stack to the
+    // standard output stream.
+    template<class CharT, class Traits>
+    std::basic_ostream<CharT,Traits>&
+    Backtrace(std::basic_ostream<CharT, Traits>& out) {
+#if defined(__linux__)
+        void *buffer[100];
+        int nptrs = backtrace(buffer,100);
+        out << "Backtrace of " << nptrs << " calls" << std::endl;
+
+        // This uses malloc to allocate memory for strings, and passes
+        // ownership to the caller.
+        char **strings = backtrace_symbols(buffer,nptrs);
+        if (strings == nullptr) {
+            out << "Error generating backtrace" << std::endl;
+            return out;
+        }
+
+        for (int i=0; i< nptrs; ++i) out << strings[i] << std::endl;
+
+        // Free the strings pointer that was allocated with malloc.
+        std::free(strings);
+#else
+        out << "Backtrace not available" << std::endl;
+#endif
+        return out;
+    }
+};
+
+#endif


### PR DESCRIPTION
The handling of parameter bounds while working with eigenvalue decomposition and the parameter throwing has been cleaned up so that out of bounds parameters are avoided where possible, and not accepted where they cannot be avoided.  This effects three major places

1. Do not allow eigen decomposition of parameters that have a bound.  This can be overridden by the configuration file, but by default GUNDAM will exit if bounds and decomposition are combined.
2. Update the parameter set thrower to check the validity of the thrown value before setting the parameter value.
3. Update the global parameter thrower to check the validity of the thrown value before setting the parameter value.
