### PR TITLE
Address #605: Don't stop when minuit generates a NaN parameter

### DIFF
--- a/src/Fitter/src/LikelihoodInterface.cpp
+++ b/src/Fitter/src/LikelihoodInterface.cpp
@@ -194,8 +194,9 @@ double LikelihoodInterface::evalFit(const double* parArray_){
   // Update fit parameter values:
   const double *v = parArray_;
   for( auto* par : _minimizerFitParameterPtr_ ){
-    if (not getUseNormalizedFitSpace()) par->setParameterValue(*(v++));
-    else par->setParameterValue(ParameterSet::toRealParValue(*(v++), *par));
+    double p = *(v++);
+    if (getUseNormalizedFitSpace()) p = ParameterSet::toRealParValue(p, *par);
+    par->setParameterValue(p,true);
   }
 
   GenericToolbox::getElapsedTimeSinceLastCallInMicroSeconds(__METHOD_NAME__);

--- a/src/SamplesManager/src/PhysicsEvent.cpp
+++ b/src/SamplesManager/src/PhysicsEvent.cpp
@@ -26,26 +26,30 @@ void PhysicsEvent::setCommonVarNameListPtr(const std::shared_ptr<std::vector<std
 // const getters
 double PhysicsEvent::getEventWeight() const {
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if (_cacheManagerValid_ and not (*_cacheManagerValid_)) {
-    // This can be slowish, but will make sure that the cached result is
-    // updated when the cache has changed.  The values pointed to by
-    // _CacheManagerValue_ and _CacheManagerValid_ are inside
-    // of the weights cache (a bit of evil coding here), and are
-    // updated by the cache.  The update is triggered by
-    // (*_CacheManagerUpdate_)().
-    if (_cacheManagerUpdate_) (*_cacheManagerUpdate_)();
-  }
-  if (_cacheManagerValid_ and (*_cacheManagerValid_) and _cacheManagerValue_) {
-    double value = *_cacheManagerValue_;
-    LogThrowIf(std::isnan(value), "NaN weight: " << this->getSummary());
-    if (not GundamGlobals::getForceDirectCalculation()) return value;
-    if (not GundamUtils::almostEqual(value, _eventWeight_)) {
-      std::ostringstream str;
-      str << "Inconsistent event weight -- "
-          << " Calculated: " << value
-          << " Cached: " << _eventWeight_;
-      LogError << str.str() << std::endl;
-      LogThrow(str.str());
+  if (_cacheManagerValid_ and _cacheManagerValue_) {
+    if (not (*_cacheManagerValid_)) {
+      // This can be slowish, but will make sure that the cached result is
+      // updated when the cache has changed.  The values pointed to by
+      // _CacheManagerValue_ and _CacheManagerValid_ are inside
+      // of the weights cache (a bit of evil coding here), and are
+      // updated by the cache.  The update is triggered by
+      // (*_CacheManagerUpdate_)().
+      if (_cacheManagerUpdate_) (*_cacheManagerUpdate_)();
+    }
+    if ((*_cacheManagerValid_)) {
+      double value = *_cacheManagerValue_;
+      LogThrowIf(std::isnan(value), "NaN weight: " << this->getSummary());
+      if (not GundamGlobals::getForceDirectCalculation()) return value;
+      if (not GundamUtils::almostEqual(value, _eventWeight_)) {
+        const double magnitude = std::abs(value) + std::abs(_eventWeight_);
+        double delta = std::abs(value - _eventWeight_);
+        if (magnitude > 0.0) delta /= 0.5*magnitude;
+        LogError << "Inconsistent event weight -- "
+                 << " Calculated: " << value
+                 << " Cached: " << _eventWeight_
+                 << " Precision:  " << delta
+                 << std::endl;
+      }
     }
   }
 #endif

--- a/src/SamplesManager/src/SampleElement.cpp
+++ b/src/SamplesManager/src/SampleElement.cpp
@@ -157,7 +157,7 @@ void SampleElement::refillHistogram(int iThread_){
             << " Content: " << value << "!=" << (*binContentPtr)
             << " Error: " << error << "!=" << (*binErrorPtr);
         LogError << str.str() << std::endl;
-        LogThrow(str.str());
+        // std::exit(EXIT_FAILURE);
       }
     }
 #endif // GUNDAM_USING_CACHE_MANAGER


### PR DESCRIPTION
This allows the fit to continue when Minuit starts generating NaN (or other invalid) parameter values.  The fit will have failed at that point, but it will hopefully help us understand why the fits are failing.