### PR TITLE
Fix/apply LTS parameter bound fixes

### DIFF
--- a/src/Fitter/Minimizer/include/MinimizerBase.h
+++ b/src/Fitter/Minimizer/include/MinimizerBase.h
@@ -44,7 +44,7 @@ protected:
   void readConfigImpl() override;
   void initializeImpl() override;
 
-  // Internal struct that hold infos on the minimizer state
+  // Internal struct that hold info about the minimizer state
   struct Monitor{
     bool isEnabled{false};
     bool showParameters{false};
@@ -109,7 +109,11 @@ public:
 
   // const getters
   [[nodiscard]] bool disableCalcError() const{ return _disableCalcError_; }
+
+  // Get the return status for the fitter.  The return value is specific
+  // to the instantiated fitter, but is mostly centered around MINUIT
   [[nodiscard]] int getMinimizerStatus() const { return _minimizerStatus_; }
+  void setMinimizerStatus(int s) {_minimizerStatus_ = s;}
 
   // mutable getters
   Monitor& getMonitor(){ return _monitor_; }
@@ -142,23 +146,28 @@ protected:
   // function to get the vector of fit parameter pointers.  The actual vector
   // lives in the likelihood.
   std::vector<Parameter *> &getMinimizerFitParameterPtr(){ return _minimizerParameterPtrList_; }
+  const std::vector<Parameter *> &getMinimizerFitParameterPtr() const{ return _minimizerParameterPtrList_; }
 
-protected:
+  // Query if a normalized fit space is being used.
+  bool useNormalizedFitSpace() const {return _useNormalizedFitSpace_;}
+  int* getNbFreeParametersPtr() {return &_nbFreeParameters_;}
+
+private:
+  /// Save a copy of the address of the engine that owns this object.
+  FitterEngine* _owner_{nullptr};
+
+  std::vector<Parameter*> _minimizerParameterPtrList_{};
+  int _minimizerStatus_{-1}; // -1: invalid, 0: success, >0: errors
+  int _nbFreeParameters_{0};
+
+
   // config
   bool _throwOnBadLlh_{false};
   bool _useNormalizedFitSpace_{true};
 
   // internals
   bool _disableCalcError_{false};
-  int _minimizerStatus_{-1}; // -1: invalid, 0: success, >0: errors
-  int _nbFreeParameters_{0};
-  std::vector<Parameter*> _minimizerParameterPtrList_{};
   Monitor _monitor_{};
-
-
-private:
-  /// Save a copy of the address of the engine that owns this object.
-  FitterEngine* _owner_{nullptr};
 
 };
 
@@ -188,5 +197,4 @@ private:
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/Fitter/Minimizer/include/RootMinimizer.h
+++ b/src/Fitter/Minimizer/include/RootMinimizer.h
@@ -55,6 +55,14 @@ protected:
 
 private:
 
+  // Dump the Math::Minimizer table of parameter settings.  This is mostly
+  // useful for debugging.
+  void dumpFitParameterSettings();
+
+  // Dump the ROOT::Minuit2::MnUserParameterState.  This is mostly useful
+  // for debugging.
+  void dumpMinuit2State();
+
   // Parameters
   bool _preFitWithSimplex_{false};
   bool _restoreStepSizeBeforeHesse_{false};

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -15,13 +15,15 @@
 #include "Math/Factory.h"
 #include "Math/Minimizer.h"
 #include "Math/Functor.h"
+#include "Fit/ParameterSettings.h"
+#include "Minuit2/Minuit2Minimizer.h"
+#include "Minuit2/MnUserParameterState.h"
+#include "Minuit2/MinuitParameter.h"
 #include "TLegend.h"
-
 
 LoggerInit([]{
   Logger::setUserHeaderStr("[RootMinimizer]");
 });
-
 
 void RootMinimizer::readConfigImpl(){
   LogReturnIf(_config_.empty(), __METHOD_NAME__ << " config is empty." );
@@ -83,30 +85,82 @@ void RootMinimizer::initializeImpl(){
 
     if( not useNormalizedFitSpace() ){
       _rootMinimizer_->SetVariable(iFitPar, fitPar.getFullTitle(), fitPar.getParameterValue(), fitPar.getStepSize() * _stepSizeScaling_);
-      if( not std::isnan( fitPar.getMinValue() ) ){ _rootMinimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue()); }
-      if( not std::isnan( fitPar.getMaxValue() ) ){ _rootMinimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue()); }
-      // Changing the boundaries, change the value/step size?
-      _rootMinimizer_->SetVariableValue(iFitPar, fitPar.getParameterValue());
-      _rootMinimizer_->SetVariableStepSize(iFitPar, fitPar.getStepSize() * _stepSizeScaling_);
+      if (not std::isnan(fitPar.getMinValue())
+          and not std::isnan(fitPar.getMaxValue())) {
+        _rootMinimizer_->SetVariableLimits(iFitPar, fitPar.getMinValue(), fitPar.getMaxValue());
+      }
+      else if (not std::isnan(fitPar.getMinValue())) {
+        _rootMinimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue());
+      }
+      else if (not std::isnan(fitPar.getMaxValue()) ) {
+        _rootMinimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue());
+      }
     }
     else{
       _rootMinimizer_->SetVariable(iFitPar, fitPar.getFullTitle(),
                                    ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar),
                                    ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar)
       );
-      if( not std::isnan( fitPar.getMinValue() ) ){ _rootMinimizer_->SetVariableLowerLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar)); }
-      if( not std::isnan( fitPar.getMaxValue() ) ){ _rootMinimizer_->SetVariableUpperLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar)); }
-      // Changing the boundaries, change the value/step size?
-      _rootMinimizer_->SetVariableValue(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getParameterValue(), fitPar));
-      _rootMinimizer_->SetVariableStepSize(iFitPar, ParameterSet::toNormalizedParRange(fitPar.getStepSize() * _stepSizeScaling_, fitPar));
+      if (not std::isnan(fitPar.getMinValue())
+          and not std::isnan(fitPar.getMaxValue())) {
+        _rootMinimizer_->SetVariableLimits(
+          iFitPar,
+          ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar),
+          ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar));
+      }
+      else if (not std::isnan(fitPar.getMinValue())) {
+        _rootMinimizer_->SetVariableLowerLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMinValue(), fitPar));
+      }
+      else if (not std::isnan(fitPar.getMaxValue()) ) {
+        _rootMinimizer_->SetVariableUpperLimit(iFitPar, ParameterSet::toNormalizedParValue(fitPar.getMaxValue(), fitPar));
+      }
     }
   }
 
   LogWarning << "RootMinimizer initialized." << std::endl;
 }
 
-void RootMinimizer::minimize(){
+void RootMinimizer::dumpFitParameterSettings() {
+  for( std::size_t iFitPar = 0 ;
+       iFitPar < getMinimizerFitParameterPtr().size() ; ++iFitPar ) {
+    ROOT::Fit::ParameterSettings parSettings;
+    _rootMinimizer_->GetVariableSettings(iFitPar,parSettings);
+    LogDebug << "MINIMIZER #" << iFitPar;
+    LogDebug << " Fixed: " << parSettings.IsFixed();
+    if (parSettings.HasLowerLimit()) {
+      LogDebug << " Lower: " << parSettings.LowerLimit();
+    }
+    if (parSettings.HasUpperLimit()) {
+      LogDebug << " Upper: " << parSettings.UpperLimit();
+    }
+    LogDebug << " Name" << parSettings.Name();
+    LogDebug  << std::endl;
+  }
+}
 
+void RootMinimizer::dumpMinuit2State() {
+  ROOT::Minuit2::Minuit2Minimizer* mn2
+    = dynamic_cast<ROOT::Minuit2::Minuit2Minimizer*>(_rootMinimizer_.get());
+  if (not mn2) return;
+  const ROOT::Minuit2::MnUserParameterState& mn2State = mn2->State();
+  for( std::size_t iFitPar = 0 ;
+       iFitPar < getMinimizerFitParameterPtr().size() ; ++iFitPar ) {
+    const ROOT::Minuit2::MinuitParameter& par = mn2State.Parameter(iFitPar);
+    LogDebug << "MINUIT2 #" << iFitPar;
+    LogDebug << " Value: " << par.Value();
+    LogDebug << " Fixed: " << par.IsFixed();
+    if (par.HasLowerLimit()) {
+      LogDebug << " Lower: " << par.LowerLimit();
+    }
+    if (par.HasUpperLimit()) {
+      LogDebug << " Upper: " << par.UpperLimit();
+    }
+    LogDebug << " Name: " << par.GetName();
+    LogDebug  << std::endl;
+  }
+}
+
+void RootMinimizer::minimize(){
   // calling the common routine
   this->MinimizerBase::minimize();
 
@@ -129,6 +183,8 @@ void RootMinimizer::minimize(){
 
     // SIMPLEX
     getMonitor().isEnabled = true;
+    // dumpFitParameterSettings(); // Dump internal ROOT::Minimizer info
+    // dumpMinuit2State();         // Dump internal ROOT::Minuit2Minimizer info
     _fitHasConverged_ = _rootMinimizer_->Minimize();
     getMonitor().isEnabled = false;
 
@@ -156,6 +212,8 @@ void RootMinimizer::minimize(){
   getMonitor().stateTitleMonitor = "Running " + _rootMinimizer_->Options().MinimizerAlgorithm() + "...";
 
   getMonitor().isEnabled = true;
+  // dumpFitParameterSettings(); // Dump internal ROOT::Minimizer info
+  // dumpMinuit2State();         // Dump internal ROOT::Minuit2Minimizer info
   _fitHasConverged_ = _rootMinimizer_->Minimize();
   getMonitor().isEnabled = false;
 

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -28,7 +28,7 @@ void RootMinimizer::readConfigImpl(){
   this->MinimizerBase::readConfigImpl();
   LogWarning << "Configuring RootMinimizer..." << std::endl;
 
-  _monitor_.gradientDescentMonitor.isEnabled = GenericToolbox::Json::fetchValue( _config_, "monitorGradientDescent", _monitor_.gradientDescentMonitor.isEnabled );
+  getMonitor().gradientDescentMonitor.isEnabled = GenericToolbox::Json::fetchValue( _config_, "monitorGradientDescent", getMonitor().gradientDescentMonitor.isEnabled );
 
   _minimizerType_ = GenericToolbox::Json::fetchValue(_config_, "minimizer", _minimizerType_);
   _minimizerAlgo_ = GenericToolbox::Json::fetchValue(_config_, "algorithm", _minimizerAlgo_);
@@ -70,7 +70,7 @@ void RootMinimizer::initializeImpl(){
     LogWarning << "Using default minimizer algo: " << _minimizerAlgo_ << std::endl;
   }
 
-  _functor_ = ROOT::Math::Functor(this, &RootMinimizer::evalFit, _minimizerParameterPtrList_.size());
+  _functor_ = ROOT::Math::Functor(this, &RootMinimizer::evalFit, getMinimizerFitParameterPtr().size());
   _rootMinimizer_->SetFunction( _functor_ );
   _rootMinimizer_->SetStrategy(_strategy_);
   _rootMinimizer_->SetPrintLevel(_printLevel_);
@@ -78,10 +78,10 @@ void RootMinimizer::initializeImpl(){
   _rootMinimizer_->SetMaxIterations(_maxIterations_);
   _rootMinimizer_->SetMaxFunctionCalls(_maxFcnCalls_);
 
-  for( std::size_t iFitPar = 0 ; iFitPar < _minimizerParameterPtrList_.size() ; iFitPar++ ){
-    auto& fitPar = *(_minimizerParameterPtrList_[iFitPar]);
+  for( std::size_t iFitPar = 0 ; iFitPar < getMinimizerFitParameterPtr().size() ; iFitPar++ ){
+    auto& fitPar = *(getMinimizerFitParameterPtr()[iFitPar]);
 
-    if( not _useNormalizedFitSpace_ ){
+    if( not useNormalizedFitSpace() ){
       _rootMinimizer_->SetVariable(iFitPar, fitPar.getFullTitle(), fitPar.getParameterValue(), fitPar.getStepSize() * _stepSizeScaling_);
       if( not std::isnan( fitPar.getMinValue() ) ){ _rootMinimizer_->SetVariableLowerLimit(iFitPar, fitPar.getMinValue()); }
       if( not std::isnan( fitPar.getMaxValue() ) ){ _rootMinimizer_->SetVariableUpperLimit(iFitPar, fitPar.getMaxValue()); }
@@ -110,7 +110,7 @@ void RootMinimizer::minimize(){
   // calling the common routine
   this->MinimizerBase::minimize();
 
-  int nbFitCallOffset = _monitor_.nbEvalLikelihoodCalls;
+  int nbFitCallOffset = getMonitor().nbEvalLikelihoodCalls;
   LogInfo << "Fit call offset: " << nbFitCallOffset << std::endl;
 
   if( _preFitWithSimplex_ ){
@@ -124,13 +124,13 @@ void RootMinimizer::minimize(){
     _rootMinimizer_->SetTolerance(_tolerance_ * _simplexToleranceLoose_ );
     _rootMinimizer_->SetStrategy(0);
 
-    _monitor_.minimizerTitle = _minimizerType_ + "/" + "Simplex";
-    _monitor_.stateTitleMonitor = "Running Simplex...";
+    getMonitor().minimizerTitle = _minimizerType_ + "/" + "Simplex";
+    getMonitor().stateTitleMonitor = "Running Simplex...";
 
     // SIMPLEX
-    _monitor_.isEnabled = true;
+    getMonitor().isEnabled = true;
     _fitHasConverged_ = _rootMinimizer_->Minimize();
-    _monitor_.isEnabled = false;
+    getMonitor().isEnabled = false;
 
     // Make sure we are on the right spot
     updateCacheToBestfitPoint();
@@ -148,20 +148,20 @@ void RootMinimizer::minimize(){
     _rootMinimizer_->SetTolerance(_tolerance_);
     _rootMinimizer_->SetStrategy(_strategy_);
 
-    LogInfo << _monitor_.convergenceMonitor.generateMonitorString(); // lasting printout
-    LogWarning << "Simplex ended after " << _monitor_.nbEvalLikelihoodCalls - nbFitCallOffset << " calls." << std::endl;
+    LogInfo << getMonitor().convergenceMonitor.generateMonitorString(); // lasting printout
+    LogWarning << "Simplex ended after " << getMonitor().nbEvalLikelihoodCalls - nbFitCallOffset << " calls." << std::endl;
   }
 
-  _monitor_.minimizerTitle = _minimizerType_ + "/" + _minimizerAlgo_;
-  _monitor_.stateTitleMonitor = "Running " + _rootMinimizer_->Options().MinimizerAlgorithm() + "...";
+  getMonitor().minimizerTitle = _minimizerType_ + "/" + _minimizerAlgo_;
+  getMonitor().stateTitleMonitor = "Running " + _rootMinimizer_->Options().MinimizerAlgorithm() + "...";
 
-  _monitor_.isEnabled = true;
+  getMonitor().isEnabled = true;
   _fitHasConverged_ = _rootMinimizer_->Minimize();
-  _monitor_.isEnabled = false;
+  getMonitor().isEnabled = false;
 
-  int nbMinimizeCalls = _monitor_.nbEvalLikelihoodCalls - nbFitCallOffset;
+  int nbMinimizeCalls = getMonitor().nbEvalLikelihoodCalls - nbFitCallOffset;
 
-  LogInfo << _monitor_.convergenceMonitor.generateMonitorString(); // lasting printout
+  LogInfo << getMonitor().convergenceMonitor.generateMonitorString(); // lasting printout
   LogInfo << "Minimization ended after " << nbMinimizeCalls << " calls." << std::endl;
   if(_minimizerType_ == "Minuit" or _minimizerType_ == "Minuit2") LogWarning << "Status code: " << GundamUtils::minuitStatusCodeStr.at(_rootMinimizer_->Status()) << std::endl;
   else LogWarning << "Status code: " << _rootMinimizer_->Status() << std::endl;
@@ -178,12 +178,12 @@ void RootMinimizer::minimize(){
       TNamed("parameterStateAfterMinimize", GenericToolbox::Json::toReadableString( getPropagator().getParametersManager().exportParameterInjectorConfig() ).c_str() )
   );
 
-  if( _monitor_.historyTree != nullptr ){
+  if( getMonitor().historyTree != nullptr ){
     LogInfo << "Saving LLH history..." << std::endl;
-    GenericToolbox::writeInTFile(getOwner().getSaveDir(), _monitor_.historyTree.get());
+    GenericToolbox::writeInTFile(getOwner().getSaveDir(), getMonitor().historyTree.get());
   }
 
-  if( _monitor_.gradientDescentMonitor.isEnabled ){ saveGradientSteps(); }
+  if( getMonitor().gradientDescentMonitor.isEnabled ){ saveGradientSteps(); }
 
   if( _fitHasConverged_ ){ LogInfo << "Minimization has converged!" << std::endl; }
   else{ LogError << "Minimization did not converged." << std::endl; }
@@ -209,11 +209,11 @@ void RootMinimizer::minimize(){
   bestFitStats->Branch("chi2MinFitter", &chi2MinFitter);
   bestFitStats->Branch("toyIndex", &toyIndex);
   bestFitStats->Branch("nFitBins", &nbFitBins);
-  bestFitStats->Branch("nbFreeParameters", &_nbFreeParameters_);
+  bestFitStats->Branch("nbFreeParameters", getNbFreeParametersPtr());
   bestFitStats->Branch("nFitPars", &nFitPars);
   bestFitStats->Branch("nbDegreeOfFreedom", &nDof);
 
-  bestFitStats->Branch("nCallsAtBestFit", &_monitor_.nbEvalLikelihoodCalls);
+  bestFitStats->Branch("nCallsAtBestFit", &getMonitor().nbEvalLikelihoodCalls);
   bestFitStats->Branch("totalLikelihoodAtBestFit", &getLikelihoodInterface().getBuffer().totalLikelihood );
   bestFitStats->Branch("statLikelihoodAtBestFit",  &getLikelihoodInterface().getBuffer().statLikelihood );
   bestFitStats->Branch("penaltyLikelihoodAtBestFit",  &getLikelihoodInterface().getBuffer().penaltyLikelihood );
@@ -273,8 +273,8 @@ void RootMinimizer::minimize(){
   this->writePostFitData(GenericToolbox::mkdirTFile(getOwner().getSaveDir(), GenericToolbox::joinPath("postFit", _minimizerAlgo_)));
   GenericToolbox::triggerTFileWrite(GenericToolbox::mkdirTFile(getOwner().getSaveDir(), GenericToolbox::joinPath("postFit", _minimizerAlgo_)));
 
-  if( _fitHasConverged_ ){ _minimizerStatus_ = 0; }
-  else{ _minimizerStatus_ = _rootMinimizer_->Status(); }
+  if( _fitHasConverged_ ){ setMinimizerStatus(0); }
+  else{ setMinimizerStatus(_rootMinimizer_->Status()); }
 }
 void RootMinimizer::calcErrors(){
 
@@ -282,7 +282,7 @@ void RootMinimizer::calcErrors(){
 
   LogWarning << std::endl << GenericToolbox::addUpDownBars("Calling calcErrors()...") << std::endl;
 
-  int nbFitCallOffset = _monitor_.nbEvalLikelihoodCalls;
+  int nbFitCallOffset = getMonitor().nbEvalLikelihoodCalls;
   LogInfo << "Fit call offset: " << nbFitCallOffset << std::endl;
 
   if     ( _errorAlgo_ == "Minos" ){
@@ -294,9 +294,9 @@ void RootMinimizer::calcErrors(){
     for( int iFitPar = 0 ; iFitPar < _rootMinimizer_->NDim() ; iFitPar++ ){
       LogInfo << "Evaluating: " << _rootMinimizer_->VariableName(iFitPar) << "..." << std::endl;
 
-      _monitor_.isEnabled = true;
+      getMonitor().isEnabled = true;
       bool isOk = _rootMinimizer_->GetMinosError(iFitPar, errLow, errHigh);
-      _monitor_.isEnabled = false;
+      getMonitor().isEnabled = false;
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,23,02)
       LogWarning << GundamUtils::minosStatusCodeStr.at(_rootMinimizer_->MinosStatus()) << std::endl;
@@ -312,7 +312,7 @@ void RootMinimizer::calcErrors(){
 
     // Put back at minimum
     for( int iFitPar = 0 ; iFitPar < _rootMinimizer_->NDim() ; iFitPar++ ){
-      _minimizerParameterPtrList_[iFitPar]->setParameterValue(_rootMinimizer_->X()[iFitPar]);
+      getMinimizerFitParameterPtr()[iFitPar]->setParameterValue(_rootMinimizer_->X()[iFitPar]);
     }
   } // Minos
   else if( _errorAlgo_ == "Hesse" ){
@@ -320,8 +320,8 @@ void RootMinimizer::calcErrors(){
     if( _restoreStepSizeBeforeHesse_ ){
       LogWarning << "Restoring step size before HESSE..." << std::endl;
       for( int iFitPar = 0 ; iFitPar < _rootMinimizer_->NDim() ; iFitPar++ ){
-        auto& par = *_minimizerParameterPtrList_[iFitPar];
-        if(not _useNormalizedFitSpace_){ _rootMinimizer_->SetVariableStepSize(iFitPar, par.getStepSize() * _stepSizeScaling_); }
+        auto& par = *getMinimizerFitParameterPtr()[iFitPar];
+        if(not useNormalizedFitSpace()){ _rootMinimizer_->SetVariableStepSize(iFitPar, par.getStepSize() * _stepSizeScaling_); }
         else{ _rootMinimizer_->SetVariableStepSize(iFitPar, ParameterSet::toNormalizedParRange(par.getStepSize() * _stepSizeScaling_, par)); } // should be 1
       }
     }
@@ -329,14 +329,14 @@ void RootMinimizer::calcErrors(){
     // Make sure we are on the right spot
     updateCacheToBestfitPoint();
 
-    _monitor_.minimizerTitle = _minimizerType_ + "/" + _errorAlgo_;
-    _monitor_.stateTitleMonitor = "Running HESSE...";
+    getMonitor().minimizerTitle = _minimizerType_ + "/" + _errorAlgo_;
+    getMonitor().stateTitleMonitor = "Running HESSE...";
 
-    _monitor_.isEnabled = true;
+    getMonitor().isEnabled = true;
     _fitHasConverged_ = _rootMinimizer_->Hesse();
-    _monitor_.isEnabled = false;
+    getMonitor().isEnabled = false;
 
-    LogInfo << "Hesse ended after " << _monitor_.nbEvalLikelihoodCalls - nbFitCallOffset << " calls." << std::endl;
+    LogInfo << "Hesse ended after " << getMonitor().nbEvalLikelihoodCalls - nbFitCallOffset << " calls." << std::endl;
     LogWarning << "HESSE status code: " << GundamUtils::hesseStatusCodeStr.at(_rootMinimizer_->Status()) << std::endl;
     LogWarning << "Covariance matrix status code: " << GundamUtils::covMatrixStatusCodeStr.at(_rootMinimizer_->CovMatrixStatus()) << std::endl;
 
@@ -345,11 +345,11 @@ void RootMinimizer::calcErrors(){
 
     if(not _fitHasConverged_){
       LogError  << "Hesse did not converge." << std::endl;
-      LogError << _monitor_.convergenceMonitor.generateMonitorString(); // lasting printout
+      LogError << getMonitor().convergenceMonitor.generateMonitorString(); // lasting printout
     }
     else{
       LogInfo << "Hesse converged." << std::endl;
-      LogInfo << _monitor_.convergenceMonitor.generateMonitorString(); // lasting printout
+      LogInfo << getMonitor().convergenceMonitor.generateMonitorString(); // lasting printout
     }
 
     int covStatus = _rootMinimizer_->CovMatrixStatus();
@@ -379,7 +379,7 @@ void RootMinimizer::scanParameters( TDirectory* saveDir_ ){
                  << " is fixed. Skipping..." << std::endl;
       continue;
     }
-    getOwner().getParameterScanner().scanParameter(*_minimizerParameterPtrList_[iPar], saveDir_);
+    getOwner().getParameterScanner().scanParameter(*getMinimizerFitParameterPtr()[iPar], saveDir_);
   } // iPar
   for( auto& parSet : this->getPropagator().getParametersManager().getParameterSetsList() ){
     if( not parSet.isEnabled() ) continue;
@@ -418,7 +418,7 @@ void RootMinimizer::saveMinimizerSettings( TDirectory* saveDir_) const {
   GenericToolbox::writeInTFile( saveDir_, TNamed("maxFcnCalls", std::to_string(_maxFcnCalls_).c_str()) );
   GenericToolbox::writeInTFile( saveDir_, TNamed("tolerance", std::to_string(_tolerance_).c_str()) );
   GenericToolbox::writeInTFile( saveDir_, TNamed("stepSizeScaling", std::to_string(_stepSizeScaling_).c_str()) );
-  GenericToolbox::writeInTFile( saveDir_, TNamed("useNormalizedFitSpace", std::to_string(_useNormalizedFitSpace_).c_str()) );
+  GenericToolbox::writeInTFile( saveDir_, TNamed("useNormalizedFitSpace", std::to_string(useNormalizedFitSpace()).c_str()) );
 
   if( _preFitWithSimplex_ ){
     GenericToolbox::writeInTFile( saveDir_, TNamed("enableSimplexBeforeMinimize", std::to_string(_preFitWithSimplex_).c_str()) );
@@ -701,7 +701,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
 
         auto* iParList = &iParSet.getEffectiveParameterList();
         for( auto& iPar : *iParList ){
-          int iMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &iPar, _minimizerParameterPtrList_);
+          int iMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &iPar, getMinimizerFitParameterPtr());
 
           int jOffset{0};
           for( const auto& jParSet : getPropagator().getParametersManager().getParameterSetsList() ){
@@ -710,7 +710,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
             auto* jParList = &jParSet.getEffectiveParameterList();
             for( auto& jPar : *jParList ){
               int jMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &jPar,
-                                                                     _minimizerParameterPtrList_);
+                                                                     getMinimizerFitParameterPtr());
 
               if( iMinimizerIndex != -1 and jMinimizerIndex != -1 ){
                 // Use the fit-constrained value
@@ -773,7 +773,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
 
   };
 
-  if( _useNormalizedFitSpace_ ){
+  if( useNormalizedFitSpace() ){
     LogInfo << "Writing normalized decomposition of the output matrix..." << std::endl;
     if( not GundamGlobals::isLightOutputMode() ) {
       decomposeCovarianceMatrixFct(GenericToolbox::mkdirTFile(matricesDir, "normalizedFitSpace"));
@@ -782,7 +782,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
     // Rescale the post-fit values:
     for(int iRow = 0 ; iRow < postfitCovarianceMatrix.GetNrows() ; iRow++ ){
       for(int iCol = 0 ; iCol < postfitCovarianceMatrix.GetNcols() ; iCol++ ){
-        postfitCovarianceMatrix[iRow][iCol] *= (_minimizerParameterPtrList_[iRow]->getStdDevValue()) * (_minimizerParameterPtrList_[iCol]->getStdDevValue());
+        postfitCovarianceMatrix[iRow][iCol] *= (getMinimizerFitParameterPtr()[iRow]->getStdDevValue()) * (getMinimizerFitParameterPtr()[iCol]->getStdDevValue());
       }
     }
 
@@ -1100,10 +1100,10 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
     // dimension should be the right one -> parList includes the fixed one
     auto covMatrix = std::make_unique<TMatrixD>(int(parList->size()), int(parList->size()));
     for( auto& iPar : *parList ){
-      int iMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &iPar, _minimizerParameterPtrList_);
+      int iMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &iPar, getMinimizerFitParameterPtr());
       if( iMinimizerIndex == -1 ) continue;
       for( auto& jPar : *parList ){
-        int jMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &jPar, _minimizerParameterPtrList_);
+        int jMinimizerIndex = GenericToolbox::findElementIndex((Parameter*) &jPar, getMinimizerFitParameterPtr());
         if( jMinimizerIndex == -1 ) continue;
         (*covMatrix)[iPar.getParameterIndex()][jPar.getParameterIndex()] = postfitCovarianceMatrix[iMinimizerIndex][jMinimizerIndex];
       }
@@ -1161,7 +1161,7 @@ void RootMinimizer::saveGradientSteps(){
     return;
   }
 
-  LogInfo << "Saving " << _monitor_.gradientDescentMonitor.stepPointList.size() << " gradient steps..." << std::endl;
+  LogInfo << "Saving " << getMonitor().gradientDescentMonitor.stepPointList.size() << " gradient steps..." << std::endl;
 
   // make sure the parameter states get restored as we leave
   auto currentParState = getPropagator().getParametersManager().exportParameterInjectorConfig();
@@ -1183,24 +1183,24 @@ void RootMinimizer::saveGradientSteps(){
   auto lastParStep{getOwner().getPreFitParState()};
 
   std::vector<ParameterScanner::GraphEntry> globalGraphList;
-  for(size_t iGradStep = 0 ; iGradStep < _monitor_.gradientDescentMonitor.stepPointList.size() ; iGradStep++ ){
-    GenericToolbox::displayProgressBar(iGradStep, _monitor_.gradientDescentMonitor.stepPointList.size(), LogInfo.getPrefixString() + "Saving gradient steps...");
+  for(size_t iGradStep = 0 ; iGradStep < getMonitor().gradientDescentMonitor.stepPointList.size() ; iGradStep++ ){
+    GenericToolbox::displayProgressBar(iGradStep, getMonitor().gradientDescentMonitor.stepPointList.size(), LogInfo.getPrefixString() + "Saving gradient steps...");
 
     // why do we need to remute the logger at each loop??
     ParameterSet::muteLogger(); Propagator::muteLogger(); ParametersManager::muteLogger();
-    getPropagator().getParametersManager().injectParameterValues(_monitor_.gradientDescentMonitor.stepPointList[iGradStep].parState );
+    getPropagator().getParametersManager().injectParameterValues(getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState );
 
     getLikelihoodInterface().propagateAndEvalLikelihood();
 
     if( not GundamGlobals::isLightOutputMode() ) {
       auto outDir = GenericToolbox::mkdirTFile(getOwner().getSaveDir(), Form("fit/gradient/step_%i", int(iGradStep)));
-      GenericToolbox::writeInTFile(outDir, TNamed("parState", GenericToolbox::Json::toReadableString(_monitor_.gradientDescentMonitor.stepPointList[iGradStep].parState).c_str()));
+      GenericToolbox::writeInTFile(outDir, TNamed("parState", GenericToolbox::Json::toReadableString(getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState).c_str()));
       GenericToolbox::writeInTFile(outDir, TNamed("llhState", getLikelihoodInterface().getSummary().c_str()));
     }
 
     // line scan from previous point
-    getParameterScanner().scanSegment( nullptr, _monitor_.gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, 8 );
-    lastParStep = _monitor_.gradientDescentMonitor.stepPointList[iGradStep].parState;
+    getParameterScanner().scanSegment( nullptr, getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, 8 );
+    lastParStep = getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState;
 
     if( globalGraphList.empty() ){
       // copy
@@ -1251,5 +1251,4 @@ void RootMinimizer::saveGradientSteps(){
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -24,7 +24,16 @@ protected:
 public:
   // setters
   void setParameterSetListConfig(const JsonType& parameterSetListConfig_){ _parameterSetListConfig_ = parameterSetListConfig_; }
+  // Deprecated because out of bounds parameters are illegal and will result
+  // in a crash.  An out of bounds parameter is always rethrown and this value
+  // is ignored.
   [[deprecated("Must always be true")]] void setReThrowParSetIfOutOfBounds(bool reThrowParSetIfOutOfBounds_){ _reThrowParSetIfOutOfBounds_ = reThrowParSetIfOutOfBounds_; }
+  // If set to true, parameters that are outside of the physical bounds will
+  // be rethrown.  The physical bounds are always contained in the overall
+  // parameter bounds, and the throw value will always be inside of the
+  // overall parameter bounds (the overall bounds are the "domain" of the
+  // parameter).  See the Parameter::setMinValue() and
+  // Parameter::setMinPhysical for more details.
   void setReThrowParSetIfOutOfPhysical(bool reThrowParSetIfOutOfPhysical_){ _reThrowParSetIfOutOfPhysical_ = reThrowParSetIfOutOfPhysical_; }
   void setThrowToyParametersWithGlobalCov(bool throwToyParametersWithGlobalCov_){ _throwToyParametersWithGlobalCov_ = throwToyParametersWithGlobalCov_; }
   void setGlobalCovarianceMatrix(const std::shared_ptr<TMatrixD> &globalCovarianceMatrix){ _globalCovarianceMatrix_ = globalCovarianceMatrix; }

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -24,7 +24,8 @@ protected:
 public:
   // setters
   void setParameterSetListConfig(const JsonType& parameterSetListConfig_){ _parameterSetListConfig_ = parameterSetListConfig_; }
-  void setReThrowParSetIfOutOfBounds(bool reThrowParSetIfOutOfBounds_){ _reThrowParSetIfOutOfBounds_ = reThrowParSetIfOutOfBounds_; }
+  [[deprecated("Must always be true")]] void setReThrowParSetIfOutOfBounds(bool reThrowParSetIfOutOfBounds_){ _reThrowParSetIfOutOfBounds_ = reThrowParSetIfOutOfBounds_; }
+  void setReThrowParSetIfOutOfPhysical(bool reThrowParSetIfOutOfPhysical_){ _reThrowParSetIfOutOfPhysical_ = reThrowParSetIfOutOfPhysical_; }
   void setThrowToyParametersWithGlobalCov(bool throwToyParametersWithGlobalCov_){ _throwToyParametersWithGlobalCov_ = throwToyParametersWithGlobalCov_; }
   void setGlobalCovarianceMatrix(const std::shared_ptr<TMatrixD> &globalCovarianceMatrix){ _globalCovarianceMatrix_ = globalCovarianceMatrix; }
 
@@ -56,7 +57,8 @@ public:
 
 private:
   // config
-  bool _reThrowParSetIfOutOfBounds_{true};
+  bool _reThrowParSetIfOutOfBounds_{true};  // NO LONGER USE. ALWAYS TRUE.
+  bool _reThrowParSetIfOutOfPhysical_{true};
   bool _throwToyParametersWithGlobalCov_{false};
   JsonType _parameterSetListConfig_{};
 
@@ -69,6 +71,4 @@ private:
   std::shared_ptr<TMatrixD> _choleskyMatrix_{nullptr};
 
 };
-
-
 #endif //GUNDAM_PARAMETERS_MANAGER_H

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -24,6 +24,7 @@ set(HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/include/ConfigUtils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamUtils.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamApp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/GundamBacktrace.h
     )
 
 
@@ -71,4 +72,3 @@ install( TARGETS GundamUtils DESTINATION lib )
 #        COMPONENT
 #        libraries
 #)
-

--- a/src/Utils/include/GundamBacktrace.h
+++ b/src/Utils/include/GundamBacktrace.h
@@ -1,0 +1,53 @@
+#ifndef GUNDAM_Backtrace_h_seen
+#define GUNDAM_Backtrace_h_seen
+
+#include <ostream>
+
+// Backtrace depends on execinfo.h being available.  This is only available on
+// linux.
+//
+// Note: Rumor has it that this can be tested using CMake (FindBacktrace), but
+// that has not been well tested (remove this comment if it gets implemented)!
+//
+// Note: Rumor has it that Macs have it after Mac OS X 10.5, but I can't test
+// that so for now it's not included.
+//
+// Note: This is a candidate for the generic tool kit, or simple cpp logger.
+#if defined(__linux__)
+#include <execinfo.h>
+#include <cstdlib>
+#else
+#warning Backtrace is not available
+#endif
+
+namespace GundamUtils {
+    // When possible, print a backtrace for the current call stack to the
+    // standard output stream.
+    template<class CharT, class Traits>
+    std::basic_ostream<CharT,Traits>&
+    Backtrace(std::basic_ostream<CharT, Traits>& out) {
+#if defined(__linux__)
+        void *buffer[100];
+        int nptrs = backtrace(buffer,100);
+        out << "Backtrace of " << nptrs << " calls" << std::endl;
+
+        // This uses malloc to allocate memory for strings, and passes
+        // ownership to the caller.
+        char **strings = backtrace_symbols(buffer,nptrs);
+        if (strings == nullptr) {
+            out << "Error generating backtrace" << std::endl;
+            return out;
+        }
+
+        for (int i=0; i< nptrs; ++i) out << strings[i] << std::endl;
+
+        // Free the strings pointer that was allocated with malloc.
+        std::free(strings);
+#else
+        out << "Backtrace not available" << std::endl;
+#endif
+        return out;
+    }
+};
+
+#endif


### PR DESCRIPTION
This is applying a collection of fixes from the LTS/1.8.x branch that address parameter values being outside of the parameter domain (i.e. outside of the limits).  The most important change is that the way the limits are handed to MINUIT has been fixed.  This closes #581. 