### PR TITLE
Lts/issue673/broken linear interpolation

### DIFF
--- a/src/Utils/include/CalculateGraph.h
+++ b/src/Utils/include/CalculateGraph.h
@@ -52,7 +52,7 @@ namespace {
         // Check to find a point that is less than x.  This is "brute force"
         // binary search for upto 16 elements.  The "if" has been checked and
         // is efficient with CUDA.
-        const int knotCount = (dim)/2 - 2;
+        const int knotCount = (dim)/2;
         int ix = 0;
 #define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount) && (x > data[2*(ix+ioff)+1])) ix += ioff
         CHECK_OFFSET(8);

--- a/tests/fast-tests/100CheckGraph.C
+++ b/tests/fast-tests/100CheckGraph.C
@@ -1,0 +1,204 @@
+# !/bin/bash
+# Wrap a ROOT macro as a script.
+root <<EOF
+
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+////////////////////////////////////////////////////////////////////////
+// Test the CalculateCompactSpline routine on the CPU.
+
+#include "${GUNDAM_ROOT}/src/Utils/include/CalculateGraph.h"
+
+std::string args{"$*"};
+
+int status{0};
+
+/// Fail if fractional difference between "v1" and "v2" is larger than "tol"
+/// THIS IS COPIED HERE TO AVOID DEPENDENCIES
+#define TOLERANCE(_msg,_v1,_v2,_tol)                              \
+    do {                                                          \
+        double _v = (_v1)>0 ? (_v1): -(_v1);                      \
+        double _vv = (_v2)>0 ? (_v2): -(_v2);                     \
+        double _d = std::abs((_v1)-(_v2));                        \
+        double _r = _d/std::max(0.5*(_v+_vv),(_tol));             \
+        if (_r < (_tol)) {                                        \
+            break;                                                \
+        }                                                         \
+        ++status;                                                 \
+        std::cout << "FAIL:";                                     \
+        std::cout << " " << _msg                                  \
+                  << std::setprecision(8)                         \
+                  << std::scientific                              \
+                  << " (" << _r << "<" << (_tol) << ")"           \
+                  << " [" << #_v1 << "=" << (_v1)                 \
+                  << " " << #_v2 << "=" << (_v2)                  \
+                  << " " << _d << "]"                             \
+                  << std::endl;                                   \
+    } while(false);
+
+int main() {
+    std::cout << "Hello world" << std::endl;
+
+
+#define TEST1
+#ifdef TEST1
+    {
+        // Test linear interpolation between two points
+        double data[] = {0.0, 0.0, 1.0, 1.0};
+        int nData = 2;
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.0; x <= 2.0; x += 0.1) {
+            double v = CalculateGraph(x, -10.0, 10.0, data, 2*nData);
+            TOLERANCE("Two Point Tolerance", x, v, 1E-6);
+            graph1->SetPoint(p++,x,v);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph1.pdf");
+        gPad->Print("100CheckGraph1.png");
+    }
+#endif
+
+#define TEST2
+#ifdef TEST2
+    {
+        // Test interpolation between three symmetric points
+        int nData = 3;
+        double data[] = {1.0, -1.0, 0.0, 0.0, 1.0, 1.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -2.0; x <= 2.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -10.0, 10.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -10.0, 10.0, data, 2*nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 2) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph2.pdf");
+        gPad->Print("100CheckGraph2.png");
+    }
+#endif
+
+#ifdef TEST3
+    {
+        // Test interpolation between six points
+        int nData = 6;
+        double data[] = {-1.0, 2.0/(nData-1), 0.0, 0.0, 1.0, 1.0, 0.0, 0.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.5; x <= 1.5; x += 0.01) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 3) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph3.pdf");
+        gPad->Print("100CheckGraph3.png");
+    }
+#endif
+
+#ifdef TEST4
+    {
+        // Test interpolation where there can be a lot of overshoot
+        int nData = 13;
+        double data[] = {-1.0, 2.0/(nData-1),
+                         0.5, 1.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         0.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         1.5, 0.5};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.1; x <= 1.1; x += 0.01) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph4.pdf");
+        gPad->Print("100CheckGraph4.png");
+    }
+#endif
+
+#ifdef TEST5
+    {
+        // Test interpolation where there is a smooth symmetric function
+        int nData = 17;
+        double data[] = {-1.0, 2.0/(nData-1),
+                         0.0, 0.0, 0.0, 0.5, 1.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         0.5,
+                         1.0, 1.0, 1.0, 1.0,
+                         1.5, 0.5, 0.0, 0.0, 0.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            data[p+2] = std::cos(4.0*x);
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -1.5; x <= 1.5; x += 0.01) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 5) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph5.pdf");
+        gPad->Print("100CheckGraph5.png");
+    }
+#endif
+
+    return status;
+}
+exit(main());
+EOF
+# Local Variables:
+# mode:c++
+# c-basic-offset:4
+# End:


### PR DESCRIPTION
Fix linear interpolation when there are more than two knots, and add tests to make sure it stays fixed.  Two knot linear interpolation work OK.  It is a small boon that multi-knot linear interpolation isn't used much since it introduces a cusp into the likelihood and can cause MINUIT to become unstable (translation: we got lucky).

Closes #673.