### PR TITLE
LTS/1.8.x: Fix the fix that broke weight calculation

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -24,8 +24,8 @@ option( USE_STATIC_LINKS "Use static link of libraries and apps instead of share
 option( CXX_WARNINGS "Enable most C++ warning flags." ON )
 option( CXX_MARCH_FLAG "Enable cpu architecture specific optimisations." OFF )
 option( CMAKE_CXX_EXTENSIONS "Enable GNU extensions to C++ language (-std=gnu++14)." OFF )
-option( ENABLE_TESTS "Build CMake tests (optionally uses googletest)." OFF )
-option( SKIP_GOOGLE_TEST "Skip GTest unit tests (other tests enabled)." OFF )
+option( ENABLE_TESTS "Build CMake tests (optionally uses googletest)." ON )
+option( SKIP_GOOGLE_TEST "Skip GTest unit tests (other tests enabled)." ON )
 
 # Reading options
 ##################

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -136,10 +136,6 @@ namespace {
         CHECK_OFFSET(1);
 #endif
 
-        // handle positive extrapolation
-        // this ensures that x2 exists in the array
-        if( ix + 1 >= knotCount ){ ix--; }
-
         const double x1 = data[2+3*ix+2];
         const double x2 = data[2+3*(ix+1)+2];
         const double step = x2-x1;

--- a/src/Utils/include/CalculateGraph.h
+++ b/src/Utils/include/CalculateGraph.h
@@ -63,7 +63,7 @@ namespace {
         CHECK_OFFSET(1);
 
 #define CALCULATE_GRAPH_EXTRA_SAFETY_CHECK
-#undef CALCULATE_GRAPH_CONTINUE_ON_FATAL_ERROR
+#define CALCULATE_GRAPH_CONTINUE_ON_FATAL_ERROR
 #if defined(CALCULATE_GRAPH_EXTRA_SAFETY_CHECK) and not defined(__CUDACC__)
         // Double check the range calculations.  This is debugging code, so it
         // isn't intended to run on the GPU. It also assumes the iostream has
@@ -79,7 +79,7 @@ namespace {
             }
             ix = 0;
 #ifndef CALCULATE_GRAPH_CONTINUE_ON_FATAL_ERROR
-            throw std::runtime_error("CalculateGraph Error");
+            std::exit(EXIT_FAILURE);
 #endif
         }
         if (ix > knotCount-2) {
@@ -93,7 +93,7 @@ namespace {
             }
             ix = knotCount - 2;
 #ifndef CALCULATE_GRAPH_CONTINUE_ON_FATAL_ERROR
-            throw std::runtime_error("CalculateGraph Error");
+            std::exit(EXIT_FAILURE);
 #endif
         }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,13 +30,15 @@ add_test(
 ## Compiled unit tests using GoogleTest.  These are only run if GTest
 ## is found.
 if (NOT SKIP_GOOGLE_TEST)
+  # Use the pre cmake 1.10 interface because we set 3.5 as the minimum cmake
   find_package(GTest)
 else()
   cmessage( WARNING "GTest unit testing explicitly disabled by user")
 endif()
 if (NOT GTEST_FOUND)
-  cmessage( WARNING "GTest package disabled or not found.  Disable unit tests.")
+  cmessage( WARNING "GTest package not available.  Disable developer tests.")
 else()
+  cmessage( WARNING "GTest package enabled for developer unit tests.")
   enable_testing()
 
   # Setup the hemi test suite for the host

--- a/tests/fast-tests/100CheckGeneralSpline.C
+++ b/tests/fast-tests/100CheckGeneralSpline.C
@@ -77,8 +77,8 @@ int main() {
         }
         TGraph generalSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin();
-             xxx<=spline.GetXmax(); xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-1.0;
+             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateGeneralSpline(xxx,-100.0, 100.0,
@@ -129,8 +129,8 @@ int main() {
         }
         TGraph generalSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin();
-             xxx<=spline.GetXmax(); xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-1.0;
+             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateGeneralSpline(xxx,-100.0, 100.0,

--- a/tests/fast-tests/100CheckGraph.C
+++ b/tests/fast-tests/100CheckGraph.C
@@ -57,7 +57,7 @@ int main() {
         }
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
-        for (double x = -1.0; x <= 2.0; x += 0.1) {
+        for (double x = -2.0; x <= 2.0; x += 0.1) {
             double v = CalculateGraph(x, -10.0, 10.0, data, 2*nData);
             TOLERANCE("Two Point Tolerance", x, v, 1E-6);
             graph1->SetPoint(p++,x,v);
@@ -87,7 +87,7 @@ int main() {
             double v0 = CalculateGraph(x, -10.0, 10.0, data, 2*nData);
             double v1 = CalculateGraph(-x, -10.0, 10.0, data, 2*nData);
             std::ostringstream tmp;
-            tmp << "Symmetric tolerance (test 2) (X=" << x << ")";
+            tmp << "Three Point Graph (test 2) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
             graph1->SetPoint(p++,x,v0);
         }
@@ -100,6 +100,40 @@ int main() {
 
 #define TEST3
 #ifdef TEST3
+    {
+        // Test interpolation between 4 points
+        int nData = 4;
+        double data[] = {
+            1.0, -2.0,
+            0.0, -1.0,
+            0.0, 1.0,
+            1.0, 2.0,
+        };
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -12.0; x <= 12.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
+            std::ostringstream tmp;
+            tmp << "Four Point Graph (test 3) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph3.pdf");
+        gPad->Print("100CheckGraph3.png");
+    }
+#endif
+
+#define TEST4
+#ifdef TEST4
     {
         // Test interpolation between 19 points
         int nData = 19;
@@ -123,13 +157,6 @@ int main() {
             20.0, 7.0,
             29.0, 8.0,
             30.0, 9.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
-            0.0, 0.0,
         };
         std::unique_ptr<TGraph> data1(new TGraph());
         for (int p=0; p<nData; ++p) {
@@ -143,17 +170,119 @@ int main() {
             double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
             double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
             std::ostringstream tmp;
-            tmp << "Symmetric tolerance (test 4) (X=" << x << ")";
+            tmp << "Large Graph (test 4) (X=" << x << ")";
             TOLERANCE(tmp.str(), v0, v1, 1E-6);
             graph1->SetPoint(p++,x,v0);
         }
         graph1->Draw("AC");
         data1->Draw("*,same");
-        gPad->Print("100CheckGraph3.pdf");
-        gPad->Print("100CheckGraph3.png");
+        gPad->Print("100CheckGraph4.pdf");
+        gPad->Print("100CheckGraph4.png");
     }
 #endif
 
+#define TEST5
+#ifdef TEST5
+    {
+        // Test interpolation between 4 asymetric points
+        int nData = 4;
+        double data[] = {
+            -1.0, -2.0,
+            0.0, -1.0,
+            0.0, 1.0,
+            1.0, 2.0,
+        };
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -12.0; x <= 12.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
+            std::ostringstream tmp;
+            tmp << "Four Point Graph (test 5) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, -v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph5.pdf");
+        gPad->Print("100CheckGraph5.png");
+    }
+#endif
+
+#define TEST6
+#ifdef TEST6
+    {
+        // Test interpolation between 4 asymetric points
+        int nData = 4;
+        double data[] = {
+            1.0, -2.0,
+            0.0, -1.0,
+            0.0, 1.0,
+            -1.0, 2.0,
+        };
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -12.0; x <= 12.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
+            std::ostringstream tmp;
+            tmp << "Four Point Graph (test 6) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, -v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph6.pdf");
+        gPad->Print("100CheckGraph6.png");
+    }
+#endif
+
+#define TEST7
+#ifdef TEST7
+    {
+        // Test interpolation between 5 asymetric points
+        int nData = 5;
+        double data[] = {
+            1.0, -2.0,
+            0.0, -1.0,
+            0.0, 0.0,
+            0.0, 1.0,
+            -1.0, 2.0,
+        };
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[2*p+1];
+            double y = data[2*p+0];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -12.0; x <= 12.0; x += 0.1) {
+            double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
+            double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
+            std::ostringstream tmp;
+            tmp << "Five Point Graph (test 7) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, -v1, 1E-7);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckGraph7.pdf");
+        gPad->Print("100CheckGraph7.png");
+    }
+#endif
 
     return status;
 }

--- a/tests/fast-tests/100CheckGraph.C
+++ b/tests/fast-tests/100CheckGraph.C
@@ -83,7 +83,7 @@ int main() {
         }
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
-        for (double x = -2.0; x <= 2.0; x += 0.1) {
+        for (double x = -3.0; x <= 3.0; x += 0.1) {
             double v0 = CalculateGraph(x, -10.0, 10.0, data, 2*nData);
             double v1 = CalculateGraph(-x, -10.0, 10.0, data, 2*nData);
             std::ostringstream tmp;
@@ -139,7 +139,7 @@ int main() {
         }
         std::unique_ptr<TGraph> graph1(new TGraph());
         int p = 0;
-        for (double x = -10.0; x <= 10.0; x += 0.1) {
+        for (double x = -12.0; x <= 12.0; x += 0.1) {
             double v0 = CalculateGraph(x, -50.0, 50.0, data, 2*nData);
             double v1 = CalculateGraph(-x, -50.0, 50.0, data, 2*nData);
             std::ostringstream tmp;

--- a/tests/fast-tests/100CheckUniformSpline.C
+++ b/tests/fast-tests/100CheckUniformSpline.C
@@ -111,7 +111,7 @@ int main() {
         spline.SetLineColor(kRed);
         spline.Draw("same");
         const int nKnots = spline.GetNp();
-        const int dim = 3*nKnots + 2;
+        const int dim = 2*nKnots + 2;
         double data[dim];
         data[0] = -3.0;
         data[1] = 1.0;
@@ -132,7 +132,7 @@ int main() {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateUniformSpline(xxx,-100.0, 100.0,
-                                       data, dim);
+                                         data, dim);
             uniformSpline.SetPoint(point++, xxx, calcValue);
             TOLERANCE("Test1: Spline Mismatch", splineValue, calcValue, 1E-6);
         }

--- a/tests/fast-tests/100CheckUniformSpline.C
+++ b/tests/fast-tests/100CheckUniformSpline.C
@@ -76,8 +76,8 @@ int main() {
         }
         TGraph uniformSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin();
-             xxx<=spline.GetXmax(); xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-1.0;
+             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateUniformSpline(xxx,-100.0, 100.0,
@@ -127,8 +127,8 @@ int main() {
         }
         TGraph uniformSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin();
-             xxx<=spline.GetXmax(); xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-1.0;
+             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateUniformSpline(xxx,-100.0, 100.0,


### PR DESCRIPTION
Fix an attempt to fix a (non) bug in the bounds check for general spline.  The tests work now that the (non) bug fix is no longer applied.  This extends the testing for `CalculateGeneralSpline.h` and `CalculateUniformSpline.h` to more rigorously check that extrapolation is done correctly.

As part of making the testing work again, this fixes `options.cmake` where a recent attempt to disable GoogleTests was done using the wrong config definition (`ENABLE_TESTS` was used, but GoogleTests is disabled using `SKIP_GOOGLE_TEST`).  The default now correctly handles `ctest` (and `make test`) and disables `GoogleTests`