### PR TITLE
Improve the naming for Tabulated dial parameters

### DIFF
--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -493,7 +493,7 @@ bool DialCollection::initializeDialsWithTabulation(JsonType dialsDefinition_) {
   _dialCollectionData_.emplace_back(std::move(tabulated));
 
   for (const std::string& var :
-         getCollectionData<TabulatedDialFactory>()->getVariables()) {
+         getCollectionData<TabulatedDialFactory>()->getBinningVariables()) {
     addExtraLeafName(var);
   }
 

--- a/src/DialDictionary/DialFactories/include/TabulatedDialFactory.h
+++ b/src/DialDictionary/DialFactories/include/TabulatedDialFactory.h
@@ -7,143 +7,169 @@
 class Event;
 class DialBase;
 
-// Initialize the Tabulated type.  That yaml for this is
-// tableConfig:
-//    - name: <table-name>                A table name passed to the library.
-//      bins:  <number>                   The (optional) expected number of
-//                                           bins in the table. Will be
-//                                           overridden by the initFunction.
-//      libraryPath: <path-to-library>    Location of the library
-//      initFunction: <init-func-name>    Function called for initialization
-//      initArguments: [<arg1>, ...]      List of argument strings (e.g.
-//                                           input file names)
-//      updateFunction: <update-func-name> Function called to update table
-//      binningFunction: <bin-func-name>  Function to find bin index
-//      variables: [<var1>, <var2>, ... ] Variables used for binning the
-//                                           table "X" coordinate by the
-//                                           binning function.
+/// Initialize the Tabulated type.  That yaml for this is
+/// tableConfig:
+///    - name: <table-name>                A table name passed to the library.
+///      bins:  <number>                   The (optional) expected number of
+///                                           bins in the table. Will be
+///                                           overridden by the initFunction.
+///      libraryPath: <path-to-library>    Location of the library
+///      initFunction: <init-func-name>    Function called for initialization
+///      initArguments: [<arg1>, ...]      List of argument strings (e.g.
+///                                           input file names)
+///      updateFunction: <update-func-name> Function called to update table
+///      binningFunction: <bin-func-name>  Function to find bin index
+///      binningVariables: [<var1>, ... ] Variables used for binning the
+///                                           table "X" coordinate by the
+///                                           binning function.
+///
+/// INITIALIZATION FUNCTION: If initFunction is provided it will be called with
+/// the signature:
 //
-// INITIALIZATION FUNCTION: If initFunction is provided it will be called with
-// the signature:
+///    extern "C"
+///    int initFunc(const char* name, int argc, const char* argv[], int bins)
+///
+///        name -- The name of the table
+///        argc -- number of arguments
+///        argv -- argument strings.  The arguments are defined by the library,
+///                but are usually things like input file names for the lookup
+///                table information.
+///        bins -- The size of the table.  This is the expected size of the
+///                table. The library must
+///                choose an appropriate binning
 //
-//    extern "C"
-//    int initFunc(const char* name, int argc, const char* argv[], int bins)
+/// The function should return less than or equal to zero for failure, and
+/// otherwise, the number of elements needed to store the table (usually, the
+/// same as the input value of "bins").
 //
-//        name -- The name of the table
-//        argc -- number of arguments
-//        argv -- argument strings.  The arguments are defined by the library,
-//                but are usually things like input file names for the lookup
-//                table information.
-//        bins -- The size of the table.  This is the expected size of the
-//                table. The library must
-//                choose an appropriate binning
+/// UPDATE TABLE FUNCTION: The updateFunction signature is:
+///
+///    extern "C"
+///    int updateFunc(const char* name,
+///                   double table[], int bins,
+///                   const double par[], int npar)
+///
+///        name  -- table name
+///        table -- address of the table to update
+///        bins  -- The size of the table
+///        par   -- The parameters.  Must match parameters
+///                   define in the dial definition
+///        npar  -- number of parameters
 //
-// The function should return less than or equal to zero for failure, and
-// otherwise, the number of elements needed to store the table (usually, the
-// same as the input value of "bins").
+/// The function should return 0 for success, and any other value for failure
+///
+/// The table will be filled with "bins" values calculated with uniform
+/// spacing between "low" and "high".  If bins is one, there must be one
+/// value calculated for "low", if bins is two or more, then the first point
+/// is located at "low", and the last point is located at "high".  The step
+/// between the bins is (high-low)/(bins-1).  Examples:
+///
+///    bins = 2, low = 1.0, high = 6.0
+///       values calculated at 1.0 and 6.0
 //
-// UPDATE TABLE FUNCTION: The updateFunction signature is:
+///    bins = 3, low = 1.0, high = 6.0
+///       values calculated at 1.0, 3.5, and 6.0
 //
-//    extern "C"
-//    int updateFunc(const char* name,
-//                   double table[], int bins,
-//                   const double par[], int npar)
-//
-//        name  -- table name
-//        table -- address of the table to update
-//        bins  -- The size of the table
-//        par   -- The parameters.  Must match parameters
-//                   define in the dial definition
-//        npar  -- number of parameters
-//
-// The function should return 0 for success, and any other value for failure
-//
-// The table will be filled with "bins" values calculated with uniform
-// spacing between "low" and "high".  If bins is one, there must be one
-// value calculated for "low", if bins is two or more, then the first point
-// is located at "low", and the last point is located at "high".  The step
-// between the bins is (high-low)/(bins-1).  Examples:
-//
-//    bins = 2, low = 1.0, high = 6.0
-//       values calculated at 1.0 and 6.0
-//
-//    bins = 3, low = 1.0, high = 6.0
-//       values calculated at 1.0, 3.5, and 6.0
-//
-// BIN INDEX DETERMINATION: The binningFunction signature is:
+/// BIN INDEX DETERMINATION: The binningFunction signature is:
 
-//    extern "C"
-//    double binFunc(const char* name, int nvar, const double varv[], int bins);
-//        name -- table name
-//        nvar -- number of (truth) variables used to find bin
-//        varv -- array of (truth) variables used to find bin
-//        bins -- The number of bins in the table.
+///    extern "C"
+///    double binFunc(const char* name, int nvar, const double varv[], int bins);
+///        name -- table name
+///        nvar -- number of (truth) variables used to find bin
+///        varv -- array of (truth) variables used to find bin
+///        bins -- The number of bins in the table.
 //
-// The function should return a double giving the fractional bin number
-// greater or equal to zero and LESS THAN the maximum number of bins.  The
-// integer part determines the index of the value below the value to be
-// interpolated, and the fractional part determines the interpolation between
-// the indexed bin, and the next.  This determines where to find the entry for
-// the input (truth) variables.
-//
-// The code should loadable by dlopen, so it needs be compiled with (at least)
-//
-// gcc -fPIC -rdynamic --shared -o <LibraryName>.so <source>
-//
+/// The function should return a double giving the fractional bin number
+/// greater or equal to zero and LESS THAN the maximum number of bins.  The
+/// integer part determines the index of the value below the value to be
+/// interpolated, and the fractional part determines the interpolation between
+/// the indexed bin, and the next.  This determines where to find the entry for
+/// the input (truth) variables.
+///
+/// The code should loadable by dlopen, so it needs be compiled with (at least)
+///
+/// gcc -fPIC -rdynamic --shared -o <LibraryName>.so <source>
+///
 class TabulatedDialFactory : public DialCollection::CollectionData {
 public:
     TabulatedDialFactory() = default;
     ~TabulatedDialFactory() = default;
     TabulatedDialFactory(const JsonType& config_);
 
-    // Create an event-by-event weighting dial for this table.
+    /// Create an event-by-event weighting dial for this table.
     [[nodiscard]] DialBase* makeDial(const Event& event);
 
-    // Update the tabulated buffer.
+    /// Update the tabulated buffer.
     void updateTable(DialInputBuffer& inputBuffer);
 
-    // Get the table name
+    /// Get the table name
     const std::string& getName() {return _name_;}
 
-    // Get the path to the library that implements the tabulation.
+    /// Get the path to the library that implements the tabulation.
     const std::string& getLibraryPath() {return _libraryPath_;}
 
-    // Get the name of the function that is called to initialize the
-    // tabulation.  The function is called during construction.
+    /// Get the name of the function that is called to initialize the
+    /// tabulation.  The function is called during construction.
     const std::string& getInitializationFunction() {return _initFuncName_;}
 
-    // Get the arguments provided to the initialization function.
+    /// Get the arguments provided to the initialization function.
     const std::vector<std::string>& getInitializationArguments() {return _initArguments_;}
 
-    // Get the name of the function that determines the bin based on the
-    // event parameters
+    /// Get the name of the function that determines the bin based on the
+    /// event parameters
     const std::string& getBinningFunction() {return _binningFuncName_;}
 
-    // Get the name of the function to update the table.
+    /// Get the name of the function to update the table.
     const std::string& getUpdateFunction() {return _updateFuncName_;}
 
-    // Get a vector of event variable names that are used to find the bin
-    // in the table for the event.
-    const std::vector<std::string>& getVariables() {return _variableNames_;}
+    /// Get a vector of event variable names that are used to find the bin
+    /// in the table for the event.
+    const std::vector<std::string>& getBinningVariables() {return _binningVariableNames_;}
 
 private:
     std::string _name_{"table"};
     std::string _libraryPath_;
+
+    // The name of a symbol in the library that will be used to initialize the
+    // library.
     std::string _initFuncName_;
+
+    // The function that is attached to _initFuncName_.  It is called to
+    // initialize the library.  See the class documentation above for a
+    // description of what the library needs to implement.
     int (*_initFunc_)(const char* name,
-        int argc, const char* argv[],
-        int bins);
+                      int argc, const char* argv[],
+                      int bins);
+
+    /// A vector of arguments that will be passed to the initialization
+    /// function.
     std::vector<std::string> _initArguments_;
+
+    // The name of a symbol in the library that will be used to update the
+    // table before each likelihood calculation.
     std::string _updateFuncName_;
+
+    // The function that is attached to _updateFuncName_ symbol.
     int (*_updateFunc_)(const char* name,
-        double table[], int bins,
-        const double par[], int npar);
-    std::string _binningFuncName_;
-    double (*_binningFunc_)(const char* name,
-        int varc, double varv[],
-        int bins);
+                        double table[], int bins,
+                        const double par[], int npar);
+
+    // A cache to hold the table of calculated values
     std::vector<double> _table_;
-    std::vector<std::string> _variableNames_;
-    std::vector<double> _variables_;
+
+    // The name of a symbol in the library that will be used to find the
+    // bin associated with each event.
+    std::string _binningFuncName_;
+
+    // The function that is attached to _binningFuncName_ symbol.  See the
+    // class documentation for what needs to be implemented.  The varv[] array
+    // holds the event variables that are being binned.  The return value is a
+    // double where the integer part is the bin number, and the fraction is
+    // used to interpolated between bins.
+    double (*_binningFunc_)(const char* name,
+                            int varc, double varv[],
+                            int bins);
+    std::vector<std::string> _binningVariableNames_;
+    std::vector<double> _binningVariableCache_;
 };
 #endif

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -30,8 +30,8 @@ TabulatedDialFactory::TabulatedDialFactory(const JsonType& config_) {
 
     int bins =  GenericToolbox::Json::fetchValue<int>(tableConfig, "bins", -1);
 
-    _variableNames_ = GenericToolbox::Json::fetchValue(tableConfig, "variables", _variableNames_);
-    _variables_.resize(_variableNames_.size());
+    _binningVariableNames_ = GenericToolbox::Json::fetchValue(tableConfig, "binningVariables", _binningVariableNames_);
+    _binningVariableCache_.resize(_binningVariableNames_.size());
 
     std::string expandedPath = GenericToolbox::expandEnvironmentVariables(getLibraryPath());
 
@@ -42,7 +42,7 @@ TabulatedDialFactory::TabulatedDialFactory(const JsonType& config_) {
     LogInfo << "  Bin events function:     " << getBinningFunction() << std::endl;
     {
         int i{0};
-        for (const std::string& var: getVariables()) {
+        for (const std::string& var: getBinningVariables()) {
             LogInfo << "      Variable[" << i++ << "]: " << var << std::endl;
         }
     }
@@ -128,12 +128,13 @@ void TabulatedDialFactory::updateTable(DialInputBuffer& inputBuffer) {
 
 DialBase* TabulatedDialFactory::makeDial(const Event& event) {
     int i=0;
-    for (const std::string& varName : getVariables()) {
+    for (const std::string& varName : getBinningVariables()) {
         double v = event.getVariables().fetchVariable(varName).getVarAsDouble();
-        _variables_[i++] = v;
+        _binningVariableCache_[i++] = v;
     }
     double bin = _binningFunc_(getName().c_str(),
-                               (int) _variables_.size(), _variables_.data(),
+                               (int) _binningVariableCache_.size(),
+                               _binningVariableCache_.data(),
                                (int) _table_.size());
 
     if (bin < 0.0) return nullptr;

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -49,7 +49,7 @@ public:
   [[nodiscard]] bool isEnabledThrowToyParameters() const{ return _enabledThrowToyParameters_; }
   [[nodiscard]] bool isMaskForToyGeneration() const { return _maskForToyGeneration_; }
   [[nodiscard]] bool isMaskedForPropagation() const{ return _maskedForPropagation_; }
-  [[nodiscard]] bool isUseOnlyOneParameterPerEvent() const{ return _useOnlyOneParameterPerEvent_; }
+  [[deprecated]] [[nodiscard]] bool isUseOnlyOneParameterPerEvent() const{ return _useOnlyOneParameterPerEvent_; }
   [[nodiscard]] int getNbEnabledEigenParameters() const{ return _nbEnabledEigen_; }
   [[nodiscard]] double getPenaltyChi2Buffer() const{ return _penaltyChi2Buffer_; }
   [[nodiscard]] size_t getNbParameters() const{ return _parameterList_.size(); }

--- a/tests/fast-tests/200TabulatedAsimov-config.yaml
+++ b/tests/fast-tests/200TabulatedAsimov-config.yaml
@@ -105,7 +105,7 @@ fitterEngineConfig:
                 - "FLUX ${DATA_DIR}/nutaubar.txt"
               updateFunction: "updateTable"
               binningFunction: "binTable"
-              variables: ["At", "Bt"]
+              binningVariables: ["At", "Bt"]
 
 
 


### PR DESCRIPTION
This changes the tabulated YAML field named "variables" to "binningVariables" which better reflects what is being done, and fixes the code to match the change.  This is hopefully the final iteration on the Tabulated dial API (I can hope).