### PR TITLE
Lts/issue582/safe param limit checking

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,8 +1,10 @@
 Fixes relative to 1.8.4
 
+Issue #582: Safely check parameter limits during fits.  The old method for checking parameter validity during fits depended on first setting an invalid value, and then checking the validity.  Queries are added to check validity before setting.  This also adds checks for the GPU that the likelihood has not been changed since initialization.  If there is a change, a log message is generated, and the calculation falls back to the CPU.  This should only happen during debugging.
+
 Issue #578: Apply cleanups to make sure that eigendecoposition and parameter throwing honor the parameter boundaries.  
 
-Fixes: Guarrantee that all parameter value access is through the setter and getter so that the validity checks are correctly applied.
+Fixes: Guarantee that all parameter value access is through the setter and getter so that the validity checks are correctly applied.
 
 Fixes relative to 1.8.3
 

--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -45,6 +45,9 @@ private:
     // is a global event weight clamp.
     double fUpperClamp;
 
+    // Flag that the sum has been applied.
+    bool fSumsApplied;
+
     // Cache of whether the result values in memory are valid.
     bool fSumsValid;
 
@@ -58,6 +61,9 @@ public:
     /// Deconstruct the class.  This should deallocate all the memory
     /// everyplace.
     virtual ~IndexedSums();
+
+    /// Invalidate the sum in the CPU memory.
+    void Invalidate() {fSumsApplied = false; fSumsValid = false;}
 
     /// Reinitialize the cache.  This puts it into a state to be refilled, but
     /// does not deallocate any memory.
@@ -131,6 +137,5 @@ public:
 // Local Variables:
 // mode:c++
 // c-basic-offset:4
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:
 #endif

--- a/src/CacheManager/include/CacheRecursiveSums.h
+++ b/src/CacheManager/include/CacheRecursiveSums.h
@@ -71,6 +71,9 @@ private:
     // is a global event weight clamp.
     double fUpperClamp;
 
+    // Flag that the sum has been applied.
+    bool fSumsApplied;
+
     // Cache of whether the result values in memory are valid.
     bool fSumsValid;
 
@@ -84,6 +87,9 @@ public:
     /// Deconstruct the class.  This should deallocate all the memory
     /// everyplace.
     virtual ~RecursiveSums();
+
+    /// Invalidate the sum in the CPU memory.
+    void Invalidate() {fSumsApplied = false; fSumsValid = false;}
 
     /// Reinitialize the cache.  This puts it into a state to be refilled, but
     /// does not deallocate any memory.
@@ -159,6 +165,5 @@ public:
 // Local Variables:
 // mode:c++
 // c-basic-offset:4
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:
 #endif

--- a/src/CacheManager/include/CacheWeights.h
+++ b/src/CacheManager/include/CacheWeights.h
@@ -37,6 +37,9 @@ private:
     // Cache of whether the result values in memory are valid.
     bool fResultsValid;
 
+    /// Flag that the kernels have been started.
+    bool fKernelApplied;
+
     /// An array of the initial value for each result.  It's copied from the
     /// CPU to the GPU once at the beginning.
     std::unique_ptr<hemi::Array<double>> fInitialValues;
@@ -90,6 +93,12 @@ public:
         fWeightCalculator.at(index) = v;
         return index;
     }
+
+    /// Mark that the results on the CPU are no longer valid. This
+    /// is used by the Cache::Manager::Fill method to note that the input
+    /// parameters have changed.  The results will become valid after the
+    /// kernel finishes (asynchronously).
+    virtual void Invalidate() {fKernelApplied = false; fResultsValid = false;}
 
     /// Calculate the results and save them for later use.  This copies the
     /// results from the GPU to the CPU.

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -661,7 +661,25 @@ bool Cache::Manager::Fill() {
         }
     } while(false);
 #endif
+    cache->GetWeightsCache().Invalidate();
+    cache->GetHistogramsCache().Invalidate();
     for (auto& par : Cache::Manager::ParameterMap ) {
+        if (par.first->getOwner()->isMaskedForPropagation()) {
+            LogWarning << "WARNING: Masked parameter: "
+                       << par.first->getFullTitle()
+                       << std::endl;
+            LogWarning << "WARNING: Cache::Manager will not be used"
+                       << std::endl;
+            return false;
+        }
+        if (not par.first->isEnabled()) {
+            LogWarning << "WARNING: Disabled parameter: "
+                       << par.first->getFullTitle()
+                       << std::endl;
+            LogWarning << "WARNING: Cache::Manager will not be used"
+                       << std::endl;
+            return false;
+        }
         cache->GetParameterCache().SetParameter(
             par.second, par.first->getParameterValue());
     }
@@ -708,5 +726,4 @@ int Cache::Manager::ParameterIndex(const Parameter* fp) {
 // Local Variables:
 // mode:c++
 // c-basic-offset:4
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/CacheManager/src/CacheRecursiveSums.cpp
+++ b/src/CacheManager/src/CacheRecursiveSums.cpp
@@ -341,6 +341,8 @@ bool Cache::RecursiveSums::Apply() {
                  fBinOffsets->readOnlyPtr(),
                  fSums2->size());
 
+    fSumsApplied = true;
+
     return true;
 }
 

--- a/src/CacheManager/src/CacheRecursiveSums.cpp
+++ b/src/CacheManager/src/CacheRecursiveSums.cpp
@@ -87,7 +87,7 @@ Cache::RecursiveSums::~RecursiveSums() = default;
 void Cache::RecursiveSums::Reset() {
     // Very little to do here since the indexed sum cache is zeroed with it is
     // filled.  Mark it as invalid out of an abundance of caution!
-    fSumsValid = false;
+    Invalidate();
 }
 
 /// Build the internal tables after all the events are filled.  This can be
@@ -170,7 +170,8 @@ double Cache::RecursiveSums::GetSum(int i) {
     // finishes before the sum is set to be valid.  The use of isnan is to
     // make sure that the optimizer doesn't reorder the statements.
     double value = fSums->hostPtr()[i];
-    if (not std::isnan(value)) fSumsValid = true;
+    if (not fSumsApplied) fSumsValid = false;
+    else if (not std::isnan(value)) fSumsValid = true;
     else LogThrow("Cache::RecursiveSums sum is nan");
     return value;
 }
@@ -182,7 +183,8 @@ double Cache::RecursiveSums::GetSum2(int i) {
     // finishes before the sum is set to be valid.  The use of isfinite is to
     // make sure that the optimizer doesn't reorder the statements.
     double value = fSums2->hostPtr()[i];
-    if (not std::isnan(value)) fSumsValid = true;
+    if (not fSumsApplied) fSumsValid = false;
+    else if (not std::isnan(value)) fSumsValid = true;
     else LogThrow("Cache::RecursiveSums sum2 is nan");
     return value;
 }
@@ -274,7 +276,7 @@ namespace {
 
 bool Cache::RecursiveSums::Apply() {
     // Mark the results has having changed.
-    fSumsValid = false;
+    Invalidate();
 
     ///////////////////////////////////////////////////
     // Calculate the sum
@@ -367,5 +369,4 @@ bool Cache::RecursiveSums::Apply() {
 // Local Variables:
 // mode:c++
 // c-basic-offset:4
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -185,7 +185,6 @@ void LikelihoodInterface::saveGradientSteps(){
 
 double LikelihoodInterface::evalFit(const double* parArray_){
   LogThrowIf(not _isInitialized_, "not initialized");
-  GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds(__METHOD_NAME__);
 
   if(_nbFitCalls_ != 0){
     _outEvalFitAvgTimer_.counts++ ; _outEvalFitAvgTimer_.cumulated += GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds("out_evalFit");
@@ -193,11 +192,13 @@ double LikelihoodInterface::evalFit(const double* parArray_){
   ++_nbFitCalls_;
 
   // Update fit parameter values:
-  int iFitPar{0};
+  const double *v = parArray_;
   for( auto* par : _minimizerFitParameterPtr_ ){
-    if( getUseNormalizedFitSpace() ) par->setParameterValue(ParameterSet::toRealParValue(parArray_[iFitPar++], *par));
-    else par->setParameterValue(parArray_[iFitPar++]);
+    if (not getUseNormalizedFitSpace()) par->setParameterValue(*(v++));
+    else par->setParameterValue(ParameterSet::toRealParValue(*(v++), *par));
   }
+
+  GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds(__METHOD_NAME__);
 
   // Compute the Chi2
   _owner_->getPropagator().updateLlhCache();
@@ -341,14 +342,12 @@ double LikelihoodInterface::evalFit(const double* parArray_){
 }
 
 double LikelihoodInterface::evalFitValid(const double* parArray_) {
-  double value = evalFit(parArray_);
-  if (hasValidParameterValues()) return value;
-  /// A "Really Big Number".  This is nominally just infinity, but is done as
-  /// a defined constant to make the code easier to understand.  This needs to
-  /// be an appropriate value to safely represent an impossible chi-squared
-  /// value "representing" -log(0.0)/2 and should should be larger than 5E+30.
-  const double RBN = std::numeric_limits<double>::infinity();
-  return RBN;
+  // Check fit parameter values:
+  const double *v = parArray_;
+  for( auto* par : _minimizerFitParameterPtr_ ){
+    if (not par->isValidValue(*(v++))) return std::numeric_limits<double>::infinity();
+  }
+  return evalFit(parArray_);
 }
 
 double LikelihoodInterface::getLastLikelihood() const {
@@ -396,5 +395,4 @@ bool LikelihoodInterface::hasValidParameterValues() const {
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -126,6 +126,9 @@ public:
   /// is not between the minimum and maximum mirror values.
   [[nodiscard]] bool isMirrored(double value) const;
 
+  /// Query if a value matchs the validity requirements.
+  [[nodiscard]] bool isValidValue(double value) const;
+
   [[nodiscard]] bool isFree() const{ return _isFree_; }
   [[nodiscard]] bool isFixed() const{ return _isFixed_; }
   [[nodiscard]] bool isEigen() const{ return _isEigen_; }
@@ -175,6 +178,22 @@ public:
   [[nodiscard]] std::string getTitle() const;
   [[nodiscard]] std::string getFullTitle() const;
 
+  /// Define the type of validity that needs to be required by
+  /// hasValidParameterValues.  This accepts a string with the possible values
+  /// being:
+  ///
+  ///  "range" (default) -- Between the parameter minimum and maximum values.
+  ///  "norange"         -- Do not require parameters in the valid range
+  ///  "mirror"          -- Between the mirrored values (if parameter has
+  ///                       mirroring).
+  ///  "nomirror"        -- Do not require parameters in the mirrored range
+  ///  "physical"        -- Only physically meaningful values.
+  ///  "nophysical"      -- Do not require parameters in the physical range.
+  ///
+  /// Example: setParameterValidity("range,mirror,physical")
+  void setValidity(const std::string& validity);
+  void setValidity(int validity) {_validFlags_ = validity;}
+
 private:
   // Parameters
   bool _isEnabled_{true};
@@ -202,6 +221,13 @@ private:
   // Internals
   const ParameterSet* _owner_{nullptr};
   PriorType::PriorType _priorType_{PriorType::Gaussian};
+
+  /// A set of flags used to define if the parameter set has valid parameter
+  /// values.
+  /// "1" -- require valid parameters (Parameter::isInDomain will be true)
+  /// "2" -- require in the mirrored range (is inside mirrored range).
+  /// "4" -- require in the physical range (Parameter::isPhysical will be true)
+  int _validFlags_{1};
 
 };
 #endif //GUNDAM_PARAMETER_H

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -39,6 +39,7 @@ public:
   Parameter() = delete; // should always provide the owner
   explicit Parameter(const ParameterSet* owner_): _owner_(owner_) {}
 
+  //
   void setIsEnabled(bool isEnabled){ _isEnabled_ = isEnabled; }
   void setIsFixed(bool isFixed){ _isFixed_ = isFixed; }
   void setIsEigen(bool isEigen){ _isEigen_ = isEigen; }
@@ -107,7 +108,24 @@ public:
   void setOwner(const ParameterSet *owner_){ _owner_ = owner_; }
   void setPriorType(PriorType::PriorType priorType){ _priorType_ = priorType; }
 
-  // Getters
+  /// Query if a value is in the domain of likelihood for this parameter.  Math
+  /// remediation for those of us (including myself) who don't recall grammar
+  /// school math: The DOMAIN of a function is the range over which it is
+  /// defined.  For instance, the domain of the information transfer speed
+  /// (dX/dT) is greater than or equal to zero.  To be in the domain, a value
+  /// must not be NaN, and be between minValue and maxValue (if they are
+  /// defined).
+  [[nodiscard]] bool isInDomain(double value, bool verbose=false) const;
+
+  /// Query if a value is in the range where the parameter will have a
+  /// physically meaningful value.  For example, within special relativity, the
+  /// information transfer speed is between zero and the speed of light.
+  [[nodiscard]] bool isPhysical(double value) const;
+
+  /// Query if a value will be mirrored.  This is true if the parameter value
+  /// is not between the minimum and maximum mirror values.
+  [[nodiscard]] bool isMirrored(double value) const;
+
   [[nodiscard]] bool isFree() const{ return _isFree_; }
   [[nodiscard]] bool isFixed() const{ return _isFixed_; }
   [[nodiscard]] bool isEigen() const{ return _isEigen_; }
@@ -186,6 +204,4 @@ private:
   PriorType::PriorType _priorType_{PriorType::Gaussian};
 
 };
-
-
 #endif //GUNDAM_PARAMETER_H

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -64,7 +64,7 @@ public:
   ///
   /// Example: setParameterValidity("range,mirror,physical")
   void setValidity(const std::string& validity);
-  void setValidity(int validity) {_validFlags_ = validity;}
+  void setValidity(int validity);
 
   // Getters
   [[nodiscard]] bool isEnabled() const{ return _isEnabled_; }
@@ -84,10 +84,13 @@ public:
   [[nodiscard]] const std::vector<nlohmann::json>& getCustomFitParThrow() const{ return _customFitParThrow_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCorrelationMatrix() const{ return _priorCorrelationMatrix_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
-  [[nodiscard]] int getValidity() const {return _validFlags_;}
 
   /// True if all of the enabled parameters have valid values.
   [[nodiscard]] bool isValid() const;
+
+  /// Convenience method to check if a value will be valid for a particular
+  /// parameter.
+  [[nodiscard]] bool isValidParameterValue(const Parameter& p, double v) const;
 
   /// Get the vector of parameters for this parameter set in the real
   /// parameter space.  These parameters are not eigendecomposed.  WARNING:
@@ -154,13 +157,6 @@ protected:
 private:
   // Internals
   std::vector<Parameter> _parameterList_;
-
-  /// A set of flags used to define if the parameter set has valid parameter
-  /// values.
-  /// "1" -- require valid parameters (Parameter::isInDomain will be true)
-  /// "2" -- require in the mirrored range (is inside mirrored range).
-  /// "4" -- require in the physical range (Parameter::isPhysical will be true)
-  int _validFlags_{1};
 
   // JSON
   std::string _name_{};

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -50,6 +50,22 @@ public:
   // Setters
   void setMaskedForPropagation(bool maskedForPropagation_){ _maskedForPropagation_ = maskedForPropagation_; }
 
+  /// Define the type of validity that needs to be required by
+  /// hasValidParameterValues.  This accepts a string with the possible values
+  /// being:
+  ///
+  ///  "range" (default) -- Between the parameter minimum and maximum values.
+  ///  "norange"         -- Do not require parameters in the valid range
+  ///  "mirror"          -- Between the mirrored values (if parameter has
+  ///                       mirroring).
+  ///  "nomirror"        -- Do not require parameters in the mirrored range
+  ///  "physical"        -- Only physically meaningful values.
+  ///  "nophysical"      -- Do not require parameters in the physical range.
+  ///
+  /// Example: setParameterValidity("range,mirror,physical")
+  void setValidity(const std::string& validity);
+  void setValidity(int validity) {_validFlags_ = validity;}
+
   // Getters
   [[nodiscard]] bool isEnabled() const{ return _isEnabled_; }
   [[nodiscard]] bool isEnablePca() const{ return _enablePca_; }
@@ -68,6 +84,10 @@ public:
   [[nodiscard]] const std::vector<nlohmann::json>& getCustomFitParThrow() const{ return _customFitParThrow_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCorrelationMatrix() const{ return _priorCorrelationMatrix_; }
   [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+  [[nodiscard]] int getValidity() const {return _validFlags_;}
+
+  /// True if all of the enabled parameters have valid values.
+  [[nodiscard]] bool isValid() const;
 
   /// Get the vector of parameters for this parameter set in the real
   /// parameter space.  These parameters are not eigendecomposed.  WARNING:
@@ -134,6 +154,13 @@ protected:
 private:
   // Internals
   std::vector<Parameter> _parameterList_;
+
+  /// A set of flags used to define if the parameter set has valid parameter
+  /// values.
+  /// "1" -- require valid parameters (Parameter::isInDomain will be true)
+  /// "2" -- require in the mirrored range (is inside mirrored range).
+  /// "4" -- require in the physical range (Parameter::isPhysical will be true)
+  int _validFlags_{1};
 
   // JSON
   std::string _name_{};

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -55,6 +55,24 @@ public:
   static void muteLogger();
   static void unmuteLogger();
 
+  /// Define the type of validity that needs to be required by
+  /// hasValidParameterValues.  The validity is propagated to each
+  /// ParameterSet.  The validity is:
+  ///
+  ///  "range" (default) -- Between the parameter minimum and maximum values.
+  ///  "norange"         -- Do not require parameters in the valid range
+  ///  "mirror"          -- Between the mirrored values (if parameter has
+  ///                       mirroring).
+  ///  "nomirror"        -- Do not require parameters in the mirrored range
+  ///  "physical"        -- Only physically meaningful values.
+  ///  "nophysical"      -- Do not require parameters in the physical range.
+  ///
+  /// Example: setParameterValidity("range,mirror,physical")
+  void setParameterValidity(const std::string& validity);
+
+  /// Check that the parameters in all of the enabled ParameterSets are valid.
+  [[nodiscard]] bool hasValidParameterSets() const;
+
 private:
   // config
   bool _reThrowParSetIfOutOfBounds_{true}; // NO LONGER USED.  CAN NEVER BE FALSE.

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -15,7 +15,6 @@
 
 LoggerInit([]{ Logger::setUserHeaderStr("[Parameter]"); });
 
-
 void Parameter::readConfigImpl(){
   if( not _parameterConfig_.empty() ){
     _isEnabled_ = GenericToolbox::Json::fetchValue(_parameterConfig_, "isEnabled", true);
@@ -168,6 +167,20 @@ bool Parameter::isMirrored(double value_) const {
   if ( not std::isnan(_maxMirror_) and value_ > _maxMirror_ ) return true;
   return false;
 }
+bool Parameter::isValidValue(double value) const {
+  if ((_validFlags_ & 0b0001)!=0 and (not isInDomain(value))) return false;
+  if ((_validFlags_ & 0b0010)!=0 and (isMirrored(value))) return false;
+  if ((_validFlags_ & 0b0100)!=0 and (not isPhysical(value))) return false;
+  return true;
+}
+void Parameter::setValidity(const std::string& validity) {
+  if (validity.find("noran") != std::string::npos) _validFlags_ &= ~0b0001;
+  else if (validity.find("ran") != std::string::npos) _validFlags_ |= 0b0001;
+  if (validity.find("nomir") != std::string::npos) _validFlags_ &= ~0b0010;
+  else if (validity.find("mir") != std::string::npos) _validFlags_ |= 0b0010;
+  if (validity.find("nophy") != std::string::npos) _validFlags_ &= ~0b0100;
+  else if (validity.find("phy") != std::string::npos) _validFlags_ |= 0b0100;
+}
 bool Parameter::isValueWithinBounds() const{
   return isInDomain(_parameterValue_);
 }
@@ -227,5 +240,4 @@ std::string Parameter::getSummary(bool shallow_) const {
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -327,15 +327,9 @@ const std::vector<Parameter>& ParameterSet::getEffectiveParameterList() const{
 }
 
 bool ParameterSet::isValid() const {
-  if (_validFlags_ == 0) return true;
   for (const Parameter& par : getParameterList()) {
     if (not par.isEnabled()) continue;
-    if ((_validFlags_ & 0b0001) != 0
-        and (not par.isInDomain(par.getParameterValue()))) return false;
-    if ((_validFlags_ & 0b0010) != 0
-        and (par.isMirrored(par.getParameterValue()))) return false;
-    if ((_validFlags_ & 0b0100) != 0
-        and (not par.isPhysical(par.getParameterValue()))) return false;
+    if (not par.isValidValue(par.getParameterValue())) return false;
   }
   return true;
 }
@@ -373,15 +367,10 @@ double ParameterSet::getPenaltyChi2() {
 }
 
 void ParameterSet::setValidity(const std::string& validity) {
-  LogWarning << "Set parameter validity to " << validity << std::endl;
-  if (validity.find("noran") != std::string::npos) _validFlags_ &= ~0b0001;
-  else if (validity.find("ran") != std::string::npos) _validFlags_ |= 0b0001;
-  if (validity.find("nomir") != std::string::npos) _validFlags_ &= ~0b0010;
-  else if (validity.find("mir") != std::string::npos) _validFlags_ |= 0b0010;
-  if (validity.find("nophy") != std::string::npos) _validFlags_ &= ~0b0100;
-  else if (validity.find("phy") != std::string::npos) _validFlags_ |= 0b0100;
-  LogWarning << "Set parameter validity to " << validity
-             << " (" << _validFlags_ << ")" << std::endl;
+  for (Parameter& par : getParameterList()) {
+    par.setValidity(validity);
+  }
+  LogWarning << "Set parameter set validity to " << validity << std::endl;
 }
 
 // Parameter throw

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -301,3 +301,15 @@ void ParametersManager::injectParameterValues(const nlohmann::json &config_) {
 ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& name_){
   return const_cast<ParameterSet*>(const_cast<const ParametersManager*>(this)->getFitParameterSetPtr(name_));
 }
+bool ParametersManager::hasValidParameterSets() const {
+  for (const ParameterSet& parSet: getParameterSetsList()) {
+    if (not parSet.isEnabled()) continue;
+    if (not parSet.isValid()) return false;
+  }
+  return true;
+}
+void ParametersManager::setParameterValidity(const std::string& v) {
+  for (ParameterSet& parSet: getParameterSetsList()) {
+    parSet.setValidity(v);
+  }
+}

--- a/src/SamplesManager/src/PhysicsEvent.cpp
+++ b/src/SamplesManager/src/PhysicsEvent.cpp
@@ -26,30 +26,30 @@ void PhysicsEvent::setCommonVarNameListPtr(const std::shared_ptr<std::vector<std
 // const getters
 double PhysicsEvent::getEventWeight() const {
 #ifdef GUNDAM_USING_CACHE_MANAGER
-    if (_cacheManagerValue_) {
-        if (_cacheManagerValid_ != nullptr and not (*_cacheManagerValid_)) {
-            // This is slowish, but will make sure that the cached result is
-            // updated when the cache has changed.  The values pointed to by
-            // _CacheManagerValue_ and _CacheManagerValid_ are inside
-            // of the weights cache (a bit of evil coding here), and are
-            // updated by the cache.  The update is triggered by
-            // (*_CacheManagerUpdate_)().
-            if (_cacheManagerUpdate_) (*_cacheManagerUpdate_)();
-        }
-        double value = *_cacheManagerValue_;
-        LogThrowIf(std::isnan(value), "NaN weight: " << this->getSummary());
-        if (not GundamGlobals::getForceDirectCalculation()) return value;
-        if (not GundamUtils::almostEqual(value, _eventWeight_)) {
-          std::ostringstream str;
-          str << "Inconsistent event weight -- "
-              << " Calculated: " << value
-              << " Cached: " << _eventWeight_;
-          LogError << str.str() << std::endl;
-          LogThrow(str.str());
-        }
+  if (_cacheManagerValid_ and not (*_cacheManagerValid_)) {
+    // This can be slowish, but will make sure that the cached result is
+    // updated when the cache has changed.  The values pointed to by
+    // _CacheManagerValue_ and _CacheManagerValid_ are inside
+    // of the weights cache (a bit of evil coding here), and are
+    // updated by the cache.  The update is triggered by
+    // (*_CacheManagerUpdate_)().
+    if (_cacheManagerUpdate_) (*_cacheManagerUpdate_)();
+  }
+  if (_cacheManagerValid_ and (*_cacheManagerValid_) and _cacheManagerValue_) {
+    double value = *_cacheManagerValue_;
+    LogThrowIf(std::isnan(value), "NaN weight: " << this->getSummary());
+    if (not GundamGlobals::getForceDirectCalculation()) return value;
+    if (not GundamUtils::almostEqual(value, _eventWeight_)) {
+      std::ostringstream str;
+      str << "Inconsistent event weight -- "
+          << " Calculated: " << value
+          << " Cached: " << _eventWeight_;
+      LogError << str.str() << std::endl;
+      LogThrow(str.str());
     }
+  }
 #endif
-    return _eventWeight_;
+  return _eventWeight_;
 }
 const std::vector<GenericToolbox::AnyType>& PhysicsEvent::getVarHolder(const std::string &leafName_) const{
   int index = this->findVarIndex(leafName_, true);

--- a/src/SamplesManager/src/SampleElement.cpp
+++ b/src/SamplesManager/src/SampleElement.cpp
@@ -126,7 +126,8 @@ void SampleElement::refillHistogram(int iThread_){
     bool filledWithManager = false;
     double value{std::nan("not-set")};
     double error{std::nan("not-set")};
-    if (_CacheManagerValue_ !=nullptr and _CacheManagerIndex_ >= 0) {
+    if (_CacheManagerValid_ and (*_CacheManagerValid_)
+        and _CacheManagerValue_ and _CacheManagerIndex_ >= 0) {
       value = _CacheManagerValue_[_CacheManagerIndex_+iBin];
       error = _CacheManagerValue2_[_CacheManagerIndex_+iBin];
       (*binContentPtr) += value;


### PR DESCRIPTION
Safely check parameter limits during fits.  The old method for checking parameter validity during fits depended on first setting an invalid value, and then checking the validity.  Queries are added to check validity before setting.  This also adds checks for the GPU that the likelihood has not been changed since initialization.  If there is a change, a log message is generated, and the calculation falls back to the CPU.  This should only happen during debugging.

This has been tested on a data fit, and the full test suite.  Merging this will close Issue #582 