### PR TITLE
Logger uses std::exit instead of throw

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -52,7 +52,7 @@ int main(int argc, char** argv){
 
   clParser.parseCmdLine(argc, argv);
 
-  LogThrowIf(clParser.isNoOptionTriggered(), "No option was provided.");
+  LogExitIf(clParser.isNoOptionTriggered(), "No option was provided.");
 
   LogInfo << "Provided arguments: " << std::endl;
   LogInfo << clParser.getValueSummary() << std::endl << std::endl;
@@ -61,9 +61,9 @@ int main(int argc, char** argv){
   GundamGlobals::setIsDebug(clParser.isOptionTriggered("debugVerbose"));
 
   // Sanity checks
-  LogThrowIf(not clParser.isOptionTriggered("configFile"), "Xsec calculator config file not provided.");
-  LogThrowIf(not clParser.isOptionTriggered("fitterFile"), "Did not provide the output fitter file.");
-  LogThrowIf(not clParser.isOptionTriggered("nToys"), "Did not provide number of toys.");
+  LogExitIf(not clParser.isOptionTriggered("configFile"), "Xsec calculator config file not provided.");
+  LogExitIf(not clParser.isOptionTriggered("fitterFile"), "Did not provide the output fitter file.");
+  LogExitIf(not clParser.isOptionTriggered("nToys"), "Did not provide number of toys.");
 
 
   // Global parameters
@@ -89,7 +89,7 @@ int main(int argc, char** argv){
   if( GenericToolbox::hasExtension(fitterFile, "root") ){
     LogWarning << "Opening fitter output file: " << fitterFile << std::endl;
     fitterRootFile = std::unique_ptr<TFile>( TFile::Open( fitterFile.c_str() ) );
-    LogThrowIf( fitterRootFile == nullptr, "Could not open fitter output file." );
+    LogExitIf( fitterRootFile == nullptr, "Could not open fitter output file." );
 
     RootUtils::ObjectReader::throwIfNotFound = true;
 
@@ -162,7 +162,7 @@ int main(int argc, char** argv){
         std::string()
     );
 
-    LogThrowIf(associatedParSet.empty(), "Could not find parSetBinning.");
+    LogExitIf(associatedParSet.empty(), "Could not find parSetBinning.");
 
     // Looking for parSet
     auto foundDialCollection = std::find_if(
@@ -173,7 +173,7 @@ int main(int argc, char** argv){
           if( parSetPtr == nullptr ){ return false; }
           return ( parSetPtr->getName() == associatedParSet );
         });
-    LogThrowIf(
+    LogExitIf(
         foundDialCollection == fitter.getLikelihoodInterface().getModelPropagator().getDialCollectionList().end(),
         "Could not find " << associatedParSet << " among fit dial collections: "
                           << GenericToolbox::toString(fitter.getLikelihoodInterface().getModelPropagator().getDialCollectionList(),
@@ -182,7 +182,7 @@ int main(int argc, char** argv){
                                                       }
                           ));
 
-    LogThrowIf(foundDialCollection->getDialBinSet().getBinList().empty(), "Could not find binning");
+    LogExitIf(foundDialCollection->getDialBinSet().getBinList().empty(), "Could not find binning");
     sample.setBinningFilePath( foundDialCollection->getDialBinSet().getFilePath() );
 
   }
@@ -308,15 +308,15 @@ int main(int argc, char** argv){
 
     }
     void initialize(){
-      LogThrowIf(dialCollectionPtr == nullptr, "Associated dial collection not provided.");
-      LogThrowIf(dialCollectionPtr->isEventByEvent(), "Dial collection is event by event.");
-      LogThrowIf(dialCollectionPtr->getSupervisedParameter() != nullptr, "Need a dial collection that handle a whole parSet.");
+      LogExitIf(dialCollectionPtr == nullptr, "Associated dial collection not provided.");
+      LogExitIf(dialCollectionPtr->isEventByEvent(), "Dial collection is event by event.");
+      LogExitIf(dialCollectionPtr->getSupervisedParameter() != nullptr, "Need a dial collection that handle a whole parSet.");
 
       file = std::make_shared<TFile>( filePath.c_str() );
-      LogThrowIf(file == nullptr, "Could not open file");
+      LogExitIf(file == nullptr, "Could not open file");
 
       histogram = file->Get<TH1D>( histogramPath.c_str() );
-      LogThrowIf(histogram == nullptr, "Could not find histogram.");
+      LogExitIf(histogram == nullptr, "Could not find histogram.");
     }
     [[nodiscard]] double getNormFactor() const {
       double out{0};
@@ -427,7 +427,7 @@ int main(int argc, char** argv){
       }
       else{
         LogInfo << std::endl;
-        LogThrow("Unrecognized config.");
+        LogExit("Unrecognized config.");
       }
 
       LogInfo << std::endl;
@@ -538,7 +538,7 @@ int main(int argc, char** argv){
                 break;
               }
             }
-            LogThrowIf(parSetNormPtr == nullptr, "Could not find parSetNorm obj with name: " << normData.parSetNormaliserName);
+            LogExitIf(parSetNormPtr == nullptr, "Could not find parSetNorm obj with name: " << normData.parSetNormaliserName);
 
             binData /= parSetNormPtr->getNormFactor();
           }
@@ -778,7 +778,7 @@ int main(int argc, char** argv){
         break;
       }      
     }
-    LogThrowIf(xsecDataPtr==nullptr, "corresponding data not found");
+    LogExitIf(xsecDataPtr==nullptr, "corresponding data not found");
 
     // alright, now rescale error bars
     for( int iBin = 0 ; iBin < histHolder.histPtr->GetNbinsX() ; iBin++ ){

--- a/src/Applications/src/gundamFitCompare.cxx
+++ b/src/Applications/src/gundamFitCompare.cxx
@@ -76,7 +76,7 @@ int main( int argc, char** argv ){
     exit(EXIT_FAILURE);
   }
 
-  LogThrowIf(clp.isOptionTriggered("use-prefit-1") and clp.isOptionTriggered("use-prefit-2"),
+  LogExitIf(clp.isOptionTriggered("use-prefit-1") and clp.isOptionTriggered("use-prefit-2"),
              "Remove the two options to see prefit comparison of both files");
 
   LogInfo << "Reading config..." << std::endl;

--- a/src/Applications/src/gundamFitPlot.cxx
+++ b/src/Applications/src/gundamFitPlot.cxx
@@ -51,7 +51,7 @@ int main( int argc, char** argv ){
 
   // Reading configuration
   auto configFilePath = clp.getOptionVal("configFile", "");
-  LogThrowIf(configFilePath.empty(), "Config file not provided.");
+  LogExitIf(configFilePath.empty(), "Config file not provided.");
 
   ConfigUtils::ConfigHandler configHandler(configFilePath);
   configHandler.override( clp.getOptionValList<std::string>("overrideFiles") );
@@ -145,7 +145,7 @@ int main( int argc, char** argv ){
     auto* file = GenericToolbox::openExistingTFile( filePath );
 
     auto* errorsDir = file->Get<TDirectory>("FitterEngine/postFit/Hesse/errors");
-    LogThrowIf(errorsDir == nullptr);
+    LogExitIf(errorsDir == nullptr);
     for( int iParSet = 0 ; iParSet < errorsDir->GetListOfKeys()->GetEntries() ; iParSet++ ){
       auto* parSetDir{errorsDir->Get<TDirectory>(errorsDir->GetListOfKeys()->At(iParSet)->GetName())};
       auto* hist = parSetDir->Get<TH1D>("valuesNorm/postFitErrors_TH1D");

--- a/src/Applications/src/gundamFitReader.cxx
+++ b/src/Applications/src/gundamFitReader.cxx
@@ -68,14 +68,14 @@ int main(int argc, char** argv){
 
   clParser.parseCmdLine(argc, argv);
 
-  LogThrowIf(clParser.isNoOptionTriggered(), "No option was provided.");
+  LogExitIf(clParser.isNoOptionTriggered(), "No option was provided.");
 
   LogInfo << "Provided arguments: " << std::endl;
   LogInfo << clParser.getValueSummary() << std::endl << std::endl;
   LogInfo << clParser.dumpConfigAsJsonStr() << std::endl;
 
 
-  LogThrowIf( clParser.getNbValueSet("fitFiles") == 0, "no fit files provided" );
+  LogExitIf( clParser.getNbValueSet("fitFiles") == 0, "no fit files provided" );
 
 
   for( auto& file : clParser.getOptionValList<std::string>("fitFiles") ){

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -97,7 +97,7 @@ int main(int argc, char** argv){
 
   clParser.parseCmdLine(argc, argv);
 
-  LogThrowIf(clParser.isNoOptionTriggered(), "No option was provided.");
+  LogExitIf(clParser.isNoOptionTriggered(), "No option was provided.");
 
   LogInfo << "Provided arguments: " << std::endl;
   LogInfo << clParser.getValueSummary() << std::endl << std::endl;
@@ -118,9 +118,9 @@ int main(int argc, char** argv){
   // Is build compatible with GPU option?
   if( clParser.isOptionTriggered("usingGpu") ){
 #ifdef GUNDAM_USING_CACHE_MANAGER
-    LogThrowIf( not Cache::Manager::HasCUDA(), "CUDA support not enabled with this GUNDAM build." );
+    LogExitIf( not Cache::Manager::HasCUDA(), "CUDA support not enabled with this GUNDAM build." );
 #else
-    LogThrow("CUDA support not enabled with this GUNDAM build (GUNDAM_USING_CACHE_MANAGER required).")
+    LogExit("CUDA support not enabled with this GUNDAM build (GUNDAM_USING_CACHE_MANAGER required).")
 #endif
     LogWarning << "Using GPU parallelization." << std::endl;
   }
@@ -137,7 +137,7 @@ int main(int argc, char** argv){
       else if ("on" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = true;
       else if ("off" == clParser.getOptionVal<std::string>("usingCacheManager",0)) useCache = false;
       else {
-          LogThrow("Invalid --cache-manager argument: must be empty, 'on' or 'off'");
+          LogExit("Invalid --cache-manager argument: must be empty, 'on' or 'off'");
       }
   }
   if (clParser.isOptionTriggered("usingGpu")) useCache = true;
@@ -149,7 +149,7 @@ int main(int argc, char** argv){
                  << std::endl;
     }
 #else
-    LogThrowIf(useCache, "GUNDAM compiled without Cache::Manager");
+    LogExitIf(useCache, "GUNDAM compiled without Cache::Manager");
 #endif
 
   // inject parameter config?
@@ -179,7 +179,7 @@ int main(int argc, char** argv){
 
   // Reading configuration
   auto configFilePath = clParser.getOptionVal("configFile", "");
-  LogThrowIf(configFilePath.empty(), "Config file not provided.");
+  LogExitIf(configFilePath.empty(), "Config file not provided.");
 
   ConfigUtils::ConfigHandler configHandler(configFilePath);
   configHandler.override( clParser.getOptionValList<std::string>("overrideFiles") );
@@ -242,7 +242,7 @@ int main(int argc, char** argv){
   else{
     std::string minGundamVersion("0.0.0");
     GenericToolbox::Json::fillValue(gundamFitterConfig, minGundamVersion, "minGundamVersion");
-    LogThrowIf(
+    LogExitIf(
         not GundamUtils::isNewerOrEqualVersion( minGundamVersion ),
         "Version check FAILED: " << GundamUtils::getVersionStr() << " < " << minGundamVersion
     );
@@ -293,7 +293,7 @@ int main(int argc, char** argv){
         isFound = true;
       }
     }
-    LogThrowIf(not isFound, "Could not find data entry \"" << selectedDataEntry << "\" among defined data sets");
+    LogExitIf(not isFound, "Could not find data entry \"" << selectedDataEntry << "\" among defined data sets");
   }
 
   // --skip-hesse
@@ -378,7 +378,7 @@ int main(int argc, char** argv){
   }
 
   if( clParser.isOptionTriggered("debugMaxNbEventToLoad") ){
-    LogThrowIf(clParser.getNbValueSet("debugMaxNbEventToLoad") != 1, "Nb of event not specified.");
+    LogExitIf(clParser.getNbValueSet("debugMaxNbEventToLoad") != 1, "Nb of event not specified.");
     LogDebug << "Load " << clParser.getOptionVal<size_t>("debugMaxNbEventToLoad") << "max events per dataset." << std::endl;
     for( auto& dataset : fitter.getLikelihoodInterface().getDatasetList() ){
       dataset.setNbMaxEventToLoad(clParser.getOptionVal<size_t>("debugMaxNbEventToLoad"));
@@ -398,7 +398,7 @@ int main(int argc, char** argv){
 
   if( clParser.isOptionTriggered("scanLine") ){
     auto* outDir = GenericToolbox::mkdirTFile(fitter.getSaveDir(), GenericToolbox::joinPath("preFit", "cmdScanLine"));
-    LogThrowIf( clParser.getNbValueSet("scanLine") == 0, "No injector file provided.");
+    LogExitIf( clParser.getNbValueSet("scanLine") == 0, "No injector file provided.");
     if( clParser.getNbValueSet("scanLine") == 1 ){
       LogAlert << "Will scan the line toward the point set in: " << clParser.getOptionVal<std::string>("scanLine", 0) << std::endl;
 
@@ -421,7 +421,7 @@ int main(int argc, char** argv){
       fitter.getParameterScanner().scanSegment( outDir, endPoint, startPoint );
     }
     else{
-      LogThrow("");
+      LogExit("");
     }
   }
 

--- a/src/Applications/src/gundamInputZipper.cxx
+++ b/src/Applications/src/gundamInputZipper.cxx
@@ -53,13 +53,13 @@ int main(int argc, char** argv) {
 
   clParser.parseCmdLine(argc, argv);
 
-  LogThrowIf(clParser.isNoOptionTriggered(), "No option was provided.");
+  LogExitIf(clParser.isNoOptionTriggered(), "No option was provided.");
 
   LogInfo << "Provided arguments: " << std::endl;
   LogInfo << clParser.getValueSummary() << std::endl << std::endl;
   LogInfo << clParser.dumpConfigAsJsonStr() << std::endl;
 
-  LogThrowIf( not clParser.isOptionTriggered("configFile") );
+  LogExitIf( not clParser.isOptionTriggered("configFile") );
 
   ConfigUtils::ConfigHandler configHandler( clParser.getOptionVal<std::string>("configFile") );
   configHandler.override( clParser.getOptionValList<std::string>("overrideFiles") );
@@ -140,10 +140,10 @@ int main(int argc, char** argv) {
   if( clParser.isOptionTriggered("zipOutFolder") ){
     LogInfo << "Creating a .gz archive of \"" << outFolder << "\"" << std::endl;
     auto err = std::system( ("tar -czvf \"" + outFolder + ".tar.gz\" \"" + outFolder + "\"").c_str() );
-    LogThrowIf( err != 0, "Error while running the tar command." );
+    LogExitIf( err != 0, "Error while running the tar command." );
     LogInfo << "Removing created temp folder..." << std::endl;
     err = std::system( ("rm -r \"" + outFolder + "\"").c_str() );
-    LogThrowIf( err != 0, "Error while running the tar command." );
+    LogExitIf( err != 0, "Error while running the tar command." );
     LogInfo << "Archive writen under \"" << outFolder << ".tar.gz\"" << std::endl;
   }
 

--- a/src/CacheManager/src/CacheIndexedSums.cpp
+++ b/src/CacheManager/src/CacheIndexedSums.cpp
@@ -23,8 +23,8 @@ Cache::IndexedSums::IndexedSums(Cache::Weights::Results& inputs,
     : fEventWeights(inputs),
       fLowerClamp(-std::numeric_limits<double>::infinity()),
       fUpperClamp(std::numeric_limits<double>::infinity()) {
-  LogThrowIf((inputs.size()<1), "No bins to sum");
-  LogThrowIf((bins<1), "No bins to sum");
+  LogExitIf((inputs.size()<1), "No bins to sum");
+  LogExitIf((bins<1), "No bins to sum");
 
   LogInfo << "Cached IndexedSums -- bins reserved: "
           << bins
@@ -42,16 +42,16 @@ Cache::IndexedSums::IndexedSums(Cache::Weights::Results& inputs,
     // set.  The initial values are seldom changed, so they are not
     // pinned.
     fSums = std::make_unique<hemi::Array<double>>(bins,true);
-    LogThrowIf(not fSums, "Bad Sums Alloc");
+    LogExitIf(not fSums, "Bad Sums Alloc");
     fSums2 = std::make_unique<hemi::Array<double>>(bins,true);
-    LogThrowIf(not fSums2, "Bad Sums2 Alloc");
+    LogExitIf(not fSums2, "Bad Sums2 Alloc");
     fIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
-    LogThrowIf(not fIndexes, "Bad IndexesAlloc");
+    LogExitIf(not fIndexes, "Bad IndexesAlloc");
 
   }
   catch (...) {
     LogError << "Uncaught exception, so stopping" << std::endl;
-    LogThrow("Uncaught exception -- not enough memory available");
+    LogExit("Uncaught exception -- not enough memory available");
   }
 
   // Place the cache into a default state.
@@ -78,10 +78,10 @@ void Cache::IndexedSums::Reset() {
 }
 
 void Cache::IndexedSums::SetEventIndex(int event, int bin) {
-  LogThrowIf((event < 0), "Event index out of range");
-  LogThrowIf((fEventWeights.size() <= event), "Event index out of range");
-  LogThrowIf((bin<0), "Bin is out of range");
-  LogThrowIf((fSums->size() <= bin), "Bin is out of range");
+  LogExitIf((event < 0), "Event index out of range");
+  LogExitIf((fEventWeights.size() <= event), "Event index out of range");
+  LogExitIf((bin<0), "Bin is out of range");
+  LogExitIf((fSums->size() <= bin), "Bin is out of range");
   fIndexes->hostPtr()[event] = bin;
 }
 
@@ -94,28 +94,28 @@ void Cache::IndexedSums::SetMinimumEventWeight(double minimum) {
 }
 
 double Cache::IndexedSums::GetSum(int i) {
-  LogThrowIf(i<0, "Sum index out of range");
-  LogThrowIf((fSums->size() <= i), "Sum index out of range");
+  LogExitIf(i<0, "Sum index out of range");
+  LogExitIf((fSums->size() <= i), "Sum index out of range");
   // This odd ordering is to make sure the thread-safe hostPtr update
   // finishes before the sum is set to be valid.  The use of isnan is to
   // make sure that the optimizer doesn't reorder the statements.
   double value = fSums->hostPtr()[i];
   if (not fSumsApplied) fSumsValid = false;
   else if (not std::isnan(value)) fSumsValid = true;
-  else LogThrow("Cache::IndexedSums sum is nan");
+  else LogExit("Cache::IndexedSums sum is nan");
   return value;
 }
 
 double Cache::IndexedSums::GetSum2(int i) {
-  LogThrowIf((i<0), "Sum2 index out of range");
-  LogThrowIf((fSums2->size()<= i), "Sum2 index out of range");
+  LogExitIf((i<0), "Sum2 index out of range");
+  LogExitIf((fSums2->size()<= i), "Sum2 index out of range");
   // This odd ordering is to make sure the thread-safe hostPtr update
   // finishes before the sum is set to be valid.  The use of isfinite is to
   // make sure that the optimizer doesn't reorder the statements.
   double value = fSums2->hostPtr()[i];
   if (not fSumsApplied) fSumsValid = false;
   else if (not std::isnan(value)) fSumsValid = true;
-  else LogThrow("Cache::IndexedSums sum2 is nan");
+  else LogExit("Cache::IndexedSums sum2 is nan");
   return value;
 }
 

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -63,18 +63,18 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
   fTotalBytes = 0;
   try {
     fParameterCache = std::make_unique<Cache::Parameters>(config.parameters);
-    LogThrowIf(not fParameterCache, "Bad ParameterCache alloc");
+    LogExitIf(not fParameterCache, "Bad ParameterCache alloc");
     fTotalBytes += fParameterCache->GetResidentMemory();
 
     fWeightsCache = std::make_unique<Cache::Weights>(config.events);
-    LogThrowIf(not fWeightsCache, "Bad WeightsCache alloc");
+    LogExitIf(not fWeightsCache, "Bad WeightsCache alloc");
     fTotalBytes += fWeightsCache->GetResidentMemory();
 
     fNormalizations = std::make_unique<Cache::Weight::Normalization>(
         fWeightsCache->GetWeights(),
         fParameterCache->GetParameters(),
         config.norms);
-    LogThrowIf(not fNormalizations, "Bad Normalizations alloc");
+    LogExitIf(not fNormalizations, "Bad Normalizations alloc");
     fWeightsCache->AddWeightCalculator(fNormalizations.get());
     fTotalBytes += fNormalizations->GetResidentMemory();
 
@@ -85,7 +85,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetUpperClamps(),
         config.compactSplines, config.compactPoints,
         config.spaceOption);
-    LogThrowIf(not fCompactSplines, "Bad CompactSplines alloc");
+    LogExitIf(not fCompactSplines, "Bad CompactSplines alloc");
     fWeightsCache->AddWeightCalculator(fCompactSplines.get());
     fTotalBytes += fCompactSplines->GetResidentMemory();
 
@@ -96,7 +96,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetUpperClamps(),
         config.monotonicSplines, config.monotonicPoints,
         config.spaceOption);
-    LogThrowIf(not fMonotonicSplines, "Bad MonotonicSplines alloc");
+    LogExitIf(not fMonotonicSplines, "Bad MonotonicSplines alloc");
     fWeightsCache->AddWeightCalculator(fMonotonicSplines.get());
     fTotalBytes += fMonotonicSplines->GetResidentMemory();
 
@@ -107,7 +107,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetUpperClamps(),
         config.uniformSplines, config.uniformPoints,
         config.spaceOption);
-    LogThrowIf(not fUniformSplines, "Bad UniformSplines alloc");
+    LogExitIf(not fUniformSplines, "Bad UniformSplines alloc");
     fWeightsCache->AddWeightCalculator(fUniformSplines.get());
     fTotalBytes += fUniformSplines->GetResidentMemory();
 
@@ -118,7 +118,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetUpperClamps(),
         config.generalSplines, config.generalPoints,
         config.spaceOption);
-    LogThrowIf(not fGeneralSplines, "Bad GeneralSplines alloc");
+    LogExitIf(not fGeneralSplines, "Bad GeneralSplines alloc");
     fWeightsCache->AddWeightCalculator(fGeneralSplines.get());
     fTotalBytes += fGeneralSplines->GetResidentMemory();
 
@@ -128,7 +128,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetLowerClamps(),
         fParameterCache->GetUpperClamps(),
         config.graphs, config.graphPoints);
-    LogThrowIf(not fGraphs, "Bad Graphs alloc");
+    LogExitIf(not fGraphs, "Bad Graphs alloc");
     fWeightsCache->AddWeightCalculator(fGraphs.get());
     fTotalBytes += fGraphs->GetResidentMemory();
 
@@ -138,7 +138,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetLowerClamps(),
         fParameterCache->GetUpperClamps(),
         config.bilinear, config.bilinearPoints);
-    LogThrowIf(not fBilinear, "Bad Bilinear alloc");
+    LogExitIf(not fBilinear, "Bad Bilinear alloc");
     fWeightsCache->AddWeightCalculator(fBilinear.get());
     fTotalBytes += fBilinear->GetResidentMemory();
 
@@ -148,7 +148,7 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         fParameterCache->GetLowerClamps(),
         fParameterCache->GetUpperClamps(),
         config.bicubic, config.bicubicPoints);
-    LogThrowIf(not fBicubic, "Bad Bicubic alloc");
+    LogExitIf(not fBicubic, "Bad Bicubic alloc");
     fWeightsCache->AddWeightCalculator(fBicubic.get());
     fTotalBytes += fBicubic->GetResidentMemory();
 
@@ -158,20 +158,20 @@ Cache::Manager::Manager(const Cache::Manager::Configuration& config) {
         config.tabulated,
         config.tabulatedPoints,
         config.tables);
-    LogThrowIf(not fTabulated, "Bad Tabulated alloc");
+    LogExitIf(not fTabulated, "Bad Tabulated alloc");
     fWeightsCache->AddWeightCalculator(fTabulated.get());
     fTotalBytes += fTabulated->GetResidentMemory();
 
     fHistogramsCache = std::make_unique<Cache::HistogramSum>(
         fWeightsCache->GetWeights(),
         config.histBins);
-    LogThrowIf(not fHistogramsCache, "Bad HistogramsCache alloc");
+    LogExitIf(not fHistogramsCache, "Bad HistogramsCache alloc");
     fTotalBytes += fHistogramsCache->GetResidentMemory();
 
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   LogInfo << "Approximate cache manager size for"
@@ -194,7 +194,7 @@ bool Cache::Manager::Build() {
 
   if( fSampleSetPtr == nullptr or fEventDialCachePtr == nullptr ){
     LogError << "fSampleSetPtr or fEventDialCachePtr not set." << std::endl;
-    LogThrow("Can't Build()");
+    LogExit("Can't Build()");
   }
 
   LogInfo << "Build the internal caches " << std::endl;
@@ -217,7 +217,7 @@ bool Cache::Manager::Build() {
   std::map<std::string, int> useCount;
   for (EventDialCache::CacheEntry& elem : fEventDialCachePtr->getCache()) {
     if (elem.event->getIndices().bin < 0) {
-      LogThrow("Caching event that isn't used");
+      LogExit("Caching event that isn't used");
     }
     ++config.events;
     for( auto& dialResponseCache : elem.dialResponseCacheList) {
@@ -274,7 +274,7 @@ bool Cache::Manager::Build() {
       else if (dialType.find("Tabulated") == 0) {
         ++config.tabulated;
         Tabulated* tabDial = dynamic_cast<Tabulated*>(dial);
-        LogThrowIf(tabDial == nullptr, "Tabulated dial is not a Tabulated dial");
+        LogExitIf(tabDial == nullptr, "Tabulated dial is not a Tabulated dial");
         // Add a place holder for this table.  This will be filled
         // with the offset to the table when the weighting is built.
         config.tables[tabDial->getTable()] = 0;
@@ -292,7 +292,7 @@ bool Cache::Manager::Build() {
     LogError << "Dial creation errors: "
              << dialErrorCount
              << std::endl;
-    LogThrow("Unsupported dial type: Incomplete dial implementation");
+    LogExit("Unsupported dial type: Incomplete dial implementation");
   }
 
   // Finish filling the configuration for the tabulated dials
@@ -415,11 +415,11 @@ bool Cache::Manager::Build() {
     }
     try {
       fSingleton = new Manager(config);
-      LogThrowIf(not fSingleton, "CacheManager Not allocated");
+      LogExitIf(not fSingleton, "CacheManager Not allocated");
     }
     catch (...) {
       LogError << "Did not allocated cache manager" << std::endl;
-      LogThrow("Cache::Manager allocation error");
+      LogExit("Cache::Manager allocation error");
     }
   }
 
@@ -653,7 +653,7 @@ bool Cache::Manager::Update() {
       LogError << "Dial creation errors --"
                << " Unsupported dial types: " << dialErrorCount
                << std::endl;
-      LogThrow("Unsupported dial type: Incomplete dial implementation");
+      LogExit("Unsupported dial type: Incomplete dial implementation");
     }
 
     // Set the initial weight for the event.  This is done here since the
@@ -674,7 +674,7 @@ bool Cache::Manager::Update() {
     LogError << "Cache Manager -- expected Results: "
              << Cache::Manager::Get()->GetWeightsCache().GetResultCount()
              << std::endl;
-    LogThrow("Probable problem putting dials in cache");
+    LogExit("Probable problem putting dials in cache");
   }
 
   fSampleHistFillerList.clear();
@@ -709,7 +709,7 @@ bool Cache::Manager::Update() {
 
   if (Cache::Manager::Get()->GetHistogramsCache().GetSumCount()
       != nextHist) {
-    LogThrow("Histogram cells are missing");
+    LogExit("Histogram cells are missing");
   }
 
   // If the event weight cap has been set, then pass it along
@@ -733,7 +733,7 @@ bool Cache::Manager::Fill() {
   if (!cache) return false;
   if (fUpdateRequired) {
     LogError << "Fill while an update is required" << std::endl;
-    LogThrow("Fill while an update is required");
+    LogExit("Fill while an update is required");
   }
   LogTraceIf(GundamGlobals::isDebug() ) << "Cache::Manager::Fill -- Fill the GPU cache" << std::endl;
 #define DUMP_FILL_INPUT_PARAMETERS

--- a/src/CacheManager/src/CacheParameters.cpp
+++ b/src/CacheManager/src/CacheParameters.cpp
@@ -98,25 +98,25 @@ Cache::Parameters::Parameters(std::size_t parameters)
     fLowerMirror.reset(new std::vector<double>(
         GetParameterCount(),
         std::numeric_limits<double>::lowest()));
-    LogThrowIf(not fLowerMirror, "Bad LowerMirror alloc");
+    LogExitIf(not fLowerMirror, "Bad LowerMirror alloc");
     fUpperMirror.reset(new std::vector<double>(
         GetParameterCount(),
         std::numeric_limits<double>::max()));
-    LogThrowIf(not fUpperMirror, "Bad UpperMirror alloc");
+    LogExitIf(not fUpperMirror, "Bad UpperMirror alloc");
 
     // Get CPU/GPU memory for the parameter values.  The mirroring is done
     // to every entry, so its also done on the GPU.  The parameters are
     // copied every iteration, so pin the CPU memory into the page set.
     fParameters.reset(new hemi::Array<double>(GetParameterCount()));
-    LogThrowIf(not fParameters, "Bad Parameters alloc");
+    LogExitIf(not fParameters, "Bad Parameters alloc");
     fLowerClamp.reset(new hemi::Array<double>(GetParameterCount(),false));
-    LogThrowIf(not fLowerClamp, "Bad LowerClamp alloc");
+    LogExitIf(not fLowerClamp, "Bad LowerClamp alloc");
     fUpperClamp.reset(new hemi::Array<double>(GetParameterCount(),false));
-    LogThrowIf(not fUpperClamp, "Bad UpperClamp alloc");
+    LogExitIf(not fUpperClamp, "Bad UpperClamp alloc");
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -142,8 +142,8 @@ double Cache::Parameters::GetParameter(int parIdx) const {
 }
 
 void Cache::Parameters::SetParameter(int parIdx, double value) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   double lm = fLowerMirror->at(parIdx);
   double um = fUpperMirror->at(parIdx);
   // Mirror the input value at lm and um.
@@ -157,50 +157,50 @@ void Cache::Parameters::SetParameter(int parIdx, double value) {
 }
 
 double Cache::Parameters::GetLowerMirror(int parIdx) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   return fLowerMirror->at(parIdx);
 }
 
 void Cache::Parameters::SetLowerMirror(int parIdx, double value) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   fLowerMirror->at(parIdx) = value;
 }
 
 double Cache::Parameters::GetUpperMirror(int parIdx) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   return fUpperMirror->at(parIdx);
 }
 
 void Cache::Parameters::SetUpperMirror(int parIdx, double value) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   fUpperMirror->at(parIdx) = value;
 }
 
 double Cache::Parameters::GetLowerClamp(int parIdx) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   return fLowerClamp->hostPtr()[parIdx];
 }
 
 void Cache::Parameters::SetLowerClamp(int parIdx, double value) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   fLowerClamp->hostPtr()[parIdx] = value;
 }
 
 double Cache::Parameters::GetUpperClamp(int parIdx) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   return fUpperClamp->hostPtr()[parIdx];
 }
 
 void Cache::Parameters::SetUpperClamp(int parIdx, double value) {
-  LogThrowIf((parIdx < 0), "Parameter index out of range");
-  LogThrowIf((GetParameterCount() <= parIdx), "Parameter index out of range");
+  LogExitIf((parIdx < 0), "Parameter index out of range");
+  LogExitIf((GetParameterCount() <= parIdx), "Parameter index out of range");
   fUpperClamp->hostPtr()[parIdx] = value;
 }
 

--- a/src/CacheManager/src/CacheRecursiveSums.cpp
+++ b/src/CacheManager/src/CacheRecursiveSums.cpp
@@ -23,8 +23,8 @@ Cache::RecursiveSums::RecursiveSums(Cache::Weights::Results& inputs,
     : fEventWeights(inputs),
       fLowerClamp(-std::numeric_limits<double>::infinity()),
       fUpperClamp(std::numeric_limits<double>::infinity()) {
-  LogThrowIf((inputs.size()<1), "No bins to sum");
-  LogThrowIf((bins<1), "No bins to sum");
+  LogExitIf((inputs.size()<1), "No bins to sum");
+  LogExitIf((bins<1), "No bins to sum");
 
   LogInfo << "Cached RecursiveSums -- bins reserved: "
           << bins
@@ -47,24 +47,24 @@ Cache::RecursiveSums::RecursiveSums(Cache::Weights::Results& inputs,
     // set.  The initial values are seldom changed, so they are not
     // pinned.
     fSums = std::make_unique<hemi::Array<double>>(bins,true);
-    LogThrowIf(not fSums, "Bad Sums Alloc");
+    LogExitIf(not fSums, "Bad Sums Alloc");
     fSums2 = std::make_unique<hemi::Array<double>>(bins,true);
-    LogThrowIf(not fSums2, "Bad Sums2 Alloc");
+    LogExitIf(not fSums2, "Bad Sums2 Alloc");
 
     fIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
-    LogThrowIf(not fIndexes, "Bad Indexes Alloc");
+    LogExitIf(not fIndexes, "Bad Indexes Alloc");
     fBinOffsets = std::make_unique<hemi::Array<int>>(bins+1,false);
-    LogThrowIf(not fBinOffsets, "Bad BinOffsets Alloc");
+    LogExitIf(not fBinOffsets, "Bad BinOffsets Alloc");
     fEventIndexes = std::make_unique<hemi::Array<int>>(fEventWeights.size(),false);
-    LogThrowIf(not fEventIndexes,"Bad EventIndexes Alloc");
+    LogExitIf(not fEventIndexes,"Bad EventIndexes Alloc");
     fWorkBuffer = std::make_unique<hemi::Array<double>>(fEventWeights.size(),false);
-    LogThrowIf(not fWorkBuffer,"Bad WorkBuffer Alloc");
+    LogExitIf(not fWorkBuffer,"Bad WorkBuffer Alloc");
     fBinIndexes = std::make_unique<hemi::Array<short>>(fEventWeights.size(),false);
-    LogThrowIf(not fBinIndexes,"Bad BinIndexes Alloc");
+    LogExitIf(not fBinIndexes,"Bad BinIndexes Alloc");
   }
   catch (...) {
     LogError << "Uncaught exception, so stopping" << std::endl;
-    LogThrow("Uncaught exception -- not enough memory available");
+    LogExit("Uncaught exception -- not enough memory available");
   }
 
   // Place the cache into a default state.
@@ -127,7 +127,7 @@ void Cache::RecursiveSums::Initialize() {
     int bin = 0;
     int offset = 0;
     for ( auto& count : binEntryCountList) {
-      LogThrowIf(bin != count.binIdx, "Bin number mismatch: bin=" << bin << " / count->first=" << count.binIdx);
+      LogExitIf(bin != count.binIdx, "Bin number mismatch: bin=" << bin << " / count->first=" << count.binIdx);
       fBinOffsets->hostPtr()[bin] = offset;
       offset += count.entryCount;
       ++bin;
@@ -156,10 +156,10 @@ void Cache::RecursiveSums::Initialize() {
 }
 
 void Cache::RecursiveSums::SetEventIndex(int event, int bin) {
-  LogThrowIf((event < 0), "Event index out of range");
-  LogThrowIf((fEventWeights.size() <= event), "Event index out of range");
-  LogThrowIf((bin<0), "Bin is out of range");
-  LogThrowIf((fSums->size() <= bin), "Bin is out of range");
+  LogExitIf((event < 0), "Event index out of range");
+  LogExitIf((fEventWeights.size() <= event), "Event index out of range");
+  LogExitIf((bin<0), "Bin is out of range");
+  LogExitIf((fSums->size() <= bin), "Bin is out of range");
   fIndexes->hostPtr()[event] = bin;
 }
 
@@ -172,28 +172,28 @@ void Cache::RecursiveSums::SetMinimumEventWeight(double minimum) {
 }
 
 double Cache::RecursiveSums::GetSum(int i) {
-  LogThrowIf(i<0, "Sum index out of range");
-  LogThrowIf((fSums->size() <= i), "Sum index out of range");
+  LogExitIf(i<0, "Sum index out of range");
+  LogExitIf((fSums->size() <= i), "Sum index out of range");
   // This odd ordering is to make sure the thread-safe hostPtr update
   // finishes before the sum is set to be valid.  The use of isnan is to
   // make sure that the optimizer doesn't reorder the statements.
   double value = fSums->hostPtr()[i];
   if (not fSumsApplied) fSumsValid = false;
   else if (not std::isnan(value)) fSumsValid = true;
-  else LogThrow("Cache::RecursiveSums sum is nan");
+  else LogExit("Cache::RecursiveSums sum is nan");
   return value;
 }
 
 double Cache::RecursiveSums::GetSum2(int i) {
-  LogThrowIf((i<0), "Sum2 index out of range");
-  LogThrowIf((fSums2->size()<= i), "Sum2 index out of range");
+  LogExitIf((i<0), "Sum2 index out of range");
+  LogExitIf((fSums2->size()<= i), "Sum2 index out of range");
   // This odd ordering is to make sure the thread-safe hostPtr update
   // finishes before the sum is set to be valid.  The use of isfinite is to
   // make sure that the optimizer doesn't reorder the statements.
   double value = fSums2->hostPtr()[i];
   if (not fSumsApplied) fSumsValid = false;
   else if (not std::isnan(value)) fSumsValid = true;
-  else LogThrow("Cache::RecursiveSums sum2 is nan");
+  else LogExit("Cache::RecursiveSums sum2 is nan");
   return value;
 }
 

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -19,7 +19,7 @@ LoggerInit([]{ Logger::setUserHeaderStr("[Cache::Weights]"); });
 // The constructor
 Cache::Weights::Weights(std::size_t results)
     : fTotalBytes(0), fResultCount(results) {
-  LogThrowIf((fResultCount<1),"No results in weight cache");
+  LogExitIf((fResultCount<1),"No results in weight cache");
 
   LogInfo << "Cached Weights -- output results reserved: "
           << GetResultCount()
@@ -37,14 +37,14 @@ Cache::Weights::Weights(std::size_t results)
     // set.  The initial values are seldom changed, so they are not
     // pinned.
     fResults.reset(new hemi::Array<double>(GetResultCount(),true));
-    LogThrowIf(not fResults, "Bad Results alloc");
+    LogExitIf(not fResults, "Bad Results alloc");
     fInitialValues.reset(new hemi::Array<double>(GetResultCount(),false));
-    LogThrowIf(not fInitialValues, "Bad InitialValues alloc");
+    LogExitIf(not fInitialValues, "Bad InitialValues alloc");
 
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -64,15 +64,15 @@ void Cache::Weights::Reset() {
 }
 
 double Cache::Weights::GetResult(int i) {
-  LogThrowIf((i<0), "Index out of range");
-  LogThrowIf((GetResultCount() <= i), "Index out of range");
+  LogExitIf((i<0), "Index out of range");
+  LogExitIf((GetResultCount() <= i), "Index out of range");
   // This odd ordering is to make sure the thread-safe hostPtr update
   // finishes before the result is set to be valid.  The use of isnan is
   // to make sure that the optimizer doesn't reorder the statements.
   double value = fResults->hostPtr()[i];
   if (not fKernelApplied) fResultsValid = false;
   else if (not std::isnan(value)) fResultsValid = true;
-  else LogThrow("Cache::Weights result is nan");
+  else LogExit("Cache::Weights result is nan");
   return value;
 }
 
@@ -83,19 +83,19 @@ double Cache::Weights::GetResultFast(int i) {
   double value = fResults->hostPtr()[i];
   if (not fKernelApplied) fResultsValid = false;
   else if (not std::isnan(value)) fResultsValid = true;
-  else LogThrow("Cache::Weights result is nan");
+  else LogExit("Cache::Weights result is nan");
   return value;
 }
 
 void Cache::Weights::SetResult(int i, double v) {
-  LogThrowIf((i<0), "Index out of range");
-  LogThrowIf((GetResultCount() <= i), "Index out of range");
+  LogExitIf((i<0), "Index out of range");
+  LogExitIf((GetResultCount() <= i), "Index out of range");
   fResults->hostPtr()[i] = v;
 }
 
 double* Cache::Weights::GetResultPointer(int i) {
-  LogThrowIf((i<0), "Index out of range");
-  LogThrowIf((GetResultCount() <= i), "Index out of range");
+  LogExitIf((i<0), "Index out of range");
+  LogExitIf((GetResultCount() <= i), "Index out of range");
   return (fResults->hostPtr() + i);
 }
 
@@ -104,14 +104,14 @@ bool* Cache::Weights::GetResultValidPointer() {
 }
 
 double  Cache::Weights::GetInitialValue(int i) {
-  LogThrowIf((i<0), "Index out of range");
-  LogThrowIf((GetResultCount() <= i), "Index out of range");
+  LogExitIf((i<0), "Index out of range");
+  LogExitIf((GetResultCount() <= i), "Index out of range");
   return fInitialValues->hostPtr()[i];
 }
 
 void Cache::Weights::SetInitialValue(int i, double v) {
-  LogThrowIf((i<0), "Index out of range");
-  LogThrowIf((GetResultCount() <= i), "Index out of range");
+  LogExitIf((i<0), "Index out of range");
+  LogExitIf((GetResultCount() <= i), "Index out of range");
   fInitialValues->hostPtr()[i] = v;
 }
 

--- a/src/CacheManager/src/WeightBicubic.cpp
+++ b/src/CacheManager/src/WeightBicubic.cpp
@@ -51,23 +51,23 @@ Cache::Weight::Bicubic::Bicubic(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fResult.reset(new hemi::Array<int>(GetReserved(),false));
-    LogThrowIf(not fResult, "Bad Result alloc");
+    LogExitIf(not fResult, "Bad Result alloc");
     fParameter.reset(
         new hemi::Array<short>(2*GetReserved(),false));
-    LogThrowIf(not fParameter, "Bad SplineParameter alloc");
+    LogExitIf(not fParameter, "Bad SplineParameter alloc");
     fIndex.reset(new hemi::Array<int>(1+GetReserved(),false));
-    LogThrowIf(not fIndex, "Bad Index alloc");
+    LogExitIf(not fIndex, "Bad Index alloc");
 
     // Get the CPU/GPU memory for the spline knots.  This is copied once
     // during initialization so do not pin the CPU memory into the page
     // set.
     fData.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSpaceReserved(),false));
-    LogThrowIf(not fData, "Bad Data alloc");
+    LogExitIf(not fData, "Bad Data alloc");
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -85,49 +85,49 @@ void Cache::Weight::Bicubic::AddData(int resIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (par1Index < 0) {
     LogError << "Invalid parameter 1 index"
              << std::endl;
-    LogThrow("Negative parameter 1 index");
+    LogExit("Negative parameter 1 index");
   }
   if (fParameters.size() <= par1Index) {
     LogError << "Invalid parameter 1 index " << par1Index
              << std::endl;
-    LogThrow("Parameter 1 index out of bounds");
+    LogExit("Parameter 1 index out of bounds");
   }
   if (par2Index < 0) {
     LogError << "Invalid parameter 2 index"
              << std::endl;
-    LogThrow("Negative parameter 2 index");
+    LogExit("Negative parameter 2 index");
   }
   if (fParameters.size() <= par2Index) {
     LogError << "Invalid parameter 2 index " << par2Index
              << std::endl;
-    LogThrow("Parameter 2 index out of bounds");
+    LogExit("Parameter 2 index out of bounds");
   }
   if (splineData.size() < 11) {
     LogError << "Insufficient points in spline " << splineData.size()
              << std::endl;
-    LogThrow("Invalid number of spline points");
+    LogExit("Invalid number of spline points");
   }
 
   int newIndex = fUsed++;
   if (fUsed > fReserved) {
     LogError << "Not enough space reserved for splines"
              << std::endl;
-    LogThrow("Not enough space reserved for splines");
+    LogExit("Not enough space reserved for splines");
   }
   if (fSpaceUsed + splineData.size() > fSpaceReserved) {
     LogError << "Not enough space reserved for spline knots"
              << std::endl;
-    LogThrow("Not enough space reserved for spline knots");
+    LogExit("Not enough space reserved for spline knots");
   }
   fResult->hostPtr()[newIndex] = resIndex;
   fParameter->hostPtr()[2*newIndex] = par1Index;
@@ -138,7 +138,7 @@ void Cache::Weight::Bicubic::AddData(int resIndex,
     if (fSpaceUsed > fSpaceReserved) {
       LogError << "Not enough space reserved for spline knots"
                << std::endl;
-      LogThrow("Not enough space reserved for spline knots");
+      LogExit("Not enough space reserved for spline knots");
     }
   }
 }

--- a/src/CacheManager/src/WeightBilinear.cpp
+++ b/src/CacheManager/src/WeightBilinear.cpp
@@ -52,23 +52,23 @@ Cache::Weight::Bilinear::Bilinear(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fResult = std::make_unique<hemi::Array<int>>(GetReserved(),false);
-    LogThrowIf(not fResult, "Bad SplineResult alloc");
+    LogExitIf(not fResult, "Bad SplineResult alloc");
     fParameter = std::make_unique<hemi::Array<short>>(
         2*GetReserved(),false);
-    LogThrowIf(not fParameter, "Bad SplineParameter alloc");
+    LogExitIf(not fParameter, "Bad SplineParameter alloc");
     fIndex = std::make_unique<hemi::Array<int>>(1+GetReserved(),false);
-    LogThrowIf(not fIndex, "Bad SplineIndex alloc");
+    LogExitIf(not fIndex, "Bad SplineIndex alloc");
 
     // Get the CPU/GPU memory for the spline knots.  This is copied once
     // during initialization so do not pin the CPU memory into the page
     // set.
     fData = std::make_unique<hemi::Array<WEIGHT_BUFFER_FLOAT>>(
         GetSpaceReserved(),false);
-    LogThrowIf(not fData, "Bad SplineSpacealloc");
+    LogExitIf(not fData, "Bad SplineSpacealloc");
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -86,49 +86,49 @@ void Cache::Weight::Bilinear::AddData(int resIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (par1Index < 0) {
     LogError << "Invalid parameter 1 index"
              << std::endl;
-    LogThrow("Negative parameter 1 index");
+    LogExit("Negative parameter 1 index");
   }
   if (fParameters.size() <= par1Index) {
     LogError << "Invalid parameter 1 index " << par1Index
              << std::endl;
-    LogThrow("Parameter 1 index out of bounds");
+    LogExit("Parameter 1 index out of bounds");
   }
   if (par2Index < 0) {
     LogError << "Invalid parameter 2 index"
              << std::endl;
-    LogThrow("Negative parameter 2 index");
+    LogExit("Negative parameter 2 index");
   }
   if (fParameters.size() <= par2Index) {
     LogError << "Invalid parameter 2 index " << par2Index
              << std::endl;
-    LogThrow("Parameter 2 index out of bounds");
+    LogExit("Parameter 2 index out of bounds");
   }
   if (data.size() < 11) {
     LogError << "Insufficient points in spline " << data.size()
              << std::endl;
-    LogThrow("Invalid number of spline points");
+    LogExit("Invalid number of spline points");
   }
 
   int newIndex = fUsed++;
   if (fUsed > fReserved) {
     LogError << "Not enough space reserved for splines"
              << std::endl;
-    LogThrow("Not enough space reserved for splines");
+    LogExit("Not enough space reserved for splines");
   }
   if (fSpaceUsed + data.size() > fSpaceReserved) {
     LogError << "Not enough space reserved for spline knots"
              << std::endl;
-    LogThrow("Not enough space reserved for spline knots");
+    LogExit("Not enough space reserved for spline knots");
   }
   fResult->hostPtr()[newIndex] = resIndex;
   fParameter->hostPtr()[2*newIndex] = par1Index;
@@ -139,7 +139,7 @@ void Cache::Weight::Bilinear::AddData(int resIndex,
     if (fSpaceUsed > fSpaceReserved) {
       LogError << "Not enough space reserved for spline knots"
                << std::endl;
-      LogThrow("Not enough space reserved for spline knots");
+      LogExit("Not enough space reserved for spline knots");
     }
   }
 }

--- a/src/CacheManager/src/WeightCompactSpline.cpp
+++ b/src/CacheManager/src/WeightCompactSpline.cpp
@@ -42,7 +42,7 @@ Cache::Weight::CompactSpline::CompactSpline(
     fSplineSpaceReserved = 2*fSplinesReserved + fSplineSpaceReserved;
   }
   else {
-    LogThrowIf(spaceOption != "space",
+    LogExitIf(spaceOption != "space",
                "Invalid space option for compact splines");
   }
 
@@ -61,23 +61,23 @@ Cache::Weight::CompactSpline::CompactSpline(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fSplineResult.reset(new hemi::Array<int>(GetSplinesReserved(),false));
-    LogThrowIf(not fSplineResult, "Bad SplineResult alloc");
+    LogExitIf(not fSplineResult, "Bad SplineResult alloc");
     fSplineParameter.reset(
         new hemi::Array<short>(GetSplinesReserved(),false));
-    LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
+    LogExitIf(not fSplineParameter, "Bad SplineParameter alloc");
     fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
-    LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
+    LogExitIf(not fSplineIndex, "Bad SplineIndex alloc");
 
     // Get the CPU/GPU memory for the spline knots.  This is copied once
     // during initialization so do not pin the CPU memory into the page
     // set.
     fSplineSpace.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSplineSpaceReserved(),false));
-    LogThrowIf(not fSplineSpace, "Bad SplineSpace alloc");
+    LogExitIf(not fSplineSpace, "Bad SplineSpace alloc");
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -99,27 +99,27 @@ void Cache::Weight::CompactSpline::AddSpline(int resIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (parIndex < 0) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Negative parameter index");
+    LogExit("Negative parameter index");
   }
   if (fParameters.size() <= parIndex) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Parameter index out of bounds");
+    LogExit("Parameter index out of bounds");
   }
   if (splineData.size() < 4) {
     LogError << "Insufficient points in spline: " << splineData.size()
              << std::endl;
-    LogThrow("Invalid number of spline points");
+    LogExit("Invalid number of spline points");
   }
   int newIndex = fSplinesUsed++;
   if (fSplinesUsed > fSplinesReserved) {
@@ -127,14 +127,14 @@ void Cache::Weight::CompactSpline::AddSpline(int resIndex,
              << " Reserved: " << fSplinesReserved
              << " Used: " << fSplinesUsed
              << std::endl;
-    LogThrow("Not enough space reserved for splines");
+    LogExit("Not enough space reserved for splines");
   }
   fSplineResult->hostPtr()[newIndex] = resIndex;
   fSplineParameter->hostPtr()[newIndex] = parIndex;
   if (fSplineIndex->hostPtr()[newIndex] != fSplineSpaceUsed) {
     LogError << "Last spline knot index should be at old end of splines"
              << std::endl;
-    LogThrow("Problem with control indices");
+    LogExit("Problem with control indices");
   }
   int knotIndex = fSplineSpaceUsed;
   fSplineSpaceUsed += splineData.size();
@@ -143,7 +143,7 @@ void Cache::Weight::CompactSpline::AddSpline(int resIndex,
              << " Reserved: " << fSplineSpaceReserved
              << " Used: " << fSplineSpaceUsed
              << std::endl;
-    LogThrow("Not enough space reserved for spline knots");
+    LogExit("Not enough space reserved for spline knots");
   }
   fSplineIndex->hostPtr()[newIndex+1] = fSplineSpaceUsed;
   for (std::size_t i = 0; i<splineData.size(); ++i) {
@@ -179,34 +179,34 @@ void Cache::Weight::CompactSpline::SetSplineKnot(
 }
 
 int Cache::Weight::CompactSpline::GetSplineParameterIndex(int sIndex) {
-  LogThrowIf((sIndex < 0), "Spline index invalid");
-  LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
+  LogExitIf((sIndex < 0), "Spline index invalid");
+  LogExitIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
   return fSplineParameter->hostPtr()[sIndex];
 }
 
 double Cache::Weight::CompactSpline::GetSplineParameter(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
-  LogThrowIf((i<0), "Index out of bounds");
-  LogThrowIf((fParameters.size() <= i),"Index out of bounds");
+  LogExitIf((i<0), "Index out of bounds");
+  LogExitIf((fParameters.size() <= i),"Index out of bounds");
   return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::CompactSpline::GetSplineKnotCount(int sIndex) {
-  LogThrowIf((sIndex < 0), "Spline index invalid");
-  LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
+  LogExitIf((sIndex < 0), "Spline index invalid");
+  LogExitIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
   return fSplineIndex->hostPtr()[sIndex+1]-fSplineIndex->hostPtr()[sIndex]-2;
 }
 
 double Cache::Weight::CompactSpline::GetSplineLowerBound(int sIndex) {
-  LogThrowIf((sIndex < 0), "Spline index invalid");
-  LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
+  LogExitIf((sIndex < 0), "Spline index invalid");
+  LogExitIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
   int knotsIndex = fSplineIndex->hostPtr()[sIndex];
   return fSplineSpace->hostPtr()[knotsIndex];
 }
 
 double Cache::Weight::CompactSpline::GetSplineUpperBound(int sIndex) {
-  LogThrowIf((sIndex < 0), "Spline index invalid");
-  LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
+  LogExitIf((sIndex < 0), "Spline index invalid");
+  LogExitIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
   int knotCount = GetSplineKnotCount(sIndex);
   double lower = GetSplineLowerBound(sIndex);
   int knotsIndex = fSplineIndex->hostPtr()[sIndex];
@@ -216,29 +216,29 @@ double Cache::Weight::CompactSpline::GetSplineUpperBound(int sIndex) {
 
 double Cache::Weight::CompactSpline::GetSplineLowerClamp(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
-  LogThrowIf((i<0),
+  LogExitIf((i<0),
              "Spline lower clamp index out of bounds");
-  LogThrowIf((fLowerClamp.size() <= i),
+  LogExitIf((fLowerClamp.size() <= i),
              "Spline lower clamp index out of bounds");
   return fLowerClamp.hostPtr()[i];
 }
 
 double Cache::Weight::CompactSpline::GetSplineUpperClamp(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
-  LogThrowIf((i<0),
+  LogExitIf((i<0),
              "Spline upper clamp index out of bounds");
-  LogThrowIf((fUpperClamp.size() <= i),
+  LogExitIf((fUpperClamp.size() <= i),
              "Spline upper clamp index out of bounds");
   return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::CompactSpline::GetSplineKnot(int sIndex, int knot) {
-  LogThrowIf((sIndex < 0),"Spline index invalid");
-  LogThrowIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
+  LogExitIf((sIndex < 0),"Spline index invalid");
+  LogExitIf((GetSplinesUsed() <= sIndex), "Spline index invalid");
   int knotsIndex = fSplineIndex->hostPtr()[sIndex];
   int count = GetSplineKnotCount(sIndex);
-  LogThrowIf((knot < 0), "Knot index invalid");
-  LogThrowIf((count <= knot), "Knot index invalid");
+  LogExitIf((knot < 0), "Knot index invalid");
+  LogExitIf((count <= knot), "Knot index invalid");
   return fSplineSpace->hostPtr()[knotsIndex+2+knot];
 }
 

--- a/src/CacheManager/src/WeightGraph.cpp
+++ b/src/CacheManager/src/WeightGraph.cpp
@@ -52,23 +52,23 @@ Cache::Weight::Graph::Graph(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fGraphResult.reset(new hemi::Array<int>(GetGraphsReserved(),false));
-    LogThrowIf(not fGraphResult, "GraphResult not allocated");
+    LogExitIf(not fGraphResult, "GraphResult not allocated");
     fGraphParameter.reset(
         new hemi::Array<short>(GetGraphsReserved(),false));
-    LogThrowIf(not fGraphParameter, "GraphParameter not allocated");
+    LogExitIf(not fGraphParameter, "GraphParameter not allocated");
     fGraphIndex.reset(new hemi::Array<int>(1+GetGraphsReserved(),false));
-    LogThrowIf(not fGraphIndex, "GraphIndex not allocated");
+    LogExitIf(not fGraphIndex, "GraphIndex not allocated");
 
     // Get the CPU/GPU memory for the graph space.  This is copied once
     // during initialization so do not pin the CPU memory into the page
     // set.
     fGraphSpace.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetGraphSpaceReserved(),false));
-    LogThrowIf(not fGraphSpace, "GraphSpace not allocated");
+    LogExitIf(not fGraphSpace, "GraphSpace not allocated");
   }
   catch (...) {
     LogError << "Uncaught exception in WeightGraph" << std::endl;
-    LogThrow("WeightGraph -- uncaught exception");
+    LogExit("WeightGraph -- uncaught exception");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -85,54 +85,54 @@ void Cache::Weight::Graph::AddGraph(int resIndex, int parIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (parIndex < 0) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Negative parameter index");
+    LogExit("Negative parameter index");
   }
   if (fParameters.size() <= parIndex) {
     LogError << "Invalid parameter index " << parIndex
              << std::endl;
-    LogThrow("Parameter index out of bounds");
+    LogExit("Parameter index out of bounds");
   }
   if (graphData.size() < 2) {
     LogError << "Insufficient points in graph " << graphData.size()
              << std::endl;
-    LogThrow("Invalid number of graph points");
+    LogExit("Invalid number of graph points");
   }
   int knots = (graphData.size())/2;
   if (15 < knots) {
     LogError << "Up to 15 knots supported by Graph " << knots
              << std::endl;
-    LogThrow("Invalid number of graph points");
+    LogExit("Invalid number of graph points");
   }
 
   int newIndex = fGraphsUsed++;
   if (fGraphsUsed > fGraphsReserved) {
     LogError << "Not enough space reserved for graphs"
              << std::endl;
-    LogThrow("Not enough space reserved for graphs");
+    LogExit("Not enough space reserved for graphs");
   }
   fGraphResult->hostPtr()[newIndex] = resIndex;
   fGraphParameter->hostPtr()[newIndex] = parIndex;
   if (fGraphIndex->hostPtr()[newIndex] != fGraphSpaceUsed) {
     LogError << "Last graph knot index should be at old end of graphs"
              << std::endl;
-    LogThrow("Problem with control indices");
+    LogExit("Problem with control indices");
   }
   int knotIndex = fGraphSpaceUsed;
   fGraphSpaceUsed += graphData.size();
   if (fGraphSpaceUsed > fGraphSpaceReserved) {
     LogError << "Not enough space reserved for graph space"
              << std::endl;
-    LogThrow("Not enough space reserved for graph space");
+    LogExit("Not enough space reserved for graph space");
   }
   fGraphIndex->hostPtr()[newIndex+1] = fGraphSpaceUsed;
   for (std::size_t i = 0; i<graphData.size(); ++i) {
@@ -143,10 +143,10 @@ void Cache::Weight::Graph::AddGraph(int resIndex, int parIndex,
 
 int Cache::Weight::Graph::GetGraphParameterIndex(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   return fGraphParameter->hostPtr()[sIndex];
 }
@@ -154,20 +154,20 @@ int Cache::Weight::Graph::GetGraphParameterIndex(int sIndex) {
 double Cache::Weight::Graph::GetGraphParameter(int sIndex) {
   int i = GetGraphParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Graph parameter index out of bounds");
+    LogExit("Graph parameter index out of bounds");
   }
   if (fParameters.size() <= i) {
-    LogThrow("Graph parameter index out of bounds");
+    LogExit("Graph parameter index out of bounds");
   }
   return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::Graph::GetGraphKnotCount(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   int k = fGraphIndex->hostPtr()[sIndex+1]-fGraphIndex->hostPtr()[sIndex];
   return k/2;
@@ -175,10 +175,10 @@ int Cache::Weight::Graph::GetGraphKnotCount(int sIndex) {
 
 double Cache::Weight::Graph::GetGraphLowerBound(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   int spaceIndex = fGraphIndex->hostPtr()[sIndex];
   return fGraphSpace->hostPtr()[spaceIndex];
@@ -186,10 +186,10 @@ double Cache::Weight::Graph::GetGraphLowerBound(int sIndex) {
 
 double Cache::Weight::Graph::GetGraphUpperBound(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   int knotCount = GetGraphKnotCount(sIndex);
   double lower = GetGraphLowerBound(sIndex);
@@ -201,10 +201,10 @@ double Cache::Weight::Graph::GetGraphUpperBound(int sIndex) {
 double Cache::Weight::Graph::GetGraphLowerClamp(int sIndex) {
   int i = GetGraphParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Graph lower clamp index out of bounds");
+    LogExit("Graph lower clamp index out of bounds");
   }
   if (fLowerClamp.size() <= i) {
-    LogThrow("Graph lower clamp index out of bounds");
+    LogExit("Graph lower clamp index out of bounds");
   }
   return fLowerClamp.hostPtr()[i];
 }
@@ -212,46 +212,46 @@ double Cache::Weight::Graph::GetGraphLowerClamp(int sIndex) {
 double Cache::Weight::Graph::GetGraphUpperClamp(int sIndex) {
   int i = GetGraphParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Graph upper clamp index out of bounds");
+    LogExit("Graph upper clamp index out of bounds");
   }
   if (fUpperClamp.size() <= i) {
-    LogThrow("Graph upper clamp index out of bounds");
+    LogExit("Graph upper clamp index out of bounds");
   }
   return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::Graph::GetGraphKnotValue(int sIndex, int knot) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   int spaceIndex = fGraphIndex->hostPtr()[sIndex];
   int count = GetGraphKnotCount(sIndex);
   if (knot < 0) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   if (count <= knot) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   return fGraphSpace->hostPtr()[spaceIndex+2+2*knot];
 }
 
 double Cache::Weight::Graph::GetGraphKnotPlace(int sIndex, int knot) {
   if (sIndex < 0) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   if (GetGraphsUsed() <= sIndex) {
-    LogThrow("Graph index invalid");
+    LogExit("Graph index invalid");
   }
   int spaceIndex = fGraphIndex->hostPtr()[sIndex];
   int count = GetGraphKnotCount(sIndex);
   if (knot < 0) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   if (count <= knot) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   return fGraphSpace->hostPtr()[spaceIndex+2+2*knot+1];
 }

--- a/src/CacheManager/src/WeightMonotonicSpline.cpp
+++ b/src/CacheManager/src/WeightMonotonicSpline.cpp
@@ -42,7 +42,7 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
     fSplineSpaceReserved = 2*fSplinesReserved + fSplineSpaceReserved;
   }
   else {
-    LogThrowIf(spaceOption != "space",
+    LogExitIf(spaceOption != "space",
                "Invalid space option for compact splines");
   }
 
@@ -61,23 +61,23 @@ Cache::Weight::MonotonicSpline::MonotonicSpline(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fSplineResult.reset(new hemi::Array<int>(GetSplinesReserved(),false));
-    LogThrowIf(not fSplineResult, "Bad SplineResult alloc");
+    LogExitIf(not fSplineResult, "Bad SplineResult alloc");
     fSplineParameter.reset(
         new hemi::Array<short>(GetSplinesReserved(),false));
-    LogThrowIf(not fSplineParameter, "Bad SplineParameter alloc");
+    LogExitIf(not fSplineParameter, "Bad SplineParameter alloc");
     fSplineIndex.reset(new hemi::Array<int>(1+GetSplinesReserved(),false));
-    LogThrowIf(not fSplineIndex, "Bad SplineIndex alloc");
+    LogExitIf(not fSplineIndex, "Bad SplineIndex alloc");
 
     // Get the CPU/GPU memory for the spline knots.  This is copied once
     // during initialization so do not pin the CPU memory into the page
     // set.
     fSplineSpace.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetSplineSpaceReserved(),false));
-    LogThrowIf(not fSplineSpace, "Bad SplineSpace alloc");
+    LogExitIf(not fSplineSpace, "Bad SplineSpace alloc");
   }
   catch (...) {
     LogError << "Uncaught exception in WeightGraph" << std::endl;
-    LogThrow("WeightGraph -- uncaught exception");
+    LogExit("WeightGraph -- uncaught exception");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -99,28 +99,28 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (parIndex < 0) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Negative parameter index");
+    LogExit("Negative parameter index");
   }
   if (fParameters.size() <= parIndex) {
     LogError << "Invalid parameter index: " << parIndex
              << " out of " << fParameters.size()
              << std::endl;
-    LogThrow("Parameter index out of bounds");
+    LogExit("Parameter index out of bounds");
   }
   if (splineData.size() < 5) {
     LogError << "Insufficient points in spline: " << splineData.size()
              << std::endl;
-    LogThrow("Invalid number of spline points");
+    LogExit("Invalid number of spline points");
   }
   int newIndex = fSplinesUsed++;
   if (fSplinesUsed > fSplinesReserved) {
@@ -128,14 +128,14 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
              << " Reserved: " << fSplinesReserved
              << " Used: " << fSplinesUsed
              << std::endl;
-    LogThrow("Not enough space reserved for splines");
+    LogExit("Not enough space reserved for splines");
   }
   fSplineResult->hostPtr()[newIndex] = resIndex;
   fSplineParameter->hostPtr()[newIndex] = parIndex;
   if (fSplineIndex->hostPtr()[newIndex] != fSplineSpaceUsed) {
     LogError << "Last spline knot index should be at old end of splines"
              << std::endl;
-    LogThrow("Problem with control indices");
+    LogExit("Problem with control indices");
   }
   int knotIndex = fSplineSpaceUsed;
   fSplineSpaceUsed += splineData.size();
@@ -144,7 +144,7 @@ void Cache::Weight::MonotonicSpline::AddSpline(int resIndex,
              << " Reserved: " << fSplineSpaceReserved
              << " Used: " << fSplineSpaceUsed
              << std::endl;
-    LogThrow("Not enough space reserved for spline knots");
+    LogExit("Not enough space reserved for spline knots");
   }
   fSplineIndex->hostPtr()[newIndex+1] = fSplineSpaceUsed;
   for (std::size_t i = 0; i<splineData.size(); ++i) {
@@ -181,10 +181,10 @@ void Cache::Weight::MonotonicSpline::SetSplineKnot(
 
 int Cache::Weight::MonotonicSpline::GetSplineParameterIndex(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   if (GetSplinesUsed() <= sIndex) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   return fSplineParameter->hostPtr()[sIndex];
 }
@@ -192,30 +192,30 @@ int Cache::Weight::MonotonicSpline::GetSplineParameterIndex(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineParameter(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Spline parameter index out of bounds");
+    LogExit("Spline parameter index out of bounds");
   }
   if (fParameters.size() <= i) {
-    LogThrow("Spline parameter index out of bounds");
+    LogExit("Spline parameter index out of bounds");
   }
   return fParameters.hostPtr()[i];
 }
 
 int Cache::Weight::MonotonicSpline::GetSplineKnotCount(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   if (GetSplinesUsed() <= sIndex) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   return fSplineIndex->hostPtr()[sIndex+1]-fSplineIndex->hostPtr()[sIndex]-2;
 }
 
 double Cache::Weight::MonotonicSpline::GetSplineLowerBound(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   if (GetSplinesUsed() <= sIndex) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   int knotsIndex = fSplineIndex->hostPtr()[sIndex];
   return fSplineSpace->hostPtr()[knotsIndex];
@@ -223,10 +223,10 @@ double Cache::Weight::MonotonicSpline::GetSplineLowerBound(int sIndex) {
 
 double Cache::Weight::MonotonicSpline::GetSplineUpperBound(int sIndex) {
   if (sIndex < 0) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   if (GetSplinesUsed() <= sIndex) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   int knotCount = GetSplineKnotCount(sIndex);
   double lower = GetSplineLowerBound(sIndex);
@@ -238,10 +238,10 @@ double Cache::Weight::MonotonicSpline::GetSplineUpperBound(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineLowerClamp(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Spline lower clamp index out of bounds");
+    LogExit("Spline lower clamp index out of bounds");
   }
   if (fLowerClamp.size() <= i) {
-    LogThrow("Spline lower clamp index out of bounds");
+    LogExit("Spline lower clamp index out of bounds");
   }
   return fLowerClamp.hostPtr()[i];
 }
@@ -249,28 +249,28 @@ double Cache::Weight::MonotonicSpline::GetSplineLowerClamp(int sIndex) {
 double Cache::Weight::MonotonicSpline::GetSplineUpperClamp(int sIndex) {
   int i = GetSplineParameterIndex(sIndex);
   if (i<0) {
-    LogThrow("Spline upper clamp index out of bounds");
+    LogExit("Spline upper clamp index out of bounds");
   }
   if (fUpperClamp.size() <= i) {
-    LogThrow("Spline upper clamp index out of bounds");
+    LogExit("Spline upper clamp index out of bounds");
   }
   return fUpperClamp.hostPtr()[i];
 }
 
 double Cache::Weight::MonotonicSpline::GetSplineKnot(int sIndex, int knot) {
   if (sIndex < 0) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   if (GetSplinesUsed() <= sIndex) {
-    LogThrow("Spline index invalid");
+    LogExit("Spline index invalid");
   }
   int knotsIndex = fSplineIndex->hostPtr()[sIndex];
   int count = GetSplineKnotCount(sIndex);
   if (knot < 0) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   if (count <= knot) {
-    LogThrow("Knot index invalid");
+    LogExit("Knot index invalid");
   }
   return fSplineSpace->hostPtr()[knotsIndex+2+knot];
 }

--- a/src/CacheManager/src/WeightNormalization.cpp
+++ b/src/CacheManager/src/WeightNormalization.cpp
@@ -39,13 +39,13 @@ Cache::Weight::Normalization::Normalization(
     // are copied once during initialization so do not pin the CPU memory
     // into the page set.
     fNormResult.reset(new hemi::Array<int>(GetNormsReserved(),false));
-    LogThrowIf(not fNormResult, "Bad NormResult Alloc");
+    LogExitIf(not fNormResult, "Bad NormResult Alloc");
     fNormParameter.reset(new hemi::Array<short>(GetNormsReserved(),false));
-    LogThrowIf(not fNormParameter, "Bad NormParameter Alloc");
+    LogExitIf(not fNormParameter, "Bad NormParameter Alloc");
   }
   catch (...) {
     LogError << "Uncaught exception, so stopping" << std::endl;
-    LogThrow("WeightNormalization -- Uncaught exception");
+    LogExit("WeightNormalization -- Uncaught exception");
   }
 
   Reset();
@@ -59,22 +59,22 @@ int Cache::Weight::Normalization::ReserveNorm(int resIndex, int parIndex) {
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
   if (parIndex < 0) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Negative parameter index");
+    LogExit("Negative parameter index");
   }
   if (fParameters.size() <= parIndex) {
     LogError << "Invalid parameter index"
              << std::endl;
-    LogThrow("Parameter index out of bounds");
+    LogExit("Parameter index out of bounds");
   }
   int newIndex = fNormsUsed++;
   if (fNormsUsed > fNormsReserved) {
@@ -82,7 +82,7 @@ int Cache::Weight::Normalization::ReserveNorm(int resIndex, int parIndex) {
              << " Reserved: " << fNormsReserved
              << " Requested: " << fNormsUsed
              << std::endl;
-    LogThrow("Not enough space reserved for results");
+    LogExit("Not enough space reserved for results");
   }
   fNormResult->hostPtr()[newIndex] = resIndex;
   fNormParameter->hostPtr()[newIndex] = parIndex;

--- a/src/CacheManager/src/WeightTabulated.cpp
+++ b/src/CacheManager/src/WeightTabulated.cpp
@@ -51,24 +51,24 @@ Cache::Weight::Tabulated::Tabulated(
     // copied once during initialization so do not pin the CPU memory into
     // the page set.
     fResult.reset(new hemi::Array<int>(GetReserved(),false));
-    LogThrowIf(not fResult, "Bad Result alloc");
+    LogExitIf(not fResult, "Bad Result alloc");
 
     fIndex.reset(new hemi::Array<int>(GetReserved(),false));
-    LogThrowIf(not fIndex, "Bad Index alloc");
+    LogExitIf(not fIndex, "Bad Index alloc");
 
     fFraction.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(GetReserved(),false));
-    LogThrowIf(not fFraction, "Bad Fraction alloc");
+    LogExitIf(not fFraction, "Bad Fraction alloc");
 
     // Get the CPU/GPU memory for the tables.  This is copied for each
     // evaluation.  The table is filled before this class is used.
     fData.reset(
         new hemi::Array<WEIGHT_BUFFER_FLOAT>(fDataReserved,false));
-    LogThrowIf(not fData, "Bad Table alloc");
+    LogExitIf(not fData, "Bad Table alloc");
   }
   catch (...) {
     LogError << "Failed to allocate memory, so stopping" << std::endl;
-    LogThrow("Not enough memory available");
+    LogExit("Not enough memory available");
   }
 
   // Initialize the caches.  Don't try to zero everything since the
@@ -88,31 +88,31 @@ void Cache::Weight::Tabulated::AddData(int resIndex,
   if (resIndex < 0) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Negative result index");
+    LogExit("Negative result index");
   }
   if (fWeights.size() <= resIndex) {
     LogError << "Invalid result index"
              << std::endl;
-    LogThrow("Result index out of bounds");
+    LogExit("Result index out of bounds");
   }
 
   int newIndex = fUsed++;
   if (fUsed > fReserved) {
     LogError << "Not enough space reserved for dials"
              << std::endl;
-    LogThrow("Not enough space reserved for dials");
+    LogExit("Not enough space reserved for dials");
   }
 
   auto tableEntry = fTables.find(table);
   if (tableEntry == fTables.end()) {
     LogError << "Request to create Tabulated weight for invalid table"
              << std::endl;
-    LogThrow("Invalid table request");
+    LogExit("Invalid table request");
   }
   int offset = tableEntry->second + index;
   if (fData->size() <= offset) {
     LogError << "Insufficent table space" << std::endl;
-    LogThrow("Insufficient table space");
+    LogExit("Insufficient table space");
   }
 
   fResult->hostPtr()[newIndex] = resIndex;

--- a/src/DatasetManager/include/DataDispenserUtils.h
+++ b/src/DatasetManager/include/DataDispenserUtils.h
@@ -47,7 +47,7 @@ struct DataDispenserParameters{
 
     SampleHist& addSampleHist(const std::string& name_){
       for( auto& sampleHist : sampleHistList ){
-        LogThrowIf(sampleHist.name == name_, "Duplicate sample hist with name: " << name_);
+        LogExitIf(sampleHist.name == name_, "Duplicate sample hist with name: " << name_);
       }
       sampleHistList.emplace_back();
       sampleHistList.back().name = name_;

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -41,7 +41,7 @@ void DataDispenser::configureImpl(){
   _threadPool_.setNThreads(GundamGlobals::getNbCpuThreads() );
 
   GenericToolbox::Json::fillValue(_config_, _parameters_.name, "name");
-  LogThrowIf(_parameters_.name.empty(), "Dataset name not set.");
+  LogExitIf(_parameters_.name.empty(), "Dataset name not set.");
 
   // histograms don't need other parameters
   if( GenericToolbox::Json::doKeyExist( _config_, "fromHistContent" ) ) {
@@ -121,8 +121,8 @@ void DataDispenser::initializeImpl(){
 
 void DataDispenser::load(Propagator& propagator_){
   LogWarning << "Loading dataset: " << getTitle() << std::endl;
-  LogThrowIf(not this->isInitialized(), "Can't load while not initialized.");
-  LogThrowIf(not propagator_.isInitialized(), "Can't load while propagator_ is not initialized.");
+  LogExitIf(not this->isInitialized(), "Can't load while not initialized.");
+  LogExitIf(not propagator_.isInitialized(), "Can't load while propagator_ is not initialized.");
 
   _cache_.clear();
   _cache_.propagatorPtr = &propagator_;
@@ -150,7 +150,7 @@ void DataDispenser::load(Propagator& propagator_){
 
   for( const auto& file: _parameters_.filePathList){
     std::string path = GenericToolbox::expandEnvironmentVariables(file);
-    LogThrowIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.treePath}), "Invalid file: " << path);
+    LogExitIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.treePath}), "Invalid file: " << path);
   }
 
   this->parseStringParameters();
@@ -187,7 +187,7 @@ void DataDispenser::parseStringParameters() {
 
   auto replaceToyIndexFct = [&](std::string& formula_){
     if( GenericToolbox::hasSubStr(formula_, "<I_TOY>") ){
-      LogThrowIf(_cache_.propagatorPtr->getIThrow()==-1, "<I_TOY> not set.");
+      LogExitIf(_cache_.propagatorPtr->getIThrow()==-1, "<I_TOY> not set.");
       GenericToolbox::replaceSubstringInsideInputString(formula_, "<I_TOY>", std::to_string(_cache_.propagatorPtr->getIThrow()));
     }
   };
@@ -238,7 +238,7 @@ void DataDispenser::doEventSelection(){
     auto treeChain{this->openChain(true)};
     nEntries = treeChain->GetEntries();
   }
-  LogThrowIf(nEntries == 0, "TChain is empty.");
+  LogExitIf(nEntries == 0, "TChain is empty.");
   LogInfo << "Will read " << nEntries << " event entries." << std::endl;
 
   _cache_.threadSelectionResults.resize(nThreads);
@@ -547,7 +547,7 @@ void DataDispenser::loadFromHistContent(){
   LogWarning << "Creating dummy PhysicsEvent entries for loading hist content" << std::endl;
 
   // non-trivial as we need to propagate systematics. Need to merge with the original data loader, but not straight forward?
-  LogThrowIf( _parameters_.useReweightEngine, "Hist loader not implemented for MC containers" );
+  LogExitIf( _parameters_.useReweightEngine, "Hist loader not implemented for MC containers" );
 
   // counting events
   _cache_.sampleNbOfEvents.resize(_cache_.samplesToFillList.size());
@@ -593,12 +593,12 @@ void DataDispenser::loadFromHistContent(){
     LogScopeIndent;
 
     auto* sampleHistDef = _parameters_.fromHistContent.getSampleHistPtr(sample->getName());
-    LogThrowIf(sampleHistDef== nullptr, "Could not find sample histogram: " << sample->getName());
+    LogExitIf(sampleHistDef== nullptr, "Could not find sample histogram: " << sample->getName());
 
     LogInfo << "Filling sample \"" << sample->getName() << "\" using hist with name: " << sampleHistDef->hist << std::endl;
 
     auto* hist = fHist->Get<THnD>( sampleHistDef->hist.c_str() );
-    LogThrowIf( hist == nullptr, "Could not find THnD \"" << sampleHistDef->hist << "\" within " << fHist->GetPath() );
+    LogExitIf( hist == nullptr, "Could not find THnD \"" << sampleHistDef->hist << "\" within " << fHist->GetPath() );
 
     int nBins = 1;
     for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
@@ -1002,7 +1002,7 @@ void DataDispenser::fillFunction(int iThread_){
           LogError << "Leaf: " << nominalWeightTreeFormula->GetLeaf(iLeaf)->GetName() << "[0] = " << nominalWeightTreeFormula->GetLeaf(iLeaf)->GetValue(0) << std::endl;
         }
 
-        LogThrow("Negative nominal weight");
+        LogExit("Negative nominal weight");
       }
       if( eventIndexingBuffer.getWeights().base == 0 ){
         continue;
@@ -1176,7 +1176,7 @@ void DataDispenser::fillFunction(int iThread_){
           }
         }
         else {
-          LogThrow("Invalid dial collection -- not a known dial type");
+          LogExit("Invalid dial collection -- not a known dial type");
         }
 
       } // dial collection loop

--- a/src/DatasetManager/src/DataDispenserUtils.cpp
+++ b/src/DatasetManager/src/DataDispenserUtils.cpp
@@ -46,11 +46,11 @@ void DataDispenserCache::clear(){
   varsToOverrideList.clear();
 }
 void DataDispenserCache::addVarRequestedForIndexing(const std::string& varName_) {
-  LogThrowIf(varName_.empty(), "no var name provided.");
+  LogExitIf(varName_.empty(), "no var name provided.");
   GenericToolbox::addIfNotInVector(varName_, this->varsRequestedForIndexing);
 }
 void DataDispenserCache::addVarRequestedForStorage(const std::string& varName_){
-  LogThrowIf(varName_.empty(), "no var name provided.");
+  LogExitIf(varName_.empty(), "no var name provided.");
   GenericToolbox::addIfNotInVector(varName_, this->varsRequestedForStorage);
   this->addVarRequestedForIndexing(varName_);
 }

--- a/src/DatasetManager/src/DatasetDefinition.cpp
+++ b/src/DatasetManager/src/DatasetDefinition.cpp
@@ -37,7 +37,7 @@ void DatasetDefinition::configureImpl() {
 
   for( auto& dataEntry : GenericToolbox::Json::fetchValue(_config_, "data", JsonType()) ){
     auto name = GenericToolbox::Json::fetchValue<std::string>(dataEntry, "name");
-    LogThrowIf( GenericToolbox::isIn(name, _dataDispenserDict_), "\"" << name << "\" already taken, please use another name." )
+    LogExitIf( GenericToolbox::isIn(name, _dataDispenserDict_), "\"" << name << "\" already taken, please use another name." )
 
     _dataDispenserDict_.emplace(name, DataDispenser(this));
     _dataDispenserDict_.at(name).getParameters().isData = true;
@@ -69,7 +69,7 @@ void DatasetDefinition::initializeImpl() {
   }
 
   if( not GenericToolbox::isIn(_selectedDataEntry_, _dataDispenserDict_) ){
-    LogThrow("selectedDataEntry could not be find in available data: "
+    LogExit("selectedDataEntry could not be find in available data: "
                  << GenericToolbox::toString(_dataDispenserDict_, [](const std::pair<std::string, DataDispenser>& elm){ return elm.first; })
                  << std::endl);
   }

--- a/src/DatasetManager/src/EventVarTransform.cpp
+++ b/src/DatasetManager/src/EventVarTransform.cpp
@@ -21,7 +21,7 @@ void EventVarTransform::configureImpl(){
 }
 void EventVarTransform::initializeImpl(){
   LogInfo << "Loading variable transformation: " << _name_ << std::endl;
-  LogThrowIf(_outputVariableName_.empty(), "output variable name not set.");
+  LogExitIf(_outputVariableName_.empty(), "output variable name not set.");
 }
 
 

--- a/src/DatasetManager/src/EventVarTransformLib.cpp
+++ b/src/DatasetManager/src/EventVarTransformLib.cpp
@@ -21,7 +21,7 @@ void EventVarTransformLib::configureImpl(){
 }
 void EventVarTransformLib::initializeImpl(){
   LogInfo << "Loading variable transformation: " << _name_ << std::endl;
-  LogThrowIf(_outputVariableName_.empty(), "output variable name not set.");
+  LogExitIf(_outputVariableName_.empty(), "output variable name not set.");
 
   this->reload();
 }
@@ -33,17 +33,17 @@ void EventVarTransformLib::reload(){
 
 void EventVarTransformLib::loadLibrary(){
   LogInfo << "Loading shared lib: " << _libraryFile_ << std::endl;
-  LogThrowIf(not GenericToolbox::isFile(_libraryFile_), "Could not find lib file: " << _libraryFile_ << std::endl << _messageOnError_);
+  LogExitIf(not GenericToolbox::isFile(_libraryFile_), "Could not find lib file: " << _libraryFile_ << std::endl << _messageOnError_);
   _loadedLibrary_ = dlopen(_libraryFile_.c_str(), RTLD_LAZY );
-  LogThrowIf(_loadedLibrary_ == nullptr, "Cannot open library: " << dlerror() << std::endl << _messageOnError_);
+  LogExitIf(_loadedLibrary_ == nullptr, "Cannot open library: " << dlerror() << std::endl << _messageOnError_);
   _evalVariable_ = (dlsym(_loadedLibrary_, "evalVariable"));
-  LogThrowIf(_evalVariable_ == nullptr, "Cannot open evalFcn" << std::endl << _messageOnError_);
+  LogExitIf(_evalVariable_ == nullptr, "Cannot open evalFcn" << std::endl << _messageOnError_);
 }
 void EventVarTransformLib::initInputFormulas(){
   _inputFormulaList_.clear();
   for( auto& inputFormulaStr : _inputFormulaStrList_ ){
     _inputFormulaList_.emplace_back( inputFormulaStr.c_str(), inputFormulaStr.c_str() );
-    LogThrowIf(not _inputFormulaList_.back().IsValid(), "\"" << inputFormulaStr << "\": could not be parsed as formula expression.")
+    LogExitIf(not _inputFormulaList_.back().IsValid(), "\"" << inputFormulaStr << "\": could not be parsed as formula expression.")
   }
   _inputBuffer_.resize(_inputFormulaList_.size(), std::nan("unset"));
 }

--- a/src/DatasetManager/src/LoaderUtils.cpp
+++ b/src/DatasetManager/src/LoaderUtils.cpp
@@ -10,8 +10,8 @@
 namespace LoaderUtils{
 
   void allocateMemory(Event& event_, const std::vector<const GenericToolbox::LeafForm*>& leafFormList_){
-    LogThrowIf( event_.getVariables().getNameListPtr() == nullptr, "var name list not set." );
-    LogThrowIf( event_.getVariables().getNameListPtr()->size() != leafFormList_.size(), "size mismatch." );
+    LogExitIf( event_.getVariables().getNameListPtr() == nullptr, "var name list not set." );
+    LogExitIf( event_.getVariables().getNameListPtr()->size() != leafFormList_.size(), "size mismatch." );
 
     auto nLeaf{event_.getVariables().getNameListPtr()->size()};
     for(size_t iVar = 0 ; iVar < nLeaf ; iVar++ ){
@@ -35,7 +35,7 @@ namespace LoaderUtils{
     event_.getIndices().bin = -1;
   }
   double evalFormula(const Event& event_, const TFormula* formulaPtr_, std::vector<int>* indexDict_){
-    LogThrowIf(formulaPtr_ == nullptr, GET_VAR_NAME_VALUE(formulaPtr_));
+    LogExitIf(formulaPtr_ == nullptr, GET_VAR_NAME_VALUE(formulaPtr_));
 
     std::vector<double> parArray(formulaPtr_->GetNpar());
     for( int iPar = 0 ; iPar < formulaPtr_->GetNpar() ; iPar++ ){

--- a/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/CompactSpline.cpp
@@ -53,7 +53,7 @@ void CompactSpline::buildDial(const std::vector<double>& v1,
                               const std::vector<double>& v2,
                               const std::vector<double>& v3,
                               const std::string& option_) {
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
 
   _splineBounds_.min = v1.front();
   _splineBounds_.max = v1.back();
@@ -104,7 +104,7 @@ void CompactSpline::buildDial(const std::vector<double>& v1,
                 << " CompactSpline: Invalid inputs" << std::endl;
       std::cerr << "ERROR " << __FILE__ << "(" << __LINE__ << "): "
                 << " CompactSpline: Invalid inputs -- terminating" << std::endl;
-      LogThrow("CompactSpline with invalid inputs");
+      LogExit("CompactSpline with invalid inputs");
 #endif
   }
 
@@ -116,7 +116,7 @@ double CompactSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for CompactSpline");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for CompactSpline");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/GeneralSpline.cpp
@@ -50,7 +50,7 @@ void GeneralSpline::buildDial(const std::vector<double>& xPoints,
                               const std::vector<double>& yPoints,
                               const std::vector<double>& deriv,
                               const std::string& option_){
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
 
   _splineBounds_.min = xPoints.front();
   _splineBounds_.max = xPoints.back();

--- a/src/DialDictionary/DialDefinitions/src/Graph.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Graph.cpp
@@ -17,8 +17,8 @@ bool Graph::getAllowExtrapolation() const {
 }
 
 void Graph::buildDial(const TGraph &graph, const std::string& option_) {
-    LogThrowIf(_graph_.GetN() != 0, "Graph already set.");
-  LogThrowIf(graph.GetN() == 0, "Invalid input graph");
+    LogExitIf(_graph_.GetN() != 0, "Graph already set.");
+  LogExitIf(graph.GetN() == 0, "Invalid input graph");
   _graph_ = graph;
   _graph_.Sort();
 }
@@ -27,7 +27,7 @@ double Graph::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for Graph");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for Graph");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/LightGraph.cpp
+++ b/src/DialDictionary/DialDefinitions/src/LightGraph.cpp
@@ -19,12 +19,12 @@ bool LightGraph::getAllowExtrapolation() const {
 }
 
 void LightGraph::buildDial(const TGraph &grf, const std::string& option_) {
-  LogThrowIf(grf.GetN() == 0, "Invalid input graph");
+  LogExitIf(grf.GetN() == 0, "Invalid input graph");
   TGraph graph(grf);
   graph.Sort();
 
   int nPoints = graph.GetN();
-  LogThrowIf(nPoints>15, "Light graphs must have fewer than 15 points");
+  LogExitIf(nPoints>15, "Light graphs must have fewer than 15 points");
 
   _Data_.reserve(2*nPoints);
   _Data_.clear();
@@ -38,7 +38,7 @@ double LightGraph::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for LightGraph");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for LightGraph");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/MonotonicSpline.cpp
@@ -53,7 +53,7 @@ void MonotonicSpline::buildDial(const std::vector<double>& v1,
                                 const std::vector<double>& v2,
                                 const std::vector<double>& v3,
                                 const std::string& option_) {
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
 
   _splineBounds_.min = v1.front();
   _splineBounds_.max = v1.back();
@@ -104,7 +104,7 @@ void MonotonicSpline::buildDial(const std::vector<double>& v1,
                 << " MonotonicSpline: Invalid inputs" << std::endl;
       std::cerr << "ERROR " << __FILE__ << "(" << __LINE__ << "): "
                 << " MonotonicSpline: Invalid inputs -- terminating" << std::endl;
-      LogThrow("MonotonicSpline with invalid inputs");
+      LogExit("MonotonicSpline with invalid inputs");
 #endif
   }
 
@@ -116,7 +116,7 @@ double MonotonicSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for MonotonicSpline");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for MonotonicSpline");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/RootFormula.cpp
+++ b/src/DialDictionary/DialDefinitions/src/RootFormula.cpp
@@ -12,7 +12,7 @@ double RootFormula::evalResponse(const DialInputBuffer& input_) const {
 
 void RootFormula::setFormulaStr(const std::string& formulaStr_){
   _formula_ = TFormula(formulaStr_.c_str(), formulaStr_.c_str());
-  LogThrowIf(not _formula_.IsValid(), "\"" << formulaStr_ << "\": could not be parsed as formula expression.");
+  LogExitIf(not _formula_.IsValid(), "\"" << formulaStr_ << "\": could not be parsed as formula expression.");
 }
 
 std::string RootFormula::getSummary() const {

--- a/src/DialDictionary/DialDefinitions/src/SimpleSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/SimpleSpline.cpp
@@ -24,7 +24,7 @@ bool SimpleSpline::getAllowExtrapolation() const {
 }
 
 void SimpleSpline::buildDial(const TGraph& grf, const std::string& option_){
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
   TGraph graph_ = grf;
 
   // Copy the spline data into local storage.
@@ -90,10 +90,10 @@ void SimpleSpline::buildDial(const TGraph& grf, const std::string& option_){
 }
 
 void SimpleSpline::buildDial(const TSpline3& sp_, const std::string& option_) {
-  LogThrow("NOT IMPLEMENTED");
+  LogExit("NOT IMPLEMENTED");
 
 
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
 
 
 }
@@ -102,7 +102,7 @@ double SimpleSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for SimpleSpline");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for SimpleSpline");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/Spline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Spline.cpp
@@ -56,7 +56,7 @@ double Spline::evalResponse(const DialInputBuffer& input_) const {
   const double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for Spline");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for Spline");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialDefinitions/src/UniformSpline.cpp
+++ b/src/DialDictionary/DialDefinitions/src/UniformSpline.cpp
@@ -51,7 +51,7 @@ void UniformSpline::buildDial(const std::vector<double>& xPoints,
                               const std::vector<double>& yPoints,
                               const std::vector<double>& deriv,
                               const std::string& option_){
-  LogThrowIf(not _splineData_.empty(), "Spline data already set.");
+  LogExitIf(not _splineData_.empty(), "Spline data already set.");
 
   _splineBounds_.min = xPoints.front();
   _splineBounds_.max = xPoints.back();
@@ -67,7 +67,7 @@ void UniformSpline::buildDial(const std::vector<double>& xPoints,
   const double tolerance{std::sqrt(std::numeric_limits<float>::epsilon())};
   for (int i=0; i<xPoints.size()-1; ++i) {
       double d = std::abs(xPoints[i] - _splineData_[0] - i*_splineData_[1]);
-      LogThrowIf((d/_splineData_[1])>tolerance,
+      LogExitIf((d/_splineData_[1])>tolerance,
                  "UniformSplines require uniformly spaced knots");
   }
 
@@ -86,7 +86,7 @@ double UniformSpline::evalResponse(const DialInputBuffer& input_) const {
   double dialInput{input_.getInputBuffer()[0]};
 
 #ifndef NDEBUG
-  LogThrowIf(not std::isfinite(dialInput), "Invalid input for UniformSpline");
+  LogExitIf(not std::isfinite(dialInput), "Invalid input for UniformSpline");
 #endif
 
   if( not _allowExtrapolation_ ){

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -38,7 +38,7 @@ void DialCollection::configureImpl() {
   if( GenericToolbox::Json::doKeyExist(_config_, "dialInputList") ){
     auto dialInputList = GenericToolbox::Json::fetchValue<JsonType>(_config_, "dialInputList");
 
-    LogThrowIf(_supervisedParameterSetIndex_ == -1, "Can't initialize dialInputList without setting _supervisedParameterSetIndex_");
+    LogExitIf(_supervisedParameterSetIndex_ == -1, "Can't initialize dialInputList without setting _supervisedParameterSetIndex_");
 
     _dialInputBufferList_.emplace_back();
     _dialInputBufferList_.back().setParSetRef( _parameterSetListPtr_ );
@@ -51,7 +51,7 @@ void DialCollection::configureImpl() {
       if( GenericToolbox::Json::doKeyExist(dialInput, "name") ){
         auto parName = GenericToolbox::Json::fetchValue<std::string>(dialInput, "name");
         auto* parPtr{_parameterSetListPtr_->at( _supervisedParameterSetIndex_ ).getParameterPtr( parName )};
-        LogThrowIf(parPtr == nullptr, "Could not find parameter: " << parName);
+        LogExitIf(parPtr == nullptr, "Could not find parameter: " << parName);
         p.parIndex = parPtr->getParameterIndex();
       }
 
@@ -63,7 +63,7 @@ void DialCollection::configureImpl() {
 }
 
 void DialCollection::initializeImpl() {
-  LogThrowIf(_index_==-1, "Index not set.");
+  LogExitIf(_index_==-1, "Index not set.");
   this->setupDialInterfaceReferences();
 }
 
@@ -159,14 +159,14 @@ void DialCollection::updateInputBuffers(){
 }
 
 void DialCollection::setupDialInterfaceReferences(){
-  LogThrowIf(_supervisedParameterSetIndex_==-1, "par set index not set.");
-  LogThrowIf(_supervisedParameterSetIndex_>_parameterSetListPtr_->size(), "invalid selected parset index: " << _supervisedParameterSetIndex_);
+  LogExitIf(_supervisedParameterSetIndex_==-1, "par set index not set.");
+  LogExitIf(_supervisedParameterSetIndex_>_parameterSetListPtr_->size(), "invalid selected parset index: " << _supervisedParameterSetIndex_);
 
   // set it up is not already done
   if( _dialInputBufferList_.empty() ){
     if( _supervisedParameterIndex_ == -1 ){
       // one dial interface per parameter
-      LogThrowIf(_dialBaseList_.size() != _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size(),
+      LogExitIf(_dialBaseList_.size() != _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size(),
                  "Nb of dial base don't match the number of parameters of the selected set: nDials="
                      << _dialBaseList_.size() << " != " << "nPars="
                      << _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size()
@@ -221,7 +221,7 @@ void DialCollection::setupDialInterfaceReferences(){
       _dialInterfaceList_[iDial].setInputBufferRef( &_dialInputBufferList_[iDial] );
     }
     else{
-      LogThrow("DEV: size mismatch between input buffers and dial interfaces."
+      LogExit("DEV: size mismatch between input buffers and dial interfaces."
                    << std::endl << "interface = " << _dialInterfaceList_.size()
                    << std::endl << "input = " << _dialInputBufferList_.size()
       );
@@ -236,7 +236,7 @@ void DialCollection::setupDialInterfaceReferences(){
         _dialInterfaceList_[iDial].setDialBinRef( &_dialBinSet_.getBinList()[iDial] );
       }
       else{
-        LogThrow("DEV: size mismatch between bins and dial interfaces."
+        LogExit("DEV: size mismatch between bins and dial interfaces."
                      << std::endl << "interface = " << _dialInterfaceList_.size()
                      << std::endl << "bins = " << _dialBinSet_.getBinList().size()
         );
@@ -251,7 +251,7 @@ void DialCollection::setupDialInterfaceReferences(){
       _dialInterfaceList_[iDial].setResponseSupervisorRef( &_dialResponseSupervisorList_[iDial] );
     }
     else{
-      LogThrow("DEV: size mismatch between response supervisors and dial interfaces."
+      LogExit("DEV: size mismatch between response supervisors and dial interfaces."
                    << std::endl << "interface = " << _dialInterfaceList_.size()
                    << std::endl << "supervisor = " << _dialResponseSupervisorList_.size()
       );
@@ -290,7 +290,7 @@ void DialCollection::readGlobals(const JsonType &config_) {
           if (not allowedRanges.empty()) {
             std::vector<std::string> allowedRangesCond;
             for (auto &allowedRange: allowedRanges) {
-              LogThrowIf(allowedRange.min >= allowedRange.max,
+              LogExitIf(allowedRange.min >= allowedRange.max,
                          "Invalid range bounds: min(" << allowedRange.min << ") max(" << allowedRange.max << ")")
               std::stringstream condSs;
               condSs << "(" << expression << " >= " << allowedRange.min;
@@ -330,7 +330,7 @@ void DialCollection::readGlobals(const JsonType &config_) {
             if (not excludedRanges.empty()) {
               std::vector<std::string> excludedRangesCond;
               for (auto &excludedRange: excludedRanges) {
-                LogThrowIf(excludedRange.min >= excludedRange.max,
+                LogExitIf(excludedRange.min >= excludedRange.max,
                            "Invalid range bounds: min(" << excludedRange.min << ") max(" << excludedRange.max
                                                         << ")")
                 std::stringstream condSs;
@@ -357,14 +357,14 @@ void DialCollection::readGlobals(const JsonType &config_) {
           }
         }
 
-        LogThrowIf(ssCondEntry.str().empty(), "Could not parse condition entry: " << condEntry)
+        LogExitIf(ssCondEntry.str().empty(), "Could not parse condition entry: " << condEntry)
         conditionsList.emplace_back(ssCondEntry.str());
       } else {
-        LogThrow("Could not recognise condition entry: " << condEntry);
+        LogExit("Could not recognise condition entry: " << condEntry);
       }
     }
 
-    LogThrowIf(conditionsList.empty(), "No apply condition was recognised.")
+    LogExitIf(conditionsList.empty(), "No apply condition was recognised.")
     _applyConditionStr_ = "( ";
     _applyConditionStr_ += GenericToolbox::joinVectorString(conditionsList, " ) && ( ");
     _applyConditionStr_ += " )";
@@ -372,7 +372,7 @@ void DialCollection::readGlobals(const JsonType &config_) {
 
   if (not _applyConditionStr_.empty()) {
     _applyConditionFormula_ = std::make_shared<TFormula>("_applyConditionFormula_", _applyConditionStr_.c_str());
-    LogThrowIf(not _applyConditionFormula_->IsValid(),
+    LogExitIf(not _applyConditionFormula_->IsValid(),
                "\"" << _applyConditionStr_ << "\": could not be parsed as formula expression.")
   }
 
@@ -384,7 +384,7 @@ void DialCollection::readGlobals(const JsonType &config_) {
     _mirrorLowEdge_ = GenericToolbox::Json::fetchValue(config_, "mirrorLowEdge", _mirrorLowEdge_);
     _mirrorHighEdge_ = GenericToolbox::Json::fetchValue(config_, "mirrorHighEdge", _mirrorHighEdge_);
     _mirrorRange_ = _mirrorHighEdge_ - _mirrorLowEdge_;
-    LogThrowIf(_mirrorRange_ < 0, GET_VAR_NAME_VALUE(_mirrorHighEdge_) << " < " << GET_VAR_NAME_VALUE(_mirrorLowEdge_))
+    LogExitIf(_mirrorRange_ < 0, GET_VAR_NAME_VALUE(_mirrorHighEdge_) << " < " << GET_VAR_NAME_VALUE(_mirrorLowEdge_))
   }
 
   _allowDialExtrapolation_ = GenericToolbox::Json::fetchValue(config_, "allowDialExtrapolation", _allowDialExtrapolation_);
@@ -525,18 +525,18 @@ bool DialCollection::initializeDialsWithBinningFile(const JsonType& dialsDefinit
   // Get the filename for a file with the object array of dials (graphs)
   // that will be applied based on the binning.
   auto filePath = GenericToolbox::Json::fetchValue<std::string>(dialsDefinition, "dialsFilePath");
-  LogThrowIf(not GenericToolbox::doesTFileIsValid(filePath), "Could not open: " << filePath);
+  LogExitIf(not GenericToolbox::doesTFileIsValid(filePath), "Could not open: " << filePath);
   TFile* dialsTFile = TFile::Open(filePath.c_str());
-  LogThrowIf(dialsTFile==nullptr, "Could not open: " << filePath);
+  LogExitIf(dialsTFile==nullptr, "Could not open: " << filePath);
 
   if      ( GenericToolbox::Json::doKeyExist(dialsDefinition, "dialsList") ) {
     auto* dialsList = dialsTFile->Get<TObjArray>(GenericToolbox::Json::fetchValue<std::string>(dialsDefinition, "dialsList").c_str());
 
-    LogThrowIf(
+    LogExitIf(
         dialsList==nullptr,
         "Could not find dialsList: " << GenericToolbox::Json::fetchValue<std::string>(dialsDefinition, "dialsList")
     );
-    LogThrowIf(
+    LogExitIf(
         dialsList->GetEntries() != _dialBinSet_.getBinList().size(),
         this->getTitle() << ": Number of dials (" << dialsList->GetEntries()
                          << ") don't match the number of bins " << _dialBinSet_.getBinList().size()
@@ -584,7 +584,7 @@ bool DialCollection::initializeDialsWithBinningFile(const JsonType& dialsDefinit
     // be assigned to the events in DataDispenser.
     auto objPath = GenericToolbox::Json::fetchValue<std::string>(dialsDefinition, "dialsTreePath");
     auto* dialsTTree = (TTree*) dialsTFile->Get(objPath.c_str());
-    LogThrowIf(dialsTTree== nullptr, objPath << " within " << filePath << " could not be opened.")
+    LogExitIf(dialsTTree== nullptr, objPath << " within " << filePath << " could not be opened.")
 
     Int_t kinematicBin;
     TSpline3* splinePtr = nullptr;
@@ -717,14 +717,14 @@ bool DialCollection::initializeDialsWithDefinition() {
     // might be used to implement neutrino osillations).  It has a different
     // weight for each event.
     _isEventByEvent_ = true;
-    LogThrowIf(not initializeDialsWithTabulation(dialsDefinition),
+    LogExitIf(not initializeDialsWithTabulation(dialsDefinition),
                "Error initializing dials with tabulation");
   }
   else if( GenericToolbox::Json::doKeyExist(dialsDefinition, "binningFilePath") ) {
     // This dial collection is binned with different weights for each bin.
     // Create the dials here.
     _isEventByEvent_ = false;
-    LogThrowIf(not initializeDialsWithBinningFile(dialsDefinition),
+    LogExitIf(not initializeDialsWithBinningFile(dialsDefinition),
                "Error initializing dials with binning file");
   }
   else if (not _globalDialLeafName_.empty()) {
@@ -739,7 +739,7 @@ bool DialCollection::initializeDialsWithDefinition() {
     LogError << "  dialType:     " << getGlobalDialType() << std::endl;
     LogError << "  dialSubType:  " << getGlobalDialSubType() << std::endl;
     LogError << "  dialLeafName: " << getGlobalDialLeafName() << std::endl;
-    LogThrow("Invalid dial type");
+    LogExit("Invalid dial type");
   }
 
   _dialResponseSupervisorList_.emplace_back();
@@ -755,7 +755,7 @@ bool DialCollection::initializeDialsWithDefinition() {
 
 JsonType DialCollection::fetchDialsDefinition(const JsonType &definitionsList_) {
   auto* parSetPtr = this->getSupervisedParameterSet();
-  LogThrowIf(parSetPtr == nullptr, "Can't fetch dial definition of parameter: par ref not set.");
+  LogExitIf(parSetPtr == nullptr, "Can't fetch dial definition of parameter: par ref not set.");
   auto* par = &parSetPtr->getParameterList()[_supervisedParameterIndex_];
   for(size_t iDial = 0 ; iDial < definitionsList_.size() ; iDial++ ){
     if( par->getName().empty() ){

--- a/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
@@ -18,7 +18,7 @@ void DialInputBuffer::invalidateBuffers(){
 }
 
 void DialInputBuffer::initialise(){
-  LogThrowIf(_parSetListPtr_ == nullptr, "ParameterSet list pointer not set.");
+  LogExitIf(_parSetListPtr_ == nullptr, "ParameterSet list pointer not set.");
 
   // the size won't change anymore
   _inputParameterReferenceList_.shrink_to_fit();
@@ -31,14 +31,14 @@ void DialInputBuffer::initialise(){
 
   // sanity checks
   for( int iInput = 0 ; iInput < _inputArraySize_ ; iInput++ ){
-    LogThrowIf(_inputParameterReferenceList_[iInput].parSetIndex < 0,
+    LogExitIf(_inputParameterReferenceList_[iInput].parSetIndex < 0,
                "Parameter set index invalid: " << _inputParameterReferenceList_[iInput].parSetIndex);
-    LogThrowIf(_inputParameterReferenceList_[iInput].parSetIndex >= _parSetListPtr_->size(),
+    LogExitIf(_inputParameterReferenceList_[iInput].parSetIndex >= _parSetListPtr_->size(),
                "Parameter set index invalid: " << _inputParameterReferenceList_[iInput].parSetIndex);
 
-    LogThrowIf(_inputParameterReferenceList_[iInput].parIndex < 0,
+    LogExitIf(_inputParameterReferenceList_[iInput].parIndex < 0,
                "Parameter index invalid: " << _inputParameterReferenceList_[iInput].parIndex);
-    LogThrowIf(_inputParameterReferenceList_[iInput].parIndex >= getParameterSet(iInput).getParameterList().size(),
+    LogExitIf(_inputParameterReferenceList_[iInput].parIndex >= getParameterSet(iInput).getParameterList().size(),
                "Parameter index invalid: " << _inputParameterReferenceList_[iInput].parIndex);
   }
 
@@ -73,7 +73,7 @@ void DialInputBuffer::update(){
       tempBuffer += inputRef.mirrorEdges.minValue;
     }
     if( std::isnan(tempBuffer) ){
-        // LogThrowIf is broken, but OK for real error traps, but this is
+        // LogExitIf is broken, but OK for real error traps, but this is
         // checking user input it's critical that the error message is
         // properly formated so print an error, a backtrace, and then exit.
         LogError << "NaN while evaluating input buffer of "
@@ -91,7 +91,7 @@ void DialInputBuffer::update(){
   }
 }
 void DialInputBuffer::addParameterReference( const ParameterReference& parReference_){
-  LogThrowIf(_isInitialized_, "Can't add parameter index while initialized.");
+  LogExitIf(_isInitialized_, "Can't add parameter index while initialized.");
   _inputParameterReferenceList_.emplace_back(parReference_);
   auto& parRef = _inputParameterReferenceList_.back();
   parRef.bufferIndex = int(_inputParameterReferenceList_.size())-1;

--- a/src/DialDictionary/DialEngine/src/EventDialCache.cpp
+++ b/src/DialDictionary/DialEngine/src/EventDialCache.cpp
@@ -50,7 +50,7 @@ void EventDialCache::buildReferenceCache( SampleSet& sampleSet_, std::vector<Dia
             return false;
           });
 
-      LogThrowIf(
+      LogExitIf(
           sampleIndexCacheList[iSample].size() != sample.getEventList().size(),
           std::endl << "MISMATCH cache and event list for sample: #" << sample.getIndex() << " " << sample.getName()
               << std::endl << GET_VAR_NAME_VALUE(sampleIndexCacheList[iSample].size())
@@ -112,7 +112,7 @@ void EventDialCache::buildReferenceCache( SampleSet& sampleSet_, std::vector<Dia
             LogDebug << dialCol.getSummary() << std::endl;
           }
 
-          LogThrow("DEV ERROR: Please report this issue to github!! This should not happen");
+          LogExit("DEV ERROR: Please report this issue to github!! This should not happen");
         }
 
         cacheEntry.dialResponseCacheList.emplace_back(
@@ -151,7 +151,7 @@ void EventDialCache::fillCacheEntries(const SampleSet& sampleSet_){
 EventDialCache::IndexedCacheEntry* EventDialCache::fetchNextCacheEntry(){
   // Warning warning Will Robinson!
   // This only works IFF the indexed cache is not resized.
-  LogThrowIf(_fillIndex_ >= _indexedCache_.size());
+  LogExitIf(_fillIndex_ >= _indexedCache_.size());
   return &_indexedCache_[_fillIndex_++];
 }
 

--- a/src/DialDictionary/DialFactories/src/DialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/DialBaseFactory.cpp
@@ -24,7 +24,7 @@ DialBase* DialBaseFactory::makeDial(const std::string& dialTitle_,
   // in the event of an exception.
   std::unique_ptr<DialBase> dialBase;
 
-  LogThrowIf(dialType_.empty(), "Dial type not set.");
+  LogExitIf(dialType_.empty(), "Dial type not set.");
 
   if (dialType_ == "Norm" || dialType_ == "Normalization") {
     NormDialBaseFactory factory;
@@ -79,7 +79,7 @@ DialBase* DialBaseFactory::makeDial(const std::string& dialTitle_,
   }
 #endif
   else{
-    LogThrow("Unrecognized dial type: " << dialType_);
+    LogExit("Unrecognized dial type: " << dialType_);
   }
 
   // Pass the ownership without any constraints!
@@ -109,10 +109,10 @@ DialBase* DialBaseFactory::makeDial(const JsonType& config_){
 
     bool success = compiledLibDialPtr->loadLibrary( GenericToolbox::Json::fetchValue<std::string>(formulaConfig, "libraryFile") );
     if( not success ){
-      LogThrow("Could not load CompiledLibDial. " << GenericToolbox::Json::fetchValue(formulaConfig, "messageOnError", std::string("")) );
+      LogExit("Could not load CompiledLibDial. " << GenericToolbox::Json::fetchValue(formulaConfig, "messageOnError", std::string("")) );
     }
   }
-  else{ LogThrow("Unknown dial type: " << dialType); }
+  else{ LogExit("Unknown dial type: " << dialType); }
 
   return dialBase.release();
 }

--- a/src/DialDictionary/DialFactories/src/GraphDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/GraphDialBaseFactory.cpp
@@ -20,7 +20,7 @@ DialBase* GraphDialBaseFactory::makeDial(const std::string& dialTitle_,
 
   TGraph* srcGraph = dynamic_cast<TGraph*>(dialInitializer_);
 
-  LogThrowIf(srcGraph == nullptr, "Graph dial initializer must be a TGraph");
+  LogExitIf(srcGraph == nullptr, "Graph dial initializer must be a TGraph");
 
   // Stuff the created dial into a unique_ptr, so it will be properly deleted
   // in the event of an exception.

--- a/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/SplineDialBaseFactory.cpp
@@ -214,7 +214,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
     std::size_t bg = dialSubType_.find("uniformity(");
     bg = dialSubType_.find("(",bg);
     std::size_t en = dialSubType_.find(")",bg);
-    LogThrowIf(en == std::string::npos,
+    LogExitIf(en == std::string::npos,
                "Invalid spline uniformity with dialSubType: " << dialSubType_
                << " dial: " << dialTitle_);
     en = en - bg;
@@ -259,7 +259,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
 
   // Check that there are equal numbers of X and Y.  There have to be an equal
   // number of points or something is very wrong.
-  LogThrowIf( _xPointListBuffer_.size() != _yPointListBuffer_.size(),
+  LogExitIf( _xPointListBuffer_.size() != _yPointListBuffer_.size(),
               "INVALID Spline Input: "
               << "must have the same number of X and Y points "
               << "for dial " << dialTitle_ );
@@ -269,7 +269,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
   // detailed logic.  This shouldn't happen, and indicates there is a problem
   // with the inputs.  Don't try to continue!
   for (int i = 1; i<_xPointListBuffer_.size(); ++i) {
-    LogThrowIf(_xPointListBuffer_[i] <= _xPointListBuffer_[i-1],
+    LogExitIf(_xPointListBuffer_[i] <= _xPointListBuffer_[i-1],
                "INVALID Spline Input: points are not in increasing order "
                << " for dial " << dialTitle_);
   }
@@ -319,7 +319,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
   // Sanity check.  By the time we get here, there can't be fewer than two
   // points, and it should have been trapped above by other conditionals
   // (e.g. a single point "spline" should have been flagged as flat).
-  LogThrowIf((_xPointListBuffer_.size() < 2),
+  LogExitIf((_xPointListBuffer_.size() < 2),
              "Input data logic error: two few points "
              << "for dial " << dialTitle_ );
 
@@ -404,7 +404,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
       }
       // If the user specified a tolerance then crash, otherwise trust the
       // user knows that it's not uniform and continue.
-      LogThrowIf(uniformityTolerance != defUniformityTolerance,
+      LogExitIf(uniformityTolerance != defUniformityTolerance,
                  "Invalid catmull-rom inputs -- Nonuniform spacing");
     }
     dialBase = (not useCachedDial_) ?
@@ -428,7 +428,7 @@ DialBase* SplineDialBaseFactory::makeDial(const std::string& dialTitle_,
       }
       // If the user specified a tolerance then crash, otherwise trust the
       // user knows that it's not uniform and continue.
-      LogThrowIf(uniformityTolerance != defUniformityTolerance,
+      LogExitIf(uniformityTolerance != defUniformityTolerance,
                  "Invalid catmull-rom inputs -- Nonuniform spacing");
     }
     dialBase = (not useCachedDial_) ?

--- a/src/DialDictionary/DialFactories/src/SurfaceDialBaseFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/SurfaceDialBaseFactory.cpp
@@ -19,7 +19,7 @@ DialBase* SurfaceDialBaseFactory::makeDial(const std::string& dialTitle_,
 
   TH2* srcObject = dynamic_cast<TH2*>(dialInitializer_);
 
-  LogThrowIf(srcObject == nullptr, "Surface dial initializers must be a TH2");
+  LogExitIf(srcObject == nullptr, "Surface dial initializers must be a TH2");
 
   // Stuff the created dial into a unique_ptr, so it will be properly deleted
   // in the event of an exception.
@@ -41,7 +41,7 @@ DialBase* SurfaceDialBaseFactory::makeDial(const std::string& dialTitle_,
   if (not dialBase) {
     LogError << "Invalid dialSubType value: " << dialSubType_ << std::endl;
     LogError << "Valid dialSubType values are: Bilinear, Bicubic" << std::endl;
-    LogThrow("Invalid Surface dialSubType");
+    LogExit("Invalid Surface dialSubType");
   }
 
   dialBase->buildDial(*srcObject);

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -62,7 +62,7 @@ void FitterEngine::configureImpl(){
       this->_minimizer_ = std::make_unique<AdaptiveMcmc>( this );
       break;
     default:
-      LogThrow("Unknown minimizer type selected: " << minimizerTypeStr << std::endl << "Available: " << MinimizerType::generateEnumFieldsAsString());
+      LogExit("Unknown minimizer type selected: " << minimizerTypeStr << std::endl << "Available: " << MinimizerType::generateEnumFieldsAsString());
   }
 
   // now the minimizer is created, forward deprecated options
@@ -116,8 +116,8 @@ void FitterEngine::configureImpl(){
   LogWarning << "FitterEngine configured." << std::endl;
 }
 void FitterEngine::initializeImpl(){
-  LogThrowIf(_config_.empty(), "Config is not set.");
-  LogThrowIf(_saveDir_== nullptr);
+  LogExitIf(_config_.empty(), "Config is not set.");
+  LogExitIf(_saveDir_== nullptr);
 
   if( GundamGlobals::isLightOutputMode() ){
     // TODO: this check should be more universal
@@ -260,7 +260,7 @@ void FitterEngine::initializeImpl(){
 // Core
 void FitterEngine::fit(){
   LogWarning << __METHOD_NAME__ << std::endl;
-  LogThrowIf( not isInitialized() );
+  LogExitIf( not isInitialized() );
 
   LogWarning << "Pre-fit likelihood state:" << std::endl;
 
@@ -651,7 +651,7 @@ void FitterEngine::checkNumericalAccuracy(){
       getLikelihoodInterface().evalLikelihood();
 
       if( responses[iThrow] == responses[iThrow] ){ // not nan
-        LogThrowIf(getLikelihoodInterface().getLastLikelihood() != responses[iThrow], "Not accurate: " << getLikelihoodInterface().getLastLikelihood() - responses[iThrow] << " / "
+        LogExitIf(getLikelihoodInterface().getLastLikelihood() != responses[iThrow], "Not accurate: " << getLikelihoodInterface().getLastLikelihood() - responses[iThrow] << " / "
                                                                                                     << GET_VAR_NAME_VALUE(getLikelihoodInterface().getLastLikelihood()) << " <=> " << GET_VAR_NAME_VALUE(responses[iThrow])
         )
       }

--- a/src/Fitter/Minimizer/include/AdaptiveMcmc.h
+++ b/src/Fitter/Minimizer/include/AdaptiveMcmc.h
@@ -236,7 +236,7 @@ private:
     std::unique_ptr<ROOT::Math::Functor> functor{};
     std::vector<double> x;
     double operator() (const sMCMC::Vector& point) {
-      LogThrowIf(functor == nullptr, "Functor is not initialized");
+      LogExitIf(functor == nullptr, "Functor is not initialized");
       // Copy the point into a local vector since there is no guarrantee that
       // the MCMC will be running on a vector of doubles.  This is paranoia
       // coding.

--- a/src/Fitter/Minimizer/include/MinimizerBase.h
+++ b/src/Fitter/Minimizer/include/MinimizerBase.h
@@ -98,11 +98,11 @@ protected:
 
       [[nodiscard]] int getValueIndex(const std::string& name_) const {
         int idx = GenericToolbox::findElementIndex(name_, valueDefinitionList, [](const ValueDefinition& elm){ return elm.name; });
-        LogThrowIf(idx == -1, "Could not find element " << name_);
+        LogExitIf(idx == -1, "Could not find element " << name_);
         return idx;
       }
       [[nodiscard]] double getLastStepValue(const std::string& name_) const {
-        LogThrowIf(stepPointList.empty());
+        LogExitIf(stepPointList.empty());
         return stepPointList.back().valueMonitorList[getValueIndex(name_)];
       }
       [[nodiscard]] double getLastStepDeltaValue(const std::string& name_) const {

--- a/src/Fitter/Minimizer/src/AdaptiveMcmc.cpp
+++ b/src/Fitter/Minimizer/src/AdaptiveMcmc.cpp
@@ -410,7 +410,7 @@ bool AdaptiveMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
              << std::endl;
     LogError << "   Proposal Y Bins:     " << proposalCov->GetNbinsY()
              << std::endl;
-    LogThrow("Mismatched proposal covariance matrix");
+    LogExit("Mismatched proposal covariance matrix");
   }
 
   // Dump all of the previous correlations.
@@ -426,7 +426,7 @@ bool AdaptiveMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
       LogError << "Mismatch of parameter and covariance names" << std::endl;
       LogError << "Parameter:  " << parName << std::endl;
       LogError << "Covariance: " << covName << std::endl;
-      LogThrow("Mismatched covariance histogram");
+      LogExit("Mismatched covariance histogram");
     }
     double sig1 = std::sqrt(proposalCov->GetBinContent(count1,count1));
     int count2 = 0;
@@ -537,7 +537,7 @@ void AdaptiveMcmc::setupAndRunAdaptiveStep( AdaptiveStepMCMC& mcmc) {
     }
   }
   StartStatus = mcmc.Start(prior, false);
-  if (StartStatus!=true || prior.size()==0) LogThrow("The initial point is bad. MCMC chain cannot start.");
+  if (StartStatus!=true || prior.size()==0) LogExit("The initial point is bad. MCMC chain cannot start.");
 
   // Set the correlations in the default step proposal.
   if (not adaptiveLoadProposalCovariance(

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -32,7 +32,7 @@ void MinimizerBase::configureImpl(){
 void MinimizerBase::initializeImpl(){
   LogWarning << "Initializing MinimizerBase..." << std::endl;
 
-  LogThrowIf(_owner_ == nullptr, "FitterEngine owner not set.");
+  LogExitIf(_owner_ == nullptr, "FitterEngine owner not set.");
 
   _nbFreeParameters_ = 0;
   _minimizerParameterPtrList_.clear();
@@ -103,7 +103,7 @@ void MinimizerBase::minimize(){
   /// This base implementation can be called in derived class in order to print
   /// the initial state of the fit.
 
-  LogThrowIf(not isInitialized(), "not initialized");
+  LogExitIf(not isInitialized(), "not initialized");
 
   this->printParameters();
 
@@ -131,7 +131,7 @@ void MinimizerBase::scanParameters(TDirectory* saveDir_){
   /// be different from the parameters used for the likelihood.
 
   LogInfo << "Performing scans of fit parameters..." << std::endl;
-  LogThrowIf( not isInitialized() );
+  LogExitIf( not isInitialized() );
   for( auto& parPtr : _minimizerParameterPtrList_ ) { getParameterScanner().scanParameter( *parPtr, saveDir_ ); }
 }
 double MinimizerBase::evalFit( const double* parArray_ ){
@@ -328,7 +328,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
 
   if( _throwOnBadLlh_ and not getLikelihoodInterface().getBuffer().isValid() ){
     LogError << getLikelihoodInterface().getSummary() << std::endl;
-    LogThrow( "Invalid total likelihood value." );
+    LogExit( "Invalid total likelihood value." );
   }
 
   _monitor_.externalTimer.start();

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -65,7 +65,7 @@ void RootMinimizer::initializeImpl(){
   _rootMinimizer_ = std::unique_ptr<ROOT::Math::Minimizer>(
       ROOT::Math::Factory::CreateMinimizer(_minimizerType_, _minimizerAlgo_)
   );
-  LogThrowIf(_rootMinimizer_ == nullptr, "Could not create minimizer: " << _minimizerType_ << "/" << _minimizerAlgo_);
+  LogExitIf(_rootMinimizer_ == nullptr, "Could not create minimizer: " << _minimizerType_ << "/" << _minimizerAlgo_);
 
   if( _minimizerAlgo_.empty() ){
     _minimizerAlgo_ = _rootMinimizer_->Options().MinimizerAlgorithm();
@@ -168,7 +168,7 @@ void RootMinimizer::minimize(){
 
   if( _preFitWithSimplex_ ){
     LogWarning << "Running simplex algo before the minimizer" << std::endl;
-    LogThrowIf(_minimizerType_ != "Minuit2", "Can't launch simplex with " << _minimizerType_);
+    LogExitIf(_minimizerType_ != "Minuit2", "Can't launch simplex with " << _minimizerType_);
 
     std::string originalAlgo = _rootMinimizer_->Options().MinimizerAlgorithm();
 
@@ -335,7 +335,7 @@ void RootMinimizer::minimize(){
 }
 void RootMinimizer::calcErrors(){
 
-  LogThrowIf(not isInitialized(), "not initialized");
+  LogExitIf(not isInitialized(), "not initialized");
 
   LogWarning << std::endl << GenericToolbox::addUpDownBars("Calling calcErrors()...") << std::endl;
 
@@ -428,7 +428,7 @@ void RootMinimizer::calcErrors(){
   }
 }
 void RootMinimizer::scanParameters( TDirectory* saveDir_ ){
-  LogThrowIf(not isInitialized());
+  LogExitIf(not isInitialized());
   LogInfo << "Performing scans of fit parameters..." << std::endl;
   for( int iPar = 0 ; iPar < getMinimizer()->NDim() ; iPar++ ){
     if( getMinimizer()->IsFixedVariable(iPar) ){
@@ -493,8 +493,8 @@ void RootMinimizer::saveMinimizerSettings( TDirectory* saveDir_) const {
 // protected
 void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
   LogInfo << __METHOD_NAME__ << std::endl;
-  LogThrowIf(not isInitialized(), "not initialized");
-  LogThrowIf(saveDir_==nullptr, "Save dir not specified");
+  LogExitIf(not isInitialized(), "not initialized");
+  LogExitIf(saveDir_==nullptr, "Save dir not specified");
 
   LogInfo << "Extracting post-fit covariance matrix" << std::endl;
   auto* matricesDir = GenericToolbox::mkdirTFile(saveDir_, "hessian");
@@ -1211,7 +1211,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
   } // parSet
 }
 void RootMinimizer::updateCacheToBestfitPoint(){
-  LogThrowIf(_rootMinimizer_->X() == nullptr, "No best fit point provided by the minimizer.");
+  LogExitIf(_rootMinimizer_->X() == nullptr, "No best fit point provided by the minimizer.");
 
   LogWarning << "Updating propagator cache to the best fit point..." << std::endl;
   this->evalFit(_rootMinimizer_->X() );

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -38,13 +38,13 @@ void Parameter::configureImpl(){
 
 }
 void Parameter::initializeImpl() {
-  LogThrowIf(_owner_ == nullptr, "Parameter set ref is not set.");
-  LogThrowIf(_parameterIndex_ == -1, "Parameter index is not set.");
+  LogExitIf(_owner_ == nullptr, "Parameter set ref is not set.");
+  LogExitIf(_parameterIndex_ == -1, "Parameter index is not set.");
 
   if( not _isEnabled_ ) { return; }
-  LogThrowIf(std::isnan(_priorValue_), "Prior value is not set: " << getFullTitle());
-  LogThrowIf(std::isnan(_stdDevValue_), "Std dev value is not set: " << getFullTitle());
-  LogThrowIf(std::isnan(_parameterValue_), "Parameter value is not set: " << getFullTitle());
+  LogExitIf(std::isnan(_priorValue_), "Prior value is not set: " << getFullTitle());
+  LogExitIf(std::isnan(_stdDevValue_), "Std dev value is not set: " << getFullTitle());
+  LogExitIf(std::isnan(_parameterValue_), "Parameter value is not set: " << getFullTitle());
 }
 
 void Parameter::setMinMirror(double minMirror) {

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -24,7 +24,7 @@ LoggerInit([]{ Logger::setUserHeaderStr("[ParameterSet]"); });
 void ParameterSet::configureImpl(){
 
   GenericToolbox::Json::fillValue(_config_, _name_, "name");
-  LogThrowIf(_name_.empty(), "ParameterSet have no name.");
+  LogExitIf(_name_.empty(), "ParameterSet have no name.");
   LogDebugIf(GundamGlobals::isDebug()) << "Reading config for parameter set: " << _name_ << std::endl;
 
   GenericToolbox::Json::fillValue(_config_, _isEnabled_, "isEnabled");
@@ -115,7 +115,7 @@ void ParameterSet::configureImpl(){
       _nbParameterDefinition_ = int(_parameterDefinitionConfig_.get<std::vector<JsonType>>().size());
     }
 
-    LogThrowIf(_nbParameterDefinition_==-1, "Could not figure out the number of parameters to be defined for the set: " << _name_ );
+    LogExitIf(_nbParameterDefinition_==-1, "Could not figure out the number of parameters to be defined for the set: " << _name_ );
   }
 
   this->defineParameters();
@@ -190,7 +190,7 @@ void ParameterSet::processCovarianceMatrix(){
   }
   _deltaVectorPtr_ = std::make_shared<TVectorD>(_strippedCovarianceMatrix_->GetNrows());
 
-  LogThrowIf(not _strippedCovarianceMatrix_->IsSymmetric(), "Covariance matrix is not symmetric");
+  LogExitIf(not _strippedCovarianceMatrix_->IsSymmetric(), "Covariance matrix is not symmetric");
 
   if( not isEnableEigenDecomp() ){
     LogWarning << "Computing inverse of the stripped covariance matrix: "
@@ -217,7 +217,7 @@ void ParameterSet::processCovarianceMatrix(){
 
     LogInfo << "Covariance eigen values are between " << _eigenValues_->Min() << " and " << _eigenValues_->Max() << std::endl;
     if( std::isnan(_eigenSvdThreshold_) ){
-      LogThrowIf(_eigenValues_->Min() < 0, "Input covariance matrix is not positive definite.");
+      LogExitIf(_eigenValues_->Min() < 0, "Input covariance matrix is not positive definite.");
     }
     else if( _eigenValues_->Min()/_eigenValues_->Max() < _eigenSvdThreshold_ ){
       LogAlert << "Eigen values bellow the threshold(" << _eigenSvdThreshold_ << "). Using SVD..." << std::endl;
@@ -322,15 +322,15 @@ void ParameterSet::processCovarianceMatrix(){
         eigenPar.setMinValue( _parameterList_[eigenPar.getParameterIndex()].getMinValue() );
         eigenPar.setMaxValue( _parameterList_[eigenPar.getParameterIndex()].getMaxValue() );
 
-        LogThrowIf( not std::isnan(eigenPar.getMinValue()) and eigenPar.getPriorValue() < eigenPar.getMinValue(), "PRIOR IS BELLOW MIN: " << eigenPar.getSummary() );
-        LogThrowIf( not std::isnan(eigenPar.getMaxValue()) and eigenPar.getPriorValue() > eigenPar.getMaxValue(), "PRIOR IS ABOVE MAX: " << eigenPar.getSummary() );
+        LogExitIf( not std::isnan(eigenPar.getMinValue()) and eigenPar.getPriorValue() < eigenPar.getMinValue(), "PRIOR IS BELLOW MIN: " << eigenPar.getSummary() );
+        LogExitIf( not std::isnan(eigenPar.getMaxValue()) and eigenPar.getPriorValue() > eigenPar.getMaxValue(), "PRIOR IS ABOVE MAX: " << eigenPar.getSummary() );
       }
       else{
         eigenPar.setMinValue( _eigenParRange_.min );
         eigenPar.setMaxValue( _eigenParRange_.max );
 
-        LogThrowIf( not std::isnan(eigenPar.getMinValue()) and eigenPar.getPriorValue() < eigenPar.getMinValue(), "Prior value is bellow min: " << eigenPar.getSummary() );
-        LogThrowIf( not std::isnan(eigenPar.getMaxValue()) and eigenPar.getPriorValue() > eigenPar.getMaxValue(), "Prior value is above max: " << eigenPar.getSummary() );
+        LogExitIf( not std::isnan(eigenPar.getMinValue()) and eigenPar.getPriorValue() < eigenPar.getMinValue(), "Prior value is bellow min: " << eigenPar.getSummary() );
+        LogExitIf( not std::isnan(eigenPar.getMaxValue()) and eigenPar.getPriorValue() > eigenPar.getMaxValue(), "Prior value is above max: " << eigenPar.getSummary() );
       }
     }
 
@@ -393,7 +393,7 @@ void ParameterSet::moveParametersToPrior(){
 }
 void ParameterSet::throwParameters(bool rethrowIfNotInPhysical_, double gain_){
 
-  LogThrowIf(_strippedCovarianceMatrix_==nullptr, "No covariance matrix provided");
+  LogExitIf(_strippedCovarianceMatrix_==nullptr, "No covariance matrix provided");
 
   TVectorD throwsList{_strippedCovarianceMatrix_->GetNrows()};
 
@@ -455,7 +455,7 @@ void ParameterSet::throwParameters(bool rethrowIfNotInPhysical_, double gain_){
 
           if (not throwIsValid) {
             LogAlert << "Rethrowing \"" << this->getName() << "\"... try #" << nTries+1 << std::endl;
-            LogThrowIf(nTries > 10000, "Failed to find valid throw");
+            LogExitIf(nTries > 10000, "Failed to find valid throw");
             continue;
           }
 
@@ -705,21 +705,21 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
   LogWarning << "Importing parameters from config for \"" << this->getName() << "\"" << std::endl;
 
   auto config = ConfigUtils::getForwardedConfig(config_);
-  LogThrowIf( config.empty(), "Invalid injector config" << std::endl << config_ );
-  LogThrowIf( not GenericToolbox::Json::doKeyExist(config, "name"), "No parameter set name provided in" << std::endl << config_ );
-  LogThrowIf( GenericToolbox::Json::fetchValue<std::string>(config, "name") != this->getName(),
+  LogExitIf( config.empty(), "Invalid injector config" << std::endl << config_ );
+  LogExitIf( not GenericToolbox::Json::doKeyExist(config, "name"), "No parameter set name provided in" << std::endl << config_ );
+  LogExitIf( GenericToolbox::Json::fetchValue<std::string>(config, "name") != this->getName(),
               "Mismatching between parSet name (" << this->getName() << ") and injector config ("
               << GenericToolbox::Json::fetchValue<std::string>(config, "name") << ")" );
 
   auto parValues = GenericToolbox::Json::fetchValue( config, "parameterValues", JsonType() );
   if     ( parValues.empty() ) {
-    LogThrow( "No parameterValues provided." );
+    LogExit( "No parameterValues provided." );
   }
   else if( parValues.is_string() ){
     //
     LogInfo << "Reading parameter values from file: " << parValues.get<std::string>() << std::endl;
     auto parList = GenericToolbox::dumpFileAsVectorString( parValues.get<std::string>(), true );
-    LogThrowIf( parList.size() != this->getNbParameters()  ,
+    LogExitIf( parList.size() != this->getNbParameters()  ,
                 parList.size() << " parameters provided for " << this->getName() << ", expecting " << this->getNbParameters()
     );
 
@@ -741,7 +741,7 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
       if     ( GenericToolbox::Json::doKeyExist(parValueEntry, "name") ) {
         auto parName = GenericToolbox::Json::fetchValue<std::string>(parValueEntry, "name");
         auto* parPtr = this->getParameterPtr(parName);
-        LogThrowIf(parPtr == nullptr, "Could not find " << parName << " among the defined parameters in " << this->getName());
+        LogExitIf(parPtr == nullptr, "Could not find " << parName << " among the defined parameters in " << this->getName());
 
 
         if( not parPtr->isEnabled() ){
@@ -755,7 +755,7 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
       else if( GenericToolbox::Json::doKeyExist(parValueEntry, "title") ){
         auto parTitle = GenericToolbox::Json::fetchValue<std::string>(parValueEntry, "title");
         auto* parPtr = this->getParameterPtrWithTitle(parTitle);
-        LogThrowIf(parPtr == nullptr, "Could not find " << parTitle << " among the defined parameters in " << this->getName());
+        LogExitIf(parPtr == nullptr, "Could not find " << parTitle << " among the defined parameters in " << this->getName());
 
 
         if( not parPtr->isEnabled() ){
@@ -768,7 +768,7 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
       }
       else if( GenericToolbox::Json::doKeyExist(parValueEntry, "index") ){
         auto parIndex = GenericToolbox::Json::fetchValue<int>(parValueEntry, "index");
-        LogThrowIf( parIndex < 0 or parIndex >= this->getParameterList().size(),
+        LogExitIf( parIndex < 0 or parIndex >= this->getParameterList().size(),
                     "invalid parameter index (" << parIndex << ") for injection in parSet: " << this->getName() );
 
         auto* parPtr = &this->getParameterList()[parIndex];
@@ -781,7 +781,7 @@ void ParameterSet::injectParameterValues(const JsonType& config_){
         parPtr->setParameterValue( GenericToolbox::Json::fetchValue<double>(parValueEntry, "value") );
       }
       else {
-        LogThrow("Unsupported: " << parValueEntry);
+        LogExit("Unsupported: " << parValueEntry);
       }
     }
   }
@@ -849,25 +849,25 @@ void ParameterSet::readParameterDefinitionFile(){
 
   std::string path = GenericToolbox::expandEnvironmentVariables(_parameterDefinitionFilePath_);
   std::unique_ptr<TFile> parDefFile(TFile::Open(path.c_str()));
-  LogThrowIf(parDefFile == nullptr or not parDefFile->IsOpen(), "Could not open: " << path);
+  LogExitIf(parDefFile == nullptr or not parDefFile->IsOpen(), "Could not open: " << path);
 
 
   // define with the covariance matrix size
   if( not _covarianceMatrixPath_.empty() ){
     objBuffer = parDefFile->Get(_covarianceMatrixPath_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _covarianceMatrixPath_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _covarianceMatrixPath_ << "\" in " << parDefFile->GetPath())
     _priorCovarianceMatrix_ = std::shared_ptr<TMatrixDSym>((TMatrixDSym*) objBuffer->Clone());
     _priorCorrelationMatrix_ = std::shared_ptr<TMatrixDSym>((TMatrixDSym*) GenericToolbox::convertToCorrelationMatrix((TMatrixD*)_priorCovarianceMatrix_.get()));
-    LogThrowIf(_nbParameterDefinition_ != -1, "Nb of parameter was manually defined but the covariance matrix");
+    LogExitIf(_nbParameterDefinition_ != -1, "Nb of parameter was manually defined but the covariance matrix");
     _nbParameterDefinition_ = _priorCovarianceMatrix_->GetNrows();
   }
 
   // parameterPriorTVectorD
   if(not _parameterPriorValueListPath_.empty()){
     objBuffer = parDefFile->Get(_parameterPriorValueListPath_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _parameterPriorValueListPath_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _parameterPriorValueListPath_ << "\" in " << parDefFile->GetPath())
     _parameterPriorList_ = std::shared_ptr<TVectorD>((TVectorD*) objBuffer->Clone());
-    LogThrowIf(_parameterPriorList_->GetNrows() != _nbParameterDefinition_,
+    LogExitIf(_parameterPriorList_->GetNrows() != _nbParameterDefinition_,
       "Parameter prior list don't have the same size("
       << _parameterPriorList_->GetNrows()
       << ") as cov matrix(" << _nbParameterDefinition_ << ")"
@@ -877,17 +877,17 @@ void ParameterSet::readParameterDefinitionFile(){
   // parameterNameTObjArray
   if(not _parameterNameListPath_.empty()){
     objBuffer = parDefFile->Get(_parameterNameListPath_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _parameterNameListPath_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _parameterNameListPath_ << "\" in " << parDefFile->GetPath())
     _parameterNamesList_ = std::shared_ptr<TObjArray>((TObjArray*) objBuffer->Clone());
   }
 
   // parameterLowerBoundsTVectorD
   if( not _parameterLowerBoundsTVectorD_.empty() ){
     objBuffer = parDefFile->Get(_parameterLowerBoundsTVectorD_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _parameterLowerBoundsTVectorD_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _parameterLowerBoundsTVectorD_ << "\" in " << parDefFile->GetPath())
     _parameterLowerBoundsList_ = std::shared_ptr<TVectorD>((TVectorD*) objBuffer->Clone());
 
-    LogThrowIf(_parameterLowerBoundsList_->GetNrows() != _nbParameterDefinition_,
+    LogExitIf(_parameterLowerBoundsList_->GetNrows() != _nbParameterDefinition_,
                 "Parameter prior list don't have the same size(" << _parameterLowerBoundsList_->GetNrows()
                                                                  << ") as cov matrix(" << _nbParameterDefinition_ << ")" );
   }
@@ -895,16 +895,16 @@ void ParameterSet::readParameterDefinitionFile(){
   // parameterUpperBoundsTVectorD
   if( not _parameterUpperBoundsTVectorD_.empty() ){
     objBuffer = parDefFile->Get(_parameterUpperBoundsTVectorD_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _parameterUpperBoundsTVectorD_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _parameterUpperBoundsTVectorD_ << "\" in " << parDefFile->GetPath())
     _parameterUpperBoundsList_ = std::shared_ptr<TVectorD>((TVectorD*) objBuffer->Clone());
-    LogThrowIf(_parameterUpperBoundsList_->GetNrows() != _nbParameterDefinition_,
+    LogExitIf(_parameterUpperBoundsList_->GetNrows() != _nbParameterDefinition_,
                 "Parameter prior list don't have the same size(" << _parameterUpperBoundsList_->GetNrows()
                                                                  << ") as cov matrix(" << _nbParameterDefinition_ << ")" );
   }
 
   if( not _throwEnabledListPath_.empty() ){
     objBuffer = parDefFile->Get(_throwEnabledListPath_.c_str());
-    LogThrowIf(objBuffer == nullptr, "Can't find \"" << _throwEnabledListPath_ << "\" in " << parDefFile->GetPath())
+    LogExitIf(objBuffer == nullptr, "Can't find \"" << _throwEnabledListPath_ << "\" in " << parDefFile->GetPath())
     _throwEnabledList_ = std::shared_ptr<TVectorD>((TVectorD*) objBuffer->Clone());
   }
 
@@ -922,7 +922,7 @@ void ParameterSet::defineParameters(){
       par.setStepSize(TMath::Sqrt((*_priorCovarianceMatrix_)[par.getParameterIndex()][par.getParameterIndex()]));
     }
     else{
-      LogThrowIf(std::isnan(_nominalStepSize_), "Can't define free parameter without a \"nominalStepSize\"");
+      LogExitIf(std::isnan(_nominalStepSize_), "Can't define free parameter without a \"nominalStepSize\"");
       par.setStdDevValue(_nominalStepSize_); // stdDev will only be used for display purpose
       par.setStepSize(_nominalStepSize_);
       par.setPriorType(Parameter::PriorType::Flat);
@@ -978,8 +978,8 @@ void ParameterSet::defineParameters(){
     if( _parameterLowerBoundsList_ != nullptr ){ par.setMinValue((*_parameterLowerBoundsList_)[par.getParameterIndex()]); }
     if( _parameterUpperBoundsList_ != nullptr ){ par.setMaxValue((*_parameterUpperBoundsList_)[par.getParameterIndex()]); }
 
-    LogThrowIf( not std::isnan(par.getMinValue()) and par.getPriorValue() < par.getMinValue(), "PRIOR IS BELLOW MIN: " << par.getSummary() );
-    LogThrowIf( not std::isnan(par.getMaxValue()) and par.getPriorValue() > par.getMaxValue(), "PRIOR IS ABOVE MAX: " << par.getSummary() );
+    LogExitIf( not std::isnan(par.getMinValue()) and par.getPriorValue() < par.getMinValue(), "PRIOR IS BELLOW MIN: " << par.getSummary() );
+    LogExitIf( not std::isnan(par.getMaxValue()) and par.getPriorValue() > par.getMaxValue(), "PRIOR IS ABOVE MAX: " << par.getSummary() );
 
     if( not _parameterDefinitionConfig_.empty() ){
       // Alternative 1: define dials then parameters
@@ -998,7 +998,7 @@ void ParameterSet::defineParameters(){
         // No covariance provided, so find the name based on the order in
         // the parameter set.
         auto configVector = _parameterDefinitionConfig_.get<std::vector<JsonType>>();
-        LogThrowIf(configVector.size() <= par.getParameterIndex());
+        LogExitIf(configVector.size() <= par.getParameterIndex());
         auto parConfig = configVector.at(par.getParameterIndex());
         auto parName = GenericToolbox::Json::fetchValue<std::string>(parConfig, {{"name"}, {"parameterName"}});
         if (not parName.empty()) par.setName(parName);

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -140,7 +140,7 @@ const ParameterSet* ParametersManager::getFitParameterSetPtr(const std::string& 
   std::vector<std::string> parSetNames{};
   parSetNames.reserve( _parameterSetList_.size() );
   for( auto& parSet : _parameterSetList_ ){ parSetNames.emplace_back(parSet.getName()); }
-  LogThrow("Could not find fit parameter set named \"" << name_ << "\" among defined: " << GenericToolbox::toString(parSetNames));
+  LogExit("Could not find fit parameter set named \"" << name_ << "\" among defined: " << GenericToolbox::toString(parSetNames));
   return nullptr;
 }
 
@@ -176,7 +176,7 @@ void ParametersManager::throwParametersFromParSetCovariance(){
 }
 void ParametersManager::initializeStrippedGlobalCov(){
   LogInfo << "Creating stripped global covariance matrix..." << std::endl;
-  LogThrowIf( _globalCovarianceMatrix_ == nullptr, "Global covariance matrix not set." );
+  LogExitIf( _globalCovarianceMatrix_ == nullptr, "Global covariance matrix not set." );
 
   _strippedParameterList_.clear();
   for( int iGlobPar = 0 ; iGlobPar < _globalCovarianceMatrix_->GetNrows() ; iGlobPar++ ){
@@ -270,7 +270,7 @@ void ParametersManager::throwParametersFromGlobalCovariance(bool quietVerbose_){
     }
 
     if( rethrow ) {
-      LogThrowIf( throwNb > 100000, "Too many throw attempts")
+      LogExitIf( throwNb > 100000, "Too many throw attempts")
       // wrap back to the while loop
       LogWarning << "Rethrowing after attempt #" << throwNb << std::endl;
       continue;
@@ -328,7 +328,7 @@ void ParametersManager::injectParameterValues(const JsonType &config_) {
     LogInfo << "Reading injection parameters for parSet: " << parSetName << std::endl;
 
     auto* selectedParSet = this->getFitParameterSetPtr(parSetName );
-    LogThrowIf( selectedParSet == nullptr, "Could not find parSet: " << parSetName );
+    LogExitIf( selectedParSet == nullptr, "Could not find parSet: " << parSetName );
 
     selectedParSet->injectParameterValues(entryParSet);
   }

--- a/src/Propagator/src/EventTreeWriter.cpp
+++ b/src/Propagator/src/EventTreeWriter.cpp
@@ -98,7 +98,7 @@ template<typename T> void EventTreeWriter::writeEventsTemplate(const GenericTool
 
       auto& var = evPtr->getVariables().fetchVariable( varName ).get();
       char typeTag = GenericToolbox::findOriginalVariableType(var);
-      LogThrowIf( typeTag == 0 or typeTag == char(0xFF), varName << " has an invalid leaf type." );
+      LogExitIf( typeTag == 0 or typeTag == char(0xFF), varName << " has an invalid leaf type." );
 
       std::string leafDefStr{ varName };
 //      if(not disableArrays_ and lH.size() > 1){ leafDefStr += "[" + std::to_string(lH.size()) + "]"; }
@@ -129,7 +129,7 @@ template<typename T> void EventTreeWriter::writeEventsTemplate(const GenericTool
   std::vector<std::pair<size_t,size_t>> parIndexList{};
 
   if( writeDials ){
-    LogThrowIf(parSetListPtr == nullptr);
+    LogExitIf(parSetListPtr == nullptr);
 
     // how many pars?
     size_t nPars = 0;

--- a/src/Propagator/src/PlotGenerator.cpp
+++ b/src/Propagator/src/PlotGenerator.cpp
@@ -92,7 +92,7 @@ void PlotGenerator::configureImpl(){
 }
 void PlotGenerator::initializeImpl() {
   LogWarning << __METHOD_NAME__ << std::endl;
-  LogThrowIf(_modelSampleListPtr_ == nullptr);
+  LogExitIf(_modelSampleListPtr_ == nullptr);
 }
 
 
@@ -111,12 +111,12 @@ std::vector<HistHolder> &PlotGenerator::getHistHolderList(int cacheSlot_){
 
 // Core
 void PlotGenerator::generateSamplePlots(TDirectory *saveDir_, int cacheSlot_) {
-  LogThrowIf( not isInitialized() );
+  LogExitIf( not isInitialized() );
   this->generateSampleHistograms(GenericToolbox::mkdirTFile(saveDir_, "histograms"), cacheSlot_);
   this->generateCanvas(_histHolderCacheList_[cacheSlot_], GenericToolbox::mkdirTFile(saveDir_, "canvas"));
 }
 void PlotGenerator::generateSampleHistograms(TDirectory *saveDir_, int cacheSlot_) {
-  LogThrowIf(not isInitialized());
+  LogExitIf(not isInitialized());
 
   LogInfo << "Generating sample histograms..." << std::endl;
 
@@ -271,7 +271,7 @@ void PlotGenerator::generateSampleHistograms(TDirectory *saveDir_, int cacheSlot
 
 }
 void PlotGenerator::generateCanvas(const std::vector<HistHolder> &histHolderList_, TDirectory *saveDir_, bool stackHist_){
-  LogThrowIf(not isInitialized());
+  LogExitIf(not isInitialized());
 
   auto buildCanvasPath = [](const HistHolder* hist_){
     std::stringstream ss;
@@ -505,7 +505,7 @@ void PlotGenerator::generateComparisonPlots(const std::vector<HistHolder> &hists
   this->generateCanvas(_comparisonHistHolderList_, GenericToolbox::mkdirTFile(saveDir_, "canvas"), false);
 }
 void PlotGenerator::generateComparisonHistograms(const std::vector<HistHolder> &histList_, const std::vector<HistHolder> &refHistsList_, TDirectory *saveDir_) {
-  LogThrowIf(not isInitialized());
+  LogExitIf(not isInitialized());
 
   bool newHistHolder{false};
   if( _comparisonHistHolderList_.empty() ) newHistHolder = true;
@@ -646,12 +646,12 @@ void PlotGenerator::defineHistogramHolders() {
 
       [[nodiscard]] const SplitSample& fetchSample(const Sample* samplePtr_) const{
         int idx{GenericToolbox::findElementIndex(samplePtr_, sampleList, [](const SplitSample& s_){ return s_.samplePtr; })};
-        LogThrowIf(idx==-1, "Can't find SplitVariableDictionary for: " << samplePtr_->getName());
+        LogExitIf(idx==-1, "Can't find SplitVariableDictionary for: " << samplePtr_->getName());
         return sampleList[idx];
       }
       SplitSample& fetchSample(const Sample* samplePtr_){
         int idx{GenericToolbox::findElementIndex(samplePtr_, sampleList, [](const SplitSample& s_){ return s_.samplePtr; })};
-        LogThrowIf(idx==-1, "Can't find SplitVariableDictionary for: " << samplePtr_->getName());
+        LogExitIf(idx==-1, "Can't find SplitVariableDictionary for: " << samplePtr_->getName());
         return sampleList[idx];
       }
     };
@@ -662,7 +662,7 @@ void PlotGenerator::defineHistogramHolders() {
     }
     [[nodiscard]] const Entry& fetchEntry(const std::string& name_) const{
       int idx{GenericToolbox::findElementIndex(name_, entryList, [](const Entry& e_){ return e_.name; })};
-      LogThrowIf(idx==-1, "Can't find SplitVariableDictionary for: " << name_);
+      LogExitIf(idx==-1, "Can't find SplitVariableDictionary for: " << name_);
       return entryList[idx];
     }
   };
@@ -803,7 +803,7 @@ void PlotGenerator::defineHistogramHolders() {
               else if( not histDef.binning.getBinList().empty() ){
 
                 auto varList{histDef.binning.buildVariableNameList()};
-                LogThrowIf(varList.size()!=1, "Binning should be defined with only one variable, here: " << GenericToolbox::toString(varList))
+                LogExitIf(varList.size()!=1, "Binning should be defined with only one variable, here: " << GenericToolbox::toString(varList))
 
                 for(const auto& bin: histDef.binning.getBinList()){
                   const auto& edges = bin.getVarEdges(varList[0]);
@@ -819,7 +819,7 @@ void PlotGenerator::defineHistogramHolders() {
                 }
               }
               else{
-                LogThrow("Could not find the binning definition.")
+                LogExit("Could not find the binning definition.")
               }
 
               // Hist fill function

--- a/src/SamplesManager/src/Sample.cpp
+++ b/src/SamplesManager/src/Sample.cpp
@@ -21,7 +21,7 @@ void Sample::configureImpl(){
   GenericToolbox::Json::fillValue(_config_, _selectionCutStr_, {{"selectionCutStr"},{"selectionCuts"}});
   GenericToolbox::Json::fillValue(_config_, _enabledDatasetList_, {{"datasets"},{"dataSets"}});
 
-  LogThrowIf(_name_.empty(), "No name was provided for sample #" << _index_ << std::endl << GenericToolbox::Json::toReadableString(_config_));
+  LogExitIf(_name_.empty(), "No name was provided for sample #" << _index_ << std::endl << GenericToolbox::Json::toReadableString(_config_));
   LogDebugIf(GundamGlobals::isDebug()) << "Defining sample \"" << _name_ << "\"" << std::endl;
   if( not _isEnabled_ ){
     LogDebugIf(GundamGlobals::isDebug()) << "-> disabled" << std::endl;
@@ -78,11 +78,11 @@ void Sample::shrinkEventList(size_t newTotalSize_){
     return;
   }
 
-  LogThrowIf(_eventList_.size() < newTotalSize_,
+  LogExitIf(_eventList_.size() < newTotalSize_,
              "Can't shrink since eventList is too small: " << GET_VAR_NAME_VALUE(newTotalSize_)
                                                            << " > " << GET_VAR_NAME_VALUE(_eventList_.size()));
 
-  LogThrowIf(not _loadedDatasetList_.empty() and _loadedDatasetList_.back().eventNb < (_eventList_.size() - newTotalSize_),
+  LogExitIf(not _loadedDatasetList_.empty() and _loadedDatasetList_.back().eventNb < (_eventList_.size() - newTotalSize_),
              "Can't shrink since eventList of the last dataSet is too small.");
 
   LogInfo << _name_ << ": shrinking event list from " << _eventList_.size() << " to " << newTotalSize_ << "..." << std::endl;

--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -49,7 +49,7 @@ void SampleSet::configureImpl(){
       if( not GenericToolbox::Json::fetchValue(sampleConfig, "isEnabled", true) ) continue;
       nSamples++;
     }
-    LogThrowIf(nSamples != _sampleList_.size(), "Can't reload config with different number of samples");
+    LogExitIf(nSamples != _sampleList_.size(), "Can't reload config with different number of samples");
 
     for( size_t iSample = 0 ; iSample < _sampleList_.size() ; iSample++ ){
       if( not GenericToolbox::Json::fetchValue(sampleListConfig[iSample], "isEnabled", true) ) continue;
@@ -77,7 +77,7 @@ std::vector<std::string> SampleSet::fetchRequestedVariablesForIndexing() const{
   return out;
 }
 void SampleSet::copyEventsFrom(const SampleSet& src_){
-  LogThrowIf(
+  LogExitIf(
       src_.getSampleList().size() != this->getSampleList().size(),
       "Can't copy events from mismatching sample lists. src(" << src_.getSampleList().size() << ")"
       << "dst(" << this->getSampleList().size() << ")."

--- a/src/SamplesManager/src/VariableCollection.cpp
+++ b/src/SamplesManager/src/VariableCollection.cpp
@@ -9,16 +9,16 @@
 
 
 void VariableCollection::setVarNameList( const std::shared_ptr<std::vector<std::string>> &nameListPtr_ ){
-  LogThrowIf(nameListPtr_ == nullptr, "Invalid commonNameListPtr_ provided.");
+  LogExitIf(nameListPtr_ == nullptr, "Invalid commonNameListPtr_ provided.");
   _nameListPtr_ = nameListPtr_;
   _varList_.clear();
   _varList_.resize(_nameListPtr_->size());
 }
 
 int VariableCollection::findVarIndex( const std::string& leafName_, bool throwIfNotFound_) const{
-  LogThrowIf(_nameListPtr_ == nullptr, "Can't " << __METHOD_NAME__ << " while _commonLeafNameListPtr_ is empty.");
+  LogExitIf(_nameListPtr_ == nullptr, "Can't " << __METHOD_NAME__ << " while _commonLeafNameListPtr_ is empty.");
   int out{GenericToolbox::findElementIndex(leafName_, *_nameListPtr_)};
-  LogThrowIf(throwIfNotFound_ and out == -1, leafName_ << " not found in: " << GenericToolbox::toString(*_nameListPtr_));
+  LogExitIf(throwIfNotFound_ and out == -1, leafName_ << " not found in: " << GenericToolbox::toString(*_nameListPtr_));
   return out;
 }
 const VariableHolder& VariableCollection::fetchVariable( const std::string& name_) const{

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2020.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2020.h
@@ -47,7 +47,7 @@ namespace JointProbability{
     double temp = predVal*fractional*fractional-1;
     // b^2 - 4ac in quadratic equation
     double temp2 = temp*temp + 4*dataVal*fractional*fractional;
-    LogThrowIf(temp2 < 0, "Negative square root in Barlow Beeston coefficient calculation!");
+    LogExitIf(temp2 < 0, "Negative square root in Barlow Beeston coefficient calculation!");
 
     // Solve for the positive beta
     double beta = (-1*temp+sqrt(temp2))/2.;
@@ -83,7 +83,7 @@ namespace JointProbability{
                << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights << std::endl;
     }
 
-    LogThrowIf(std::isnan(chisq), "NaN chi2 " << predVal << " " << dataVal
+    LogExitIf(std::isnan(chisq), "NaN chi2 " << predVal << " " << dataVal
                                               << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights << " "
                                               << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights);
 

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -99,7 +99,7 @@ namespace JointProbability{
                    << std::endl;
           LogError << "nomMC bin " << bin_
                    << " error is " << nomHistErr[bin_];
-          LogThrow("The mc uncertainty is not a usable number");
+          LogExit("The mc uncertainty is not a usable number");
         }
         else{
           return std::numeric_limits<double>::infinity();
@@ -115,7 +115,7 @@ namespace JointProbability{
           LogError << "The mcuncert is not finite " << mcuncert << std::endl;
           LogError << "predMC bin " << bin_
                    << " error is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
-          LogThrow("The mc uncertainty is not a usable number");
+          LogExit("The mc uncertainty is not a usable number");
         }
         else{
           return std::numeric_limits<double>::infinity();
@@ -170,7 +170,7 @@ namespace JointProbability{
       // b^2 - 4ac in quadratic equation
       double temp2 = temp * temp + 4 * dataVal * fractional * fractional;
       if(temp2 < 0){
-        if( throwIfInfLlh ){ LogThrow("Negative square root in Barlow Beeston"); }
+        if( throwIfInfLlh ){ LogExit("Negative square root in Barlow Beeston"); }
         else{ return std::numeric_limits<double>::infinity(); }
       }
 
@@ -249,7 +249,7 @@ namespace JointProbability{
                << GET_VAR_NAME_VALUE(stat) << std::endl
                << GET_VAR_NAME_VALUE(penalty) << std::endl
                << GET_VAR_NAME_VALUE(mcuncert) << std::endl;
-      LogThrow("Bad chisq for bin");
+      LogExit("Bad chisq for bin");
     }
 
     if(verboseLevel>=3){

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022Sfgd.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022Sfgd.h
@@ -78,7 +78,7 @@ namespace JointProbability{
     // b^2 - 4ac in quadratic equation
     double temp2 = temp * temp + 4 * dataVal * fractional * fractional;
 
-    LogThrowIf(temp2 < 0, "Negative square root in Barlow Beeston coefficient calculation!");
+    LogExitIf(temp2 < 0, "Negative square root in Barlow Beeston coefficient calculation!");
 
 
     // Solve for the positive beta

--- a/src/StatisticalInference/JointProbability/include/PluginJointProbability.h
+++ b/src/StatisticalInference/JointProbability/include/PluginJointProbability.h
@@ -52,11 +52,11 @@ namespace JointProbability{
       this->compile();
       this->load();
     }
-    else{ LogThrow("Can't initialize JointProbabilityPlugin without llhSharedLib nor llhPluginSrc."); }
+    else{ LogExit("Can't initialize JointProbabilityPlugin without llhSharedLib nor llhPluginSrc."); }
   }
 
   double PluginJointProbability::eval( const SamplePair& samplePair_, int bin_ ) const{
-    LogThrowIf(evalFcn == nullptr, "Library not loaded properly.");
+    LogExitIf(evalFcn == nullptr, "Library not loaded properly.");
     return reinterpret_cast<double (*)( double, double, double )>(evalFcn)(
         samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights,
         samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights,
@@ -70,17 +70,17 @@ namespace JointProbability{
 
     // create library
     std::stringstream ss;
-    LogThrowIf(getenv("CXX") == nullptr, "CXX env is not set. Can't compile.");
+    LogExitIf(getenv("CXX") == nullptr, "CXX env is not set. Can't compile.");
     ss << "$CXX -std=c++11 -shared " << llhPluginSrc << " -o " << llhSharedLib;
-    LogThrowIf(system(ss.str().c_str()) != 0, "Compile command failed.");
+    LogExitIf(system(ss.str().c_str()) != 0, "Compile command failed.");
   }
 
   void PluginJointProbability::load(){
     LogInfo << "Loading shared lib: " << llhSharedLib << std::endl;
     fLib = dlopen(llhSharedLib.c_str(), RTLD_LAZY);
-    LogThrowIf(fLib == nullptr, "Cannot open library: " << dlerror());
+    LogExitIf(fLib == nullptr, "Cannot open library: " << dlerror());
     evalFcn = (dlsym(fLib, "evalFct"));
-    LogThrowIf(evalFcn == nullptr, "Cannot open evalFcn");
+    LogExitIf(evalFcn == nullptr, "Cannot open evalFcn");
   }
 
 }

--- a/src/StatisticalInference/JointProbability/src/JointProbability.cpp
+++ b/src/StatisticalInference/JointProbability/src/JointProbability.cpp
@@ -28,7 +28,7 @@ namespace JointProbability{
     auto jType{JointProbabilityType::toEnum( type_, true )};
 
     if( jType == JointProbabilityType::EnumOverflow  ){
-      LogThrow( "Unknown JointProbabilityType: " << type_ );
+      LogExit( "Unknown JointProbabilityType: " << type_ );
     }
 
     return makeJointProbability( jType );
@@ -62,7 +62,7 @@ namespace JointProbability{
         out = std::make_unique<BarlowBeestonBanff2022Sfgd>();
         break;
       default:
-        LogThrow( "Unknown JointProbabilityType: " << type_.toString() );
+        LogExit( "Unknown JointProbabilityType: " << type_.toString() );
     }
 
     return out.release();

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -472,7 +472,7 @@ void LikelihoodInterface::buildSamplePairList(){
 
   auto nModelSamples{_modelPropagator_.getSampleSet().getSampleList().size()};
   auto nDataSamples{_dataPropagator_.getSampleSet().getSampleList().size()};
-  LogThrowIf(nModelSamples != nDataSamples,
+  LogExitIf(nModelSamples != nDataSamples,
              "Mismatching number of samples for model(" << nModelSamples <<
                                                         ") and data(" << nDataSamples << ") propagators."
   );

--- a/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
+++ b/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
@@ -35,7 +35,7 @@ void ParameterScanner::configureImpl() {
 void ParameterScanner::initializeImpl() {
   LogWarning << "Initializing ParameterScanner..." << std::endl;
 
-  LogThrowIf(_likelihoodInterfacePtr_ == nullptr, "_likelihoodInterfacePtr_ not set.");
+  LogExitIf(_likelihoodInterfacePtr_ == nullptr, "_likelihoodInterfacePtr_ not set.");
 
   _scanDataDict_.clear();
   if( GenericToolbox::Json::fetchValue(_varsConfig_, "llh", true) ){
@@ -140,13 +140,13 @@ void ParameterScanner::initializeImpl() {
 }
 
 void ParameterScanner::scanParameterList( std::vector<Parameter>& par_, TDirectory* saveDir_){
-  LogThrowIf(not isInitialized());
-  LogThrowIf(saveDir_ == nullptr);
+  LogExitIf(not isInitialized());
+  LogExitIf(saveDir_ == nullptr);
   for( auto& par : par_ ){ this->scanParameter(par, saveDir_); }
 }
 void ParameterScanner::scanParameter(Parameter& par_, TDirectory* saveDir_) {
-  LogThrowIf(not isInitialized());
-  LogThrowIf(saveDir_ == nullptr);
+  LogExitIf(not isInitialized());
+  LogExitIf(saveDir_ == nullptr);
   std::vector<double> parPoints(_nbPoints_+1,0);
 
   LogInfo << "Scanning: " << par_.getFullTitle() << " / " << _nbPoints_ << " steps..." << std::endl;
@@ -173,7 +173,7 @@ void ParameterScanner::scanParameter(Parameter& par_, TDirectory* saveDir_) {
       offSet = 1;
     }
 
-    LogThrowIf(
+    LogExitIf(
         std::isnan(newVal),
         "Scanning point is nan. Current values are: "
             << std::endl
@@ -250,8 +250,8 @@ void ParameterScanner::scanSegment(TDirectory *saveDir_, const JsonType &end_, c
       []{ ParameterSet::unmuteLogger(); ParametersManager::unmuteLogger(); }
   );
 
-  LogThrowIf(end_.empty(), "Ending injector config is empty()");
-  LogThrowIf(nSteps_ < 0, "Invalid nSteps");
+  LogExitIf(end_.empty(), "Ending injector config is empty()");
+  LogExitIf(nSteps_ < 0, "Invalid nSteps");
 
   // nSteps_+2 as we also want the first and last points
   int nTotalSteps = nSteps_+2;
@@ -330,8 +330,8 @@ void ParameterScanner::scanSegment(TDirectory *saveDir_, const JsonType &end_, c
   _likelihoodInterfacePtr_->propagateAndEvalLikelihood();
 }
 void ParameterScanner::generateOneSigmaPlots(TDirectory* saveDir_){
-  LogThrowIf(not isInitialized());
-  LogThrowIf(saveDir_ == nullptr, "saveDir_ not set.");
+  LogExitIf(not isInitialized());
+  LogExitIf(saveDir_ == nullptr, "saveDir_ not set.");
 
   // Build the histograms with the current parameters
   _likelihoodInterfacePtr_->getModelPropagator().propagateParameters();
@@ -392,7 +392,7 @@ void ParameterScanner::generateOneSigmaPlots(TDirectory* saveDir_){
 
 }
 void ParameterScanner::varyEvenRates(const std::vector<double>& paramVariationList_, TDirectory* saveDir_){
-  LogThrowIf(not isInitialized());
+  LogExitIf(not isInitialized());
   saveDir_->cd();
 
   LogInfo << __METHOD_NAME__ << std::endl;

--- a/src/Utils/include/RootUtils.h
+++ b/src/Utils/include/RootUtils.h
@@ -38,7 +38,7 @@ namespace RootUtils{
     }
     if( obj == nullptr ){
       LogErrorIf(not ObjectReader::quiet) << redLightText << "Could not find object among names: " << resetColor << GenericToolbox::toString(objPathList_) << std::endl;
-      LogThrowIf(ObjectReader::throwIfNotFound, "Object not found.");
+      LogExitIf(ObjectReader::throwIfNotFound, "Object not found.");
       return false;
     }
     action_(obj);

--- a/src/Utils/src/Bin.cpp
+++ b/src/Utils/src/Bin.cpp
@@ -31,7 +31,7 @@ void Bin::Edges::configureImpl(){
     isConditionVar = true;
   }
   else{
-    LogThrow("No bound definition for edges: " << _config_);
+    LogExit("No bound definition for edges: " << _config_);
   }
 
 }
@@ -93,7 +93,7 @@ void Bin::addBinEdge( const std::string &variableName_, double lowEdge_, double 
 // Getters
 const Bin::Edges& Bin::getVarEdges( const std::string& varName_ ) const{
   auto* varEgdesPtr{getVarEdgesPtr(varName_)};
-  LogThrowIf(varEgdesPtr == nullptr, "Couldn't find varEdges corresponding to varName:" << varName_);
+  LogExitIf(varEgdesPtr == nullptr, "Couldn't find varEdges corresponding to varName:" << varName_);
   return *varEgdesPtr;
 }
 const Bin::Edges* Bin::getVarEdgesPtr( const std::string& varName_ ) const{
@@ -132,7 +132,7 @@ bool Bin::isOverlapping( const Bin& other_) const{
   return true;
 }
 bool Bin::isInBin( const std::vector<double>& valuesList_) const{
-  LogThrowIf( valuesList_.size() != _binEdgesList_.size(),
+  LogExitIf( valuesList_.size() != _binEdgesList_.size(),
               "Provided " << GET_VAR_NAME_VALUE(valuesList_.size()) << " does not match " << GET_VAR_NAME_VALUE(_binEdgesList_.size()));
   const double* buf = &valuesList_[0];
 

--- a/src/Utils/src/BinSet.cpp
+++ b/src/Utils/src/BinSet.cpp
@@ -34,7 +34,7 @@ void BinSet::configureImpl() {
     if( GenericToolbox::hasExtension(_filePath_, "txt") ){ this->readTxtBinningDefinition(); }
   }
   else{
-    LogThrow("Unknown binning config entry: " << GenericToolbox::Json::toReadableString(_config_));
+    LogExit("Unknown binning config entry: " << GenericToolbox::Json::toReadableString(_config_));
   }
 
   this->sortBinEdges();
@@ -56,7 +56,7 @@ void BinSet::checkBinning(){
     }
   }
 
-  LogThrowIf(hasErrors);
+  LogExitIf(hasErrors);
 
 }
 std::string BinSet::getSummary() const{
@@ -172,7 +172,7 @@ void BinSet::readTxtBinningDefinition(){
       for( size_t iElement = 1 ; iElement < lineElements.size() ; iElement++ ){
 
         if( not expectedVariableList.empty() and lineElements.at(iElement) == expectedVariableList.back() ){
-          LogThrowIf(
+          LogExitIf(
               expectedVariableIsRangeList.back(),
               "Same variable appear more than 2 times: " << GenericToolbox::toString(lineElements)
           );
@@ -280,7 +280,7 @@ void BinSet::readBinningConfig( const JsonType& binning_){
         auto maxVal( GenericToolbox::Json::fetchValue<double>(binDefEntry, "max") );
 
         double step{(maxVal - minVal)/nBins};
-        LogThrowIf( step <= 0, "Invalid binning: " << GenericToolbox::Json::toReadableString(binDefEntry) );
+        LogExitIf( step <= 0, "Invalid binning: " << GenericToolbox::Json::toReadableString(binDefEntry) );
 
         dim.edgesList.reserve( nBins + 1 );
         double edgeValue{minVal};
@@ -291,13 +291,13 @@ void BinSet::readBinningConfig( const JsonType& binning_){
         dim.edgesList.emplace_back( edgeValue );
       }
       else{
-        LogThrow("Unrecognised binning definition: " << binningDefinition);
+        LogExit("Unrecognised binning definition: " << binningDefinition);
       }
 
       dim.nBins = int( dim.edgesList.size() );
       if( not dim.isEdgesDiscreteValues ){ dim.nBins--; }
 
-      LogThrowIf(dim.nBins == 0, "Invalid edgesList for binEdgeEntry: " << GenericToolbox::Json::toReadableString(binDefEntry));
+      LogExitIf(dim.nBins == 0, "Invalid edgesList for binEdgeEntry: " << GenericToolbox::Json::toReadableString(binDefEntry));
     }
 
     int nBinsTotal{1};

--- a/src/Utils/src/ConfigUtils.cpp
+++ b/src/Utils/src/ConfigUtils.cpp
@@ -38,7 +38,7 @@ namespace ConfigUtils {
         output = GenericToolbox::Json::readConfigFile(configFilePath_);
       }
     }
-    catch(...){ LogThrow("Error while reading config file: " << configFilePath_); }
+    catch(...){ LogExit("Error while reading config file: " << configFilePath_); }
 
     // resolve sub-references to other config files
     ConfigUtils::unfoldConfig( output );
@@ -140,7 +140,7 @@ namespace ConfigUtils {
   ConfigHandler::ConfigHandler(const std::string& filePath_){
     if( GenericToolbox::hasExtension( filePath_, "root" ) ){
       LogInfo << "Extracting config file for fitter file: " << filePath_ << std::endl;
-      LogThrowIf( not GenericToolbox::doesTFileIsValid(filePath_), "Invalid root file: " << filePath_ );
+      LogExitIf( not GenericToolbox::doesTFileIsValid(filePath_), "Invalid root file: " << filePath_ );
       auto fitFile = std::shared_ptr<TFile>( GenericToolbox::openExistingTFile( filePath_ ) );
 
       auto* conf = fitFile->Get<TNamed>("gundam/config_TNamed");
@@ -148,7 +148,7 @@ namespace ConfigUtils {
         // legacy
         conf = fitFile->Get<TNamed>("gundamFitter/unfoldedConfig_TNamed");
       }
-      LogThrowIf(conf==nullptr, "no config in ROOT file " << filePath_);
+      LogExitIf(conf==nullptr, "no config in ROOT file " << filePath_);
       config = GenericToolbox::Json::readConfigJsonStr( conf->GetTitle() );
       fitFile->Close();
     }
@@ -163,7 +163,7 @@ namespace ConfigUtils {
   }
   void ConfigHandler::override( const std::string& filePath_ ){
     LogInfo << "Overriding config with \"" << filePath_ << "\"" << std::endl;
-    LogThrowIf(not GenericToolbox::isFile(filePath_), "Could not find " << filePath_);
+    LogExitIf(not GenericToolbox::isFile(filePath_), "Could not find " << filePath_);
     this->override( ConfigUtils::readConfigFile(filePath_) );
   }
   void ConfigHandler::override( const std::vector<std::string>& filesList_ ){

--- a/src/Utils/src/GundamUtils.cpp
+++ b/src/Utils/src/GundamUtils.cpp
@@ -38,7 +38,7 @@ namespace GundamUtils {
       return true;
     }
     auto minVersionSplit = GenericToolbox::splitString(minVersion_, ".");
-    LogThrowIf(minVersionSplit.size() != 3, "Invalid version format: " << minVersion_);
+    LogExitIf(minVersionSplit.size() != 3, "Invalid version format: " << minVersion_);
 
     // stripping "f" tag
     if( minVersionSplit[2].back() == 'f' ){ minVersionSplit[2].pop_back(); }


### PR DESCRIPTION
GUNDAM has been designed such that it stops whenever something wrong is happening. `LogThrow` were wrongly used to stop the program as `throw` would be called (still allowing devs to catch these errors) and sometimes the logger wouldn't show the last lines as std::cout don't get properly flushed.

std::exit() makes sure both issues are addressed. `LogThrow` might be used in the future for very specific cases.