### PR TITLE
Resolve Issue 674: Add useful DialInputBuffer error

### DIFF
--- a/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
@@ -5,6 +5,7 @@
 #include "DialInputBuffer.h"
 
 #include "Logger.h"
+#include "GundamBacktrace.h"
 
 
 #ifndef DISABLE_USER_HEADER
@@ -70,6 +71,16 @@ void DialInputBuffer::update(){
 
       // re-apply the offset
       tempBuffer += inputRef.mirrorEdges.minValue;
+    }
+    if( std::isnan(tempBuffer) ){
+        // LogThrowIf is broken, but OK for real error traps, but this is
+        // checking user input it's critical that the error message is
+        // properly formated so print an error, a backtrace, and then exit.
+        LogError << "NaN while evaluating input buffer of "
+                 << inputRef.getParameter(_parSetListPtr_).getTitle()
+                 << std::endl;
+        LogError << GundamUtils::Backtrace << std::endl;
+        std::exit(EXIT_FAILURE);
     }
 
     // has it been updated?


### PR DESCRIPTION
This fixes the check on the DialInputBuffer input parameters to make sure that an error message gets printed for the user.  The trap is usually caused by a mistake in the user input file, so the error message needs to provide good clues, and throw doesn't help.  Use sys::exit(EXIT_FAILURE) since this probably isn't caused by a gundam bug.

# Conflicts:
#	src/DialDictionary/DialEngine/src/DialInputBuffer.cpp