### PR TITLE
Lts/fix/build output

### DIFF
--- a/cmake/applications.cmake
+++ b/cmake/applications.cmake
@@ -1,6 +1,6 @@
 
 message("")
-cmessage( WARNING "Defining applications...")
+cmessage( STATUS "Defining applications...")
 
 add_subdirectory( ${CMAKE_SOURCE_DIR}/src/Applications )
 

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,7 +1,7 @@
 
 
 message("")
-cmessage( WARNING "Configuring compiler options...")
+cmessage( STATUS "Configuring compiler options...")
 
 # Changes default install path to be a subdirectory of the build dir.
 # Should set the installation dir at configure time with

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,5 +1,5 @@
 message("")
-cmessage( WARNING "Checking dependencies...")
+cmessage( STATUS "Checking dependencies...")
 
 
 ##########

--- a/cmake/modules.cmake
+++ b/cmake/modules.cmake
@@ -1,6 +1,6 @@
 
 message("")
-cmessage( WARNING "Defining modules...")
+cmessage( STATUS "Defining modules...")
 
 set( MODULES Utils )
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,7 +1,7 @@
 # CMake options
 
 message("")
-cmessage( WARNING "Setting up options...")
+cmessage( STATUS` "Setting up options...")
 
 
 # general options
@@ -24,7 +24,8 @@ option( USE_STATIC_LINKS "Use static link of libraries and apps instead of share
 option( CXX_WARNINGS "Enable most C++ warning flags." ON )
 option( CXX_MARCH_FLAG "Enable cpu architecture specific optimisations." OFF )
 option( CMAKE_CXX_EXTENSIONS "Enable GNU extensions to C++ language (-std=gnu++14)." OFF )
-option( ENABLE_GOOGLE_TESTS "Build Google tests." OFF )
+option( ENABLE_TESTS "Build CMake tests (optionally uses googletest)." ON )
+option( SKIP_GOOGLE_TEST "Skip GTest unit tests (other tests enabled)." OFF )
 
 # Reading options
 ##################

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -2,7 +2,7 @@
 # SubModules: These are just adding the code directly, as stand-alone projects.
 
 message("")
-cmessage( WARNING "Checking submodules..." )
+cmessage( STATUS "Checking submodules..." )
 
 function( checkSubmodule )
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,8 +1,7 @@
-
-
-if( ENABLE_GOOGLE_TESTS )
-  message("")
-  cmessage( WARNING "Defining tests...")
+if( ENABLE_TESTS )
+  cmessage( STATUS "Build GUNDAM test and validations")
   include( CTest )
   add_subdirectory( ${CMAKE_SOURCE_DIR}/tests )
+else()
+  cmessage(WARNING "GUNDAM tests and validations not enabled.  Use with caution.")
 endif()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,6 +1,6 @@
 
 message("")
-cmessage( WARNING "Checking out git version...")
+cmessage( STATUS "Check git version...")
 
 # Printout version & generate header
 cmessage( STATUS "Pre-checking GUNDAM version" )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@
 #  ${CMAKE_BINARY_DIR}/Testing/gundam-tests.<date>
 #
 
-cmessage( STATUS "Setting up tests..." )
+cmessage( STATUS "Build GUNDAM tests" )
 
 # Run the gundam-tests.sh script which runs scripted tests.  The
 # COMMAND is a little complicated since the testing script needs to
@@ -29,8 +29,14 @@ add_test(
 
 ## Compiled unit tests using GoogleTest.  These are only run if GTest
 ## is found.
-find_package(GTest)
-if(GTEST_FOUND)
+if (NOT SKIP_GOOGLE_TEST)
+  find_package(GTest)
+else()
+  cmessage( WARNING "GTest unit testing explicitly disabled by user")
+endif()
+if (NOT GTEST_FOUND)
+  cmessage( WARNING "GTest package disabled or not found.  Disable unit tests.")
+else()
   enable_testing()
 
   # Setup the hemi test suite for the host
@@ -56,5 +62,4 @@ if(GTEST_FOUND)
     target_link_libraries(hemiTest_device.exe GundamCache)
     gtest_discover_tests(hemiTest_device.exe)
   endif(CMAKE_CUDA_COMPILER)
-
-endif(GTEST_FOUND)
+endif(NOT GTEST_FOUND)


### PR DESCRIPTION
Fix the cmake files in preparation for a new LTS release.  Mostly changes a bunch of (not) WARNING messages into STATUS messages.  Also fixes a problem with how the use of GTest was disabled so that other tests are still done.  All testing is enabled/disabled by ENABLE_TESTS (default ON).  The GTest unit testing is disabled/enabled by SKIP_GOOGLE_TESTS (default OFF).  