### PR TITLE
Updates for xsec calculation

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -265,6 +265,12 @@ int main(int argc, char** argv){
   auto* xsecAtBestFitTree = new TTree("xsecAtBestFitTree", "xsecAtBestFitTree");
   xsecAtBestFitTree->SetDirectory( GenericToolbox::mkdirTFile(calcXsecDir, "throws") ); // temp saves will be done here
 
+  LogInfo << "Writing event samples in TTrees..." << std::endl;
+  dataSetManager.getTreeWriter().writeSamples(
+      GenericToolbox::mkdirTFile(calcXsecDir, "events"),
+      dataSetManager.getPropagator()
+  );
+
   LogInfo << "Creating normalizer objects..." << std::endl;
   // flux renorm with toys
   struct ParSetNormaliser{
@@ -743,13 +749,6 @@ int main(int argc, char** argv){
   propagator.getPlotGenerator().generateCanvas(
       propagator.getPlotGenerator().getHistHolderList(0),
       GenericToolbox::mkdirTFile(calcXsecDir, "plots/canvas")
-  );
-
-
-  LogInfo << "Writing event samples in TTrees..." << std::endl;
-  dataSetManager.getTreeWriter().writeSamples(
-      GenericToolbox::mkdirTFile(calcXsecDir, "events"),
-      dataSetManager.getPropagator()
   );
 
 }

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -287,6 +287,9 @@ void ParametersManager::throwParametersFromGlobalCovariance(bool quietVerbose_){
         LogInfo << " becomes " << eigenPar.getParameterValue() << std::endl;
       }
     }
+
+    // reached this point: all parameters are within bounds
+    break;    
   }
 }
 


### PR DESCRIPTION
I was running `gundamCalcXsec` with latest GUNDAM main branch and found two things that might be updated:

1. In function `ParametersManager::throwParametersFromGlobalCovariance` parameter throw loop, it seems that the loop will never end even if all thrown parameters are within bounds. Added `break` at the loop end if the throw is successful.
2. In `gundamCalcXsec.cxx`, move the event tree filling right after propagator initialization, so that the post-fit event weights can be correctly saved in the output tree.