### PR TITLE
ZLIB build should be user specified

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -177,25 +177,25 @@ link_libraries( ${YAML_CPP_LIBRARIES} )
 # ZLIB (optional)
 ####################
 
-if( ${DISABLE_ZLIB} )
-  cmessage( WARNING "DISABLE_ZLIB=ON. Not using Zlib." )
-else()
+if( ${ENABLE_ZLIB} )
   cmessage( STATUS "Looking for optional ZLib install..." )
   find_package(ZLIB)
-endif()
 
-if( ZLIB_FOUND )
-  cmessage( STATUS "ZLIB found : ${ZLIB_VERSION_STRING}")
-  cmessage( STATUS "ZLIB_INCLUDE_DIRS = ${ZLIB_INCLUDE_DIRS}")
-  cmessage( STATUS "ZLIB_LIBRARIES = ${ZLIB_LIBRARIES}")
+  if( ZLIB_FOUND )
+    cmessage( STATUS "ZLIB found : ${ZLIB_VERSION_STRING}")
+    cmessage( STATUS "ZLIB_INCLUDE_DIRS = ${ZLIB_INCLUDE_DIRS}")
+    cmessage( STATUS "ZLIB_LIBRARIES = ${ZLIB_LIBRARIES}")
 
-  add_definitions( -D USE_ZLIB=1 )
-  include_directories( ${ZLIB_INCLUDE_DIRS} )
-  link_libraries( ${ZLIB_LIBRARIES} )
+    add_definitions( -D USE_ZLIB=1 )
+    include_directories( ${ZLIB_INCLUDE_DIRS} )
+    link_libraries( ${ZLIB_LIBRARIES} )
+  else()
+    cmessage( FATAL "Could not find ZLib. (ENABLE_ZLIB=ON)" )
+  endif()
 else()
-  cmessage( WARNING "ZLib not found. Will compile without the associated features." )
   add_definitions( -D USE_ZLIB=0 )
 endif()
+
 
 
 ####################

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -22,12 +22,12 @@ option( YAMLCPP_DIR "Set custom path to yaml-cpp lib." OFF )
 
 # dev options
 option( USE_STATIC_LINKS "Use static link of libraries and apps instead of shared." OFF )
-option( DISABLE_ZLIB "Disable Zlib dependency." OFF )
 option( CXX_WARNINGS "Enable most C++ warning flags." ON )
 option( CXX_MARCH_FLAG "Enable cpu architecture specific optimisations." OFF )
 option( CMAKE_CXX_EXTENSIONS "Enable GNU extensions to C++ language (-std=gnu++14)." OFF )
 option( DISABLE_MANUAL_LOG_HEADER "Don't rely on the manually set logger user header string." ON )
 option( DISABLE_GOOGLE_TESTS "Don't build Google tests." OFF )
+option( ENABLE_ZLIB "Use ZLib hash for cache invalidation." OFF )
 
 
 # Reading options


### PR DESCRIPTION
In the current main branch, ZLIB is used to build GUNDAM if the library is found.

ZLib is used for providing hash for each dial input buffer. Without the library, the value of the inputs them selves are used to invalidate the cache. The inclusion of ZLib have a very little impact on the performances, but adds a possible source of problem while the user is compiling GUNDAM.