### PR TITLE
Removing `reThrowParSetIfOutOfBounds` config option. Will always assu…

### DIFF
--- a/resources/doc/configuration/Propagator.md
+++ b/resources/doc/configuration/Propagator.md
@@ -22,6 +22,5 @@ It owns the parameters, the samples, and the data loader.
 | enableEventMcThrow                             | bool   | Each MC event get reweighted with Poisson(1)                                               | true    |
 | gaussStatThrowInToys                           | bool   | Throw statistical error with a gaussian distribution instead                               | false   |
 | throwAsimovFitParameters                       | bool   | Throw parameters of MC before fit (used to test fitter convergence)                        | false   |
-| reThrowParSetIfOutOfBounds                     | bool   | If any thrown parameter of the set is out of bounds, throw again                           | true    |
 | globalEventReweightCap                         | double | Will cap the weight applied by the parameters: evWeight = baseWeight * min(parWeight, cap) | nan     |
 

--- a/src/ParametersManager/include/ParametersManager.h
+++ b/src/ParametersManager/include/ParametersManager.h
@@ -24,16 +24,6 @@ protected:
 public:
   // setters
   void setParameterSetListConfig(const JsonType& parameterSetListConfig_){ _parameterSetListConfig_ = parameterSetListConfig_; }
-  // Deprecated because out of bounds parameters are illegal and will result
-  // in a crash.  An out of bounds parameter is always rethrown and this value
-  // is ignored.
-  [[deprecated("Must always be true")]] void setReThrowParSetIfOutOfBounds(bool reThrowParSetIfOutOfBounds_){ _reThrowParSetIfOutOfBounds_ = reThrowParSetIfOutOfBounds_; }
-  // If set to true, parameters that are outside of the physical bounds will
-  // be rethrown.  The physical bounds are always contained in the overall
-  // parameter bounds, and the throw value will always be inside of the
-  // overall parameter bounds (the overall bounds are the "domain" of the
-  // parameter).  See the Parameter::setMinValue() and
-  // Parameter::setMinPhysical for more details.
   void setReThrowParSetIfOutOfPhysical(bool reThrowParSetIfOutOfPhysical_){ _reThrowParSetIfOutOfPhysical_ = reThrowParSetIfOutOfPhysical_; }
   void setThrowToyParametersWithGlobalCov(bool throwToyParametersWithGlobalCov_){ _throwToyParametersWithGlobalCov_ = throwToyParametersWithGlobalCov_; }
   void setGlobalCovarianceMatrix(const std::shared_ptr<TMatrixD> &globalCovarianceMatrix){ _globalCovarianceMatrix_ = globalCovarianceMatrix; }
@@ -66,7 +56,6 @@ public:
 
 private:
   // config
-  bool _reThrowParSetIfOutOfBounds_{true};  // NO LONGER USE. ALWAYS TRUE.
   bool _reThrowParSetIfOutOfPhysical_{true};
   bool _throwToyParametersWithGlobalCov_{false};
   JsonType _parameterSetListConfig_{};

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -36,10 +36,6 @@ void Propagator::readConfigImpl(){
     auto parameterSetListConfig = GenericToolbox::Json::fetchValue<JsonType>(_config_, "parameterSetListConfig");
     _parManager_.setParameterSetListConfig( ConfigUtils::getForwardedConfig( parameterSetListConfig ) );
   });
-  GenericToolbox::Json::deprecatedAction(_config_, "reThrowParSetIfOutOfBounds", [&]{
-    LogAlert << "Forwarding the option to ParametersManager. Consider moving it into \"parametersManagerConfig:\"" << std::endl;
-    _parManager_.setReThrowParSetIfOutOfBounds(GenericToolbox::Json::fetchValue<bool>(_config_, "reThrowParSetIfOutOfBounds"));
-  });
   GenericToolbox::Json::deprecatedAction(_config_, "throwToyParametersWithGlobalCov", [&]{
     LogAlert << "Forwarding the option to ParametersManager. Consider moving it into \"parametersManagerConfig:\"" << std::endl;
     _parManager_.setThrowToyParametersWithGlobalCov(GenericToolbox::Json::fetchValue<bool>(_config_, "throwToyParametersWithGlobalCov"));


### PR DESCRIPTION
…med to be true since this new version prevents parameters to be set out of bounds