### PR TITLE
Check validity of WeightNormalization inputs

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,3 +1,7 @@
+Fixes relative to 1.8.5
+
+Issue #621: GPU normalization weight was not being checked for validity before being applied to the event weight.  This only caused problems in corner cases, but when it caused trouble, you could end up with negative expectations.  It was found while torture testing the detector systematics.  The normalization now handles invalid inputs.
+
 Fixes relative to 1.8.4
 
 Issue #582: Safely check parameter limits during fits.  The old method for checking parameter validity during fits depended on first setting an invalid value, and then checking the validity.  Queries are added to check validity before setting.  This also adds checks for the GPU that the likelihood has not been changed since initialization.  If there is a change, a log message is generated, and the calculation falls back to the CPU.  This should only happen during debugging.

--- a/src/CacheManager/include/WeightNormalization.h
+++ b/src/CacheManager/include/WeightNormalization.h
@@ -33,6 +33,10 @@ private:
     /// then constant.
     std::unique_ptr<hemi::Array<short>> fNormParameter;
 
+    // The bounds to apply to the normalization.
+    Cache::Parameters::Clamps& fLowerClamp;
+    Cache::Parameters::Clamps& fUpperClamp;
+
 public:
 
     // Construct the class.  This should allocate all the memory on the host
@@ -40,6 +44,8 @@ public:
     // which are managed by the Weights class.
     Normalization(Cache::Weights::Results& weights,
                   Cache::Parameters::Values& parameters,
+                  Cache::Parameters::Clamps& lowerClamps,
+                  Cache::Parameters::Clamps& upperClamps,
                   std::size_t norms);
 
     // Deconstruct the class.  This should deallocate all the memory


### PR DESCRIPTION
The normalization kernel was blindly using the provided normalization but should have been clamping it at the minimum or maximum value when an invalid value was provided (i.e. +/- inf, nan, or negative).  Check the clamps now.  

This was found while torture testing the toy throwing with some negative detector systematic weights.