### PR TITLE
Lts/Handle wild graphs and splines

### DIFF
--- a/ChangeLog-1.8.x
+++ b/ChangeLog-1.8.x
@@ -1,5 +1,7 @@
 Fixes relative to 1.8.5
 
+Fix (Merge #681): Handle over sized graphs and splines. The number of points that can be handled in a spline/graph has been increased, but that needs to be used carefully since large splines and graphs will make fits run more slowly. Note: Using linear interpolation with more than two knots is explicitly forbidden by MINUIT since it introduces a discontinuous derivative.  MINUIT may still run, but the results are undefined (that means the answer could be useful, or could start a thermonuclear war.  Both outcomes are formally correct).
+
 Fix (Merge #676 and #665): Make usage of GTest unit testing optional.  The full testing suite can be disabled by setting the CMake option ENABLE_TESTS to OFF.  Just the unit tests can be disabled by setting SKIP_GOOGLE_TESTS to ON.  Warning messages during the CMake build are now actual warnings that should be noticed by the users.
 
 Issue #674: Change termination behavior when DialInputBuffer finds an invalid parameter.  Previously it would throw, and it has been changed to print a descriptive message and the exit with failure.  This is because the most common way that there will be a bad parameter value in DialInputBuffer is from a bad user configuration file (or other user inputs).

--- a/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
@@ -8,7 +8,6 @@
 #include "GenericToolbox.Root.h"
 #include "Logger.h"
 
-
 LoggerInit([]{
   Logger::setUserHeaderStr("[GeneralSpline]");
 });
@@ -51,6 +50,13 @@ void GeneralSpline::buildDial(const std::vector<double>& xPoints,
                               const std::vector<double>& deriv,
                               const std::string& option_){
   LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+
+  if (xPoints.size() > 31) {
+      LogError << "Requesting a spline with to many points: "
+               << xPoints.size() << std::endl;
+      LogError << "Event weight splines are limited to 31 points" << std::endl;
+      std::exit(EXIT_FAILURE);
+  }
 
   _splineBounds_.first = xPoints.front();
   _splineBounds_.second = xPoints.back();

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -129,6 +129,7 @@ namespace {
         const int knotCount = (dim-2)/3 - 2;
         int ix = 0;
 #define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount) && (x > data[2+3*(ix+ioff)+2])) ix += ioff
+        CHECK_OFFSET(16);
         CHECK_OFFSET(8);
         CHECK_OFFSET(4);
         CHECK_OFFSET(2);

--- a/src/Utils/include/CalculateGraph.h
+++ b/src/Utils/include/CalculateGraph.h
@@ -54,7 +54,9 @@ namespace {
         // is efficient with CUDA.
         const int knotCount = (dim)/2;
         int ix = 0;
-#define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount) && (x > data[2*(ix+ioff)+1])) ix += ioff
+#define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount-1) && (x > data[2*(ix+ioff)+1])) ix += ioff
+
+        CHECK_OFFSET(16);
         CHECK_OFFSET(8);
         CHECK_OFFSET(4);
         CHECK_OFFSET(2);

--- a/tests/fast-tests/100CheckGeneralSpline.C
+++ b/tests/fast-tests/100CheckGeneralSpline.C
@@ -97,7 +97,7 @@ int main() {
 #define TEST2
 #ifdef TEST2
     {
-        // Define a TSpline3 and make sure that GeneralSpline reproduces it
+        // Define a TGraph and make sure that GeneralSpline reproduces it
         TGraph graph(3);
         graph.SetPoint(0,-3.0, 0.0);
         graph.SetPoint(1, 0.1, 1.0);
@@ -143,6 +143,60 @@ int main() {
         generalSpline.Draw("same");
         gPad->Print("100CheckGeneralSpline2.pdf");
         gPad->Print("100CheckGeneralSpline2.png");
+    }
+#endif
+
+
+#define TEST3
+#ifdef TEST3
+    {
+        // Define a large spline and make sure that GeneralSpline reproduces
+        // it
+        TGraph graph;
+        int count = 0;
+        for (int i = -10; i<11; ++i) {
+            double v = i;
+            graph.SetPoint(count++,v, std::abs(v));
+        }
+        TSpline3 spline("splineOfGraph",&graph);
+        graph.Draw("AC*");
+        graph.SetMinimum(-0.5);
+        graph.SetMaximum(15.0);
+        spline.SetLineWidth(5);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 0.0;
+        std::cout << "Test1: Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+3*knot+0] = yy;
+            data[2+3*knot+1] = ss;
+            data[2+3*knot+2] = xx;
+        }
+        TGraph generalSpline;
+        int point = 0;
+        for (double xxx = spline.GetXmin() - 2.0;
+             xxx<=spline.GetXmax() + 2.0; xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateGeneralSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            generalSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test3: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        generalSpline.SetLineWidth(3);
+        generalSpline.SetLineColor(kGreen);
+        generalSpline.Draw("same");
+        gPad->Print("100CheckGeneralSpline3.pdf");
+        gPad->Print("100CheckGeneralSpline3.png");
     }
 #endif
 

--- a/tests/fast-tests/100CheckGeneralSpline.C
+++ b/tests/fast-tests/100CheckGeneralSpline.C
@@ -64,7 +64,7 @@ int main() {
         double data[dim];
         data[0] = -3.0;
         data[1] = 0.0;
-        std::cout << "Number of knots " << nKnots << std::endl;
+        std::cout << "Test1: Number of knots " << nKnots << std::endl;
         for (int knot = 0; knot < nKnots; ++knot) {
             double xx;
             double yy;
@@ -116,7 +116,7 @@ int main() {
         double data[dim];
         data[0] = -3.0;
         data[1] = 0.0;
-        std::cout << "Number of knots " << nKnots << std::endl;
+        std::cout << "Test2: Number of knots " << nKnots << std::endl;
         for (int knot = 0; knot < nKnots; ++knot) {
             double xx;
             double yy;
@@ -136,7 +136,7 @@ int main() {
                 = CalculateGeneralSpline(xxx,-100.0, 100.0,
                                        data, dim);
             generalSpline.SetPoint(point++, xxx, calcValue);
-            TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
+            TOLERANCE("Test2: Spline Mismatch", splineValue, calcValue, 1E-6);
         }
         generalSpline.SetLineWidth(3);
         generalSpline.SetLineColor(kGreen);

--- a/tests/fast-tests/100CheckGraph.C
+++ b/tests/fast-tests/100CheckGraph.C
@@ -98,26 +98,53 @@ int main() {
     }
 #endif
 
+#define TEST3
 #ifdef TEST3
     {
-        // Test interpolation between six points
-        int nData = 6;
-        double data[] = {-1.0, 2.0/(nData-1), 0.0, 0.0, 1.0, 1.0, 0.0, 0.0};
+        // Test interpolation between 19 points
+        int nData = 19;
+        double data[] = {
+            30.0, -9.0,
+            29.0, -8.0,
+            20.0, -7.0,
+            16.0, -6.0,
+            11.0, -5.0,
+            7.0, -4.0,
+            4.0, -3.0,
+            2.0, -2.0,
+            1.0, -1.0,
+            0.0, 0.0,
+            1.0, 1.0,
+            2.0, 2.0,
+            4.0, 3.0,
+            7.0, 4.0,
+            11.0, 5.0,
+            16.0, 6.0,
+            20.0, 7.0,
+            29.0, 8.0,
+            30.0, 9.0,
+            0.0, 0.0,
+            0.0, 0.0,
+            0.0, 0.0,
+            0.0, 0.0,
+            0.0, 0.0,
+            0.0, 0.0,
+            0.0, 0.0,
+        };
         std::unique_ptr<TGraph> data1(new TGraph());
         for (int p=0; p<nData; ++p) {
-            double x = data[0] + p*data[1];
-            double y = data[p+2];
+            double x = data[2*p+1];
+            double y = data[2*p+0];
             data1->SetPoint(p,x,y);
         }
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
-        for (double x = -1.5; x <= 1.5; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+        for (double x = -10.0; x <= 10.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
             std::ostringstream tmp;
-            tmp << "Symmetric tolerance (test 3) (X=" << x << ")";
+            tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
-            graph1->SetPoint(p++,x,v0);
             graph1->SetPoint(p++,x,v0);
         }
         graph1->Draw("AC");
@@ -127,72 +154,6 @@ int main() {
     }
 #endif
 
-#ifdef TEST4
-    {
-        // Test interpolation where there can be a lot of overshoot
-        int nData = 13;
-        double data[] = {-1.0, 2.0/(nData-1),
-                         0.5, 1.5,
-                         1.0, 1.0, 1.0, 1.0,
-                         0.5,
-                         1.0, 1.0, 1.0, 1.0,
-                         1.5, 0.5};
-        std::unique_ptr<TGraph> data1(new TGraph());
-        for (int p=0; p<nData; ++p) {
-            double x = data[0] + p*data[1];
-            double y = data[p+2];
-            data1->SetPoint(p,x,y);
-        }
-        std::unique_ptr<TGraph> graph1(new TGraph());
-        int p = 0;
-        for (double x = -1.1; x <= 1.1; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
-            std::ostringstream tmp;
-            tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
-            TOLERANCE(tmp.str(), v0, v1, 1E-6);
-            graph1->SetPoint(p++,x,v0);
-        }
-        graph1->Draw("AC");
-        data1->Draw("*,same");
-        gPad->Print("100CheckGraph4.pdf");
-        gPad->Print("100CheckGraph4.png");
-    }
-#endif
-
-#ifdef TEST5
-    {
-        // Test interpolation where there is a smooth symmetric function
-        int nData = 17;
-        double data[] = {-1.0, 2.0/(nData-1),
-                         0.0, 0.0, 0.0, 0.5, 1.5,
-                         1.0, 1.0, 1.0, 1.0,
-                         0.5,
-                         1.0, 1.0, 1.0, 1.0,
-                         1.5, 0.5, 0.0, 0.0, 0.0};
-        std::unique_ptr<TGraph> data1(new TGraph());
-        for (int p=0; p<nData; ++p) {
-            double x = data[0] + p*data[1];
-            data[p+2] = std::cos(4.0*x);
-            double y = data[p+2];
-            data1->SetPoint(p,x,y);
-        }
-        std::unique_ptr<TGraph> graph1(new TGraph());
-        int p = 0;
-        for (double x = -1.5; x <= 1.5; x += 0.01) {
-            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
-            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
-            std::ostringstream tmp;
-            tmp << "Symmetric tolerance (test 5) (X=" << x << ")";
-            TOLERANCE(tmp.str(), v0, v1, 1E-6);
-            graph1->SetPoint(p++,x,v0);
-        }
-        graph1->Draw("AC");
-        data1->Draw("*,same");
-        gPad->Print("100CheckGraph5.pdf");
-        gPad->Print("100CheckGraph5.png");
-    }
-#endif
 
     return status;
 }


### PR DESCRIPTION
We are seeing requests to interpolate graphs and splines that have far more points than we intended for the likelihood calculation.  This adds some more sanity checks and tries to protect users from themselves by catching splines with clear "out-of-bounds" problems.  

The number of points that can be handled in a spline/graph has been increased, but that needs to be used carefully since most machines will allow you to allocate more memory than can be efficiently used, and then the fit will run extremely slowly.  Large splines and graphs will make programs run more slowly.

Comment: No error trapping is implemented (yet), but using linear interpolation with more than two knots is *explicitly* not allowed by MINUIT.  MINUIT will still run, but the results are undefined (that means the answer could be useful, or it could start a thermonuclear war, both results would be correct).