### PR TITLE
Broader input reading with different ROOT object types 

### DIFF
--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -525,6 +525,8 @@ bool DialCollection::initializeDialsWithBinningFile(const JsonType& dialsDefinit
   // Get the filename for a file with the object array of dials (graphs)
   // that will be applied based on the binning.
   auto filePath = GenericToolbox::Json::fetchValue<std::string>(dialsDefinition, "dialsFilePath");
+  filePath = GenericToolbox::expandEnvironmentVariables(filePath);
+
   LogThrowIf(not GenericToolbox::doesTFileIsValid(filePath), "Could not open: " << filePath);
   TFile* dialsTFile = TFile::Open(filePath.c_str());
   LogThrowIf(dialsTFile==nullptr, "Could not open: " << filePath);

--- a/src/StatisticalInference/JointProbability/src/JointProbability.cpp
+++ b/src/StatisticalInference/JointProbability/src/JointProbability.cpp
@@ -28,7 +28,7 @@ namespace JointProbability{
     auto jType{JointProbabilityType::toEnum( type_, true )};
 
     if( jType == JointProbabilityType::EnumOverflow  ){
-      LogThrow( "Unknown JointProbabilityType: " << type_ );
+      LogThrow( "Unknown JointProbabilityType: " << type_ << std::endl << "Available: " << JointProbabilityType::generateEnumStrList() );
     }
 
     return makeJointProbability( jType );


### PR DESCRIPTION
Using different inputs for various analyses, some people use slightly different object type than the one that are assumed by GUNDAM. In order to reprocess the input, this feature allows GUNDAM to convert automatically the objects to the appropriate type when possible.