### PR TITLE
Feature/event dial cache optimization

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -81,6 +81,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fPIC -g")
 ###############################################################################
 
 cmessage( STATUS "C++ Compiler      : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
+cmessage( STATUS "C++ Flags         : ${CMAKE_CXX_FLAGS}")
 cmessage( STATUS "C++ Standard      : ${CMAKE_CXX_STANDARD}" )
 cmessage( STATUS "C++ Release flags : ${CMAKE_CXX_FLAGS_RELEASE}" )
 cmessage( STATUS "C++ Debug flags   : ${CMAKE_CXX_FLAGS_DEBUG}" )

--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -59,6 +59,7 @@ public:
   // const getters
   [[nodiscard]] bool isMasked() const{ return _isMasked_; }
   [[nodiscard]] bool isDialUpdateRequested() const{ return _isDialUpdateRequested_; }
+  [[nodiscard]] bool* isDialUpdateRequestedPtr() { return &_isDialUpdateRequested_; }
   [[nodiscard]] int getBufferSize() const{ return _inputArraySize_; }
   [[nodiscard]] const std::vector<double>& getInputBuffer() const { return _inputBuffer_; }
   [[nodiscard]] const std::vector<ParameterReference> &getInputParameterIndicesList() const{ return _inputParameterReferenceList_; }

--- a/src/DialDictionary/DialEngine/include/EventDialCache.h
+++ b/src/DialDictionary/DialEngine/include/EventDialCache.h
@@ -50,15 +50,13 @@ public:
     bool *updateRequested{nullptr};
     void update(){
       // Reevaluate the dial if an update has been requested
-#ifdef OLD_INTERFACE
+#ifdef EVENT_DIAL_CACHE_SAFE_SLOW_INTERFACE
       if( dialInterface.getInputBufferRef()->isDialUpdateRequested() ){
-        response = dialInterface.evalResponse();
-      }
 #else
       if( *(this->updateRequested) ) {
+#endif
         response = dialInterface.evalResponse();
       }
-#endif
     }
     double getResponse(){
       this->update();

--- a/src/DialDictionary/DialEngine/include/EventDialCache.h
+++ b/src/DialDictionary/DialEngine/include/EventDialCache.h
@@ -38,17 +38,27 @@ public:
 
   /// DialResponseCache is keeping a reference of a DialInterface and a cached double for the response
   struct DialResponseCache {
-    explicit DialResponseCache( DialInterface& interface_ ): dialInterface(interface_) {}
-    // The dial interface to be used with the PhysicsEvent.
+    explicit DialResponseCache( DialInterface& interface_ )
+      : dialInterface(interface_) {
+      this->updateRequested = dialInterface.getInputBufferRef()->isDialUpdateRequestedPtr();
+    }
+    // The dial interface to be used with the Event.
     DialInterface& dialInterface;
     // The cached result calculated by the dial.
     double response{std::nan("unset")};
-
+    // A cached boolean to check if the dial needs to be updated.
+    bool *updateRequested{nullptr};
     void update(){
-      // evaluate the dial if an update has been requested
+      // Reevaluate the dial if an update has been requested
+#ifdef OLD_INTERFACE
       if( dialInterface.getInputBufferRef()->isDialUpdateRequested() ){
         response = dialInterface.evalResponse();
       }
+#else
+      if( *(this->updateRequested) ) {
+        response = dialInterface.evalResponse();
+      }
+#endif
     }
     double getResponse(){
       this->update();
@@ -56,7 +66,7 @@ public:
     }
   };
 
-  /// The cache element associating a PhysicsEvent to the appropriate
+  /// The cache element associating a Event to the appropriate
   /// DialInterface.
   struct CacheEntry {
     Event* event;
@@ -223,5 +233,4 @@ private:
 // Local Variables:
 // mode:c++
 // c-basic-offset:2
-// compile-command:"$(git rev-parse --show-toplevel)/cmake/gundam-build.sh"
 // End:


### PR DESCRIPTION
Profiling noted that "most" of the CPU was being spent. on EventDialCache.h line 53 
```
if( dialInterface.getInputBufferRef()->isDialUpdateRequested() ){
```
due to bad interaction with the CPU memory cache.  Checking the assembly, this bit of code needed three loads and was virtually guaranteed to miss the cache.  Fortunately, the location of the input buffer is stable, so the address of the dial update requested field is also stable.  This replaces the *safe* *correct* (but slow) C++ code with a *dangerous* (but fast) *trick* to grab the update request field directly from memory.   That removes one load, but, more importantly, has much better cache properties.