### PR TITLE
Google tests build if explicitly specified by a CMake option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN git submodule update --init --recursive
 WORKDIR $BUILD_DIR
 RUN cmake \
       -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR \
+      -D ENABLE_GOOGLE_TESTS=ON \
       $REPO_DIR 
 RUN make -j3 install
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -26,7 +26,7 @@ option( CXX_WARNINGS "Enable most C++ warning flags." ON )
 option( CXX_MARCH_FLAG "Enable cpu architecture specific optimisations." OFF )
 option( CMAKE_CXX_EXTENSIONS "Enable GNU extensions to C++ language (-std=gnu++14)." OFF )
 option( DISABLE_MANUAL_LOG_HEADER "Don't rely on the manually set logger user header string." ON )
-option( DISABLE_GOOGLE_TESTS "Don't build Google tests." OFF )
+option( ENABLE_GOOGLE_TESTS "Build Google tests." OFF )
 option( ENABLE_ZLIB "Use ZLib hash for cache invalidation." OFF )
 
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,10 +1,8 @@
 
-message("")
-cmessage( WARNING "Defining tests...")
 
-if( DISABLE_GOOGLE_TESTS )
-  cmessage( ALERT "Google tests disabled (DISABLE_GOOGLE_TESTS=ON). Skipping...")
-else()
+if( ENABLE_GOOGLE_TESTS )
+  message("")
+  cmessage( WARNING "Defining tests...")
   include( CTest )
   add_subdirectory( ${CMAKE_SOURCE_DIR}/tests )
 endif()


### PR DESCRIPTION
Compiling GUNDAM with Google tests enabled often leads to compiler errors on computing clusters. External libraries like google tests are sometimes outdated (like on CCLyon) and don't allow to compile against GUNDAM