### PR TITLE
LTS/1.8.x: Hot fix 100CheckGraph.C

### DIFF
--- a/tests/fast-tests/100CheckGraph.C
+++ b/tests/fast-tests/100CheckGraph.C
@@ -7,6 +7,8 @@ root <<EOF
 #include <memory>
 #include <cmath>
 
+#define LogError std::cout
+
 ////////////////////////////////////////////////////////////////////////
 // Test the CalculateCompactSpline routine on the CPU.
 


### PR DESCRIPTION
Missed a commit in 100CheckGraph.C that is needed for the #713 tests.  No excuses!  I missed a one-liner in the testing macro and didn't notice it wasn't part of the push.