### PR TITLE
loop over nBin not starting from 1 like TH1D

### DIFF
--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -285,7 +285,7 @@ void RootMinimizer::minimize(){
     samplesArrList[iSample].writeRawData( getLikelihoodInterface().evalStatLikelihood( samplePair ) );
 
     int nBins = samplePair.model->getHistogram().getNbBins();
-    for( int iBin = 1 ; iBin <= nBins ; iBin++ ){
+    for( int iBin = 0 ; iBin < nBins ; iBin++ ){
       leavesDict.emplace_back("llhSample_bin" + std::to_string(iBin) + "/D");
       samplesArrList[iSample].writeRawData( getLikelihoodInterface().getJointProbabilityPtr()->eval(samplePair, iBin) );
     }

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -104,6 +104,14 @@ namespace JointProbability{
                    << std::endl;
           LogError << "nomMC bin " << bin_
                    << " error is " << nomHistErr[bin_];
+
+          DEBUG_VAR(bin_);
+          DEBUG_VAR(mcuncert);
+          DEBUG_VAR(nomHistErr[bin_]);
+          DEBUG_VAR(nomHistErr.size());
+          DEBUG_VAR(nomHistErr.size());
+          DEBUG_VAR(GenericToolbox::toString(nomHistErr));
+
           LogThrow("The mc uncertainty is not a usable number");
         }
         else{


### PR DESCRIPTION
After a successful fit, GUNDAM would complain while writing a breakdown of llh:
```
2024.11.29 16:59:35  INFO RootMinimizer: Minimization ended after 46225 calls.
2024.11.29 16:59:35  WARN RootMinimizer: Status code: status = 0    : OK
2024.11.29 16:59:35  WARN RootMinimizer: Covariance matrix status code: status = 3    : accurate
2024.11.29 16:59:35  WARN RootMinimizer: Updating propagator cache to the best fit point...
2024.11.29 16:59:35  INFO RootMinimizer: Writing Minuit2/Migrad best fit parameters...
2024.11.29 16:59:35 ALERT RootMinimizer: Skipping saveGradientSteps as light output mode is fired.
2024.11.29 16:59:35  INFO RootMinimizer: Minimization has converged!
2024.11.29 16:59:35  INFO RootMinimizer: Writing convergence stats...
2024.11.29 16:59:35 ERROR BarlowBeestonBanff2022: BBNoUpdateWeights mcuncert is not valid -nan
2024.11.29 16:59:35 ERROR BarlowBeestonBanff2022: nomMC bin 154 error is -nan(virtual double JointProbability::BarlowBeestonBanff2022::eval(const SamplePair&, int) const): The mc uncertainty is not a usable number
```