### PR TITLE
Feature/testable joint probabilities

### DIFF
--- a/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
@@ -13,6 +13,7 @@ namespace JointProbability{
   class BarlowBeeston : public JointProbabilityBase {
   public:
     [[nodiscard]] std::string getType() const override { return "BarlowBeeston"; }
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
     [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
 
     struct Buffer{ double rel_var, b, c, beta, mc_hat, chi2; };
@@ -20,26 +21,37 @@ namespace JointProbability{
   };
 
   double BarlowBeeston::eval(const SamplePair& samplePair_, int bin_) const {
-    _buf_.rel_var = samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights / TMath::Sq(samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights);
-    _buf_.b       = (samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights * _buf_.rel_var) - 1;
-    _buf_.c       = 4 * samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights * _buf_.rel_var;
+    const double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
+    const double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
+    const double mcUncert = samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
+    return eval(dataVal, predVal, mcUncert, bin_);
+  }
+
+  double BarlowBeeston::eval(double data_, double pred_, double err_, int bin_) const {
+    const double dataVal = data_;
+    const double predVal = pred_;
+    const double mcUncert = err_;
+
+    _buf_.rel_var = mcUncert / TMath::Sq(predVal);
+    _buf_.b       = (predVal * _buf_.rel_var) - 1;
+    _buf_.c       = 4 * dataVal * _buf_.rel_var;
 
     _buf_.beta   = (-_buf_.b + std::sqrt(_buf_.b * _buf_.b + _buf_.c)) / 2.0;
-    _buf_.mc_hat = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights * _buf_.beta;
+    _buf_.mc_hat = predVal * _buf_.beta;
 
     // Calculate the following LLH:
     //-2lnL = 2 * beta*mc - data + data * ln(data / (beta*mc)) + (beta-1)^2 / sigma^2
     // where sigma^2 is the same as above.
     _buf_.chi2 = 0.0;
-    if(samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights <= 0.0) {
+    if(dataVal <= 0.0) {
       _buf_.chi2 = 2 * _buf_.mc_hat;
       _buf_.chi2 += (_buf_.beta - 1) * (_buf_.beta - 1) / _buf_.rel_var;
     }
     else{
-      _buf_.chi2 = 2 * (_buf_.mc_hat - samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights);
-      if(samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights > 0.0) {
-        _buf_.chi2 += 2 * samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights *
-                      std::log(samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights / _buf_.mc_hat);
+      _buf_.chi2 = 2 * (_buf_.mc_hat - dataVal);
+      if(dataVal > 0.0) {
+        _buf_.chi2 += 2 * dataVal *
+                      std::log(dataVal / _buf_.mc_hat);
       }
       _buf_.chi2 += (_buf_.beta - 1) * (_buf_.beta - 1) / _buf_.rel_var;
     }
@@ -47,5 +59,4 @@ namespace JointProbability{
   }
 
 }
-
 #endif // GUNDAM_BARLOW_BEESTON_H

--- a/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
@@ -7,9 +7,11 @@
 
 #include "JointProbabilityBase.h"
 
-
 namespace JointProbability{
 
+  /// Provide an implementation of the "classic" Barlow-Beeston LLH.  It's not
+  /// suitable for "real" work since it's not numerically stable for all input
+  /// values.
   class BarlowBeeston : public JointProbabilityBase {
   public:
     [[nodiscard]] std::string getType() const override { return "BarlowBeeston"; }
@@ -50,8 +52,7 @@ namespace JointProbability{
     else{
       _buf_.chi2 = 2 * (_buf_.mc_hat - dataVal);
       if(dataVal > 0.0) {
-        _buf_.chi2 += 2 * dataVal *
-                      std::log(dataVal / _buf_.mc_hat);
+          _buf_.chi2 += 2 * dataVal * (TMath::Log(dataVal) - TMath::Log(_buf_.mc_hat));
       }
       _buf_.chi2 += (_buf_.beta - 1) * (_buf_.beta - 1) / _buf_.rel_var;
     }

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2020.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2020.h
@@ -7,30 +7,25 @@
 
 #include "JointProbabilityBase.h"
 
-
 namespace JointProbability{
 
   class BarlowBeestonBanff2020 : public JointProbabilityBase {
   public:
     [[nodiscard]] std::string getType() const override { return "BarlowBeestonBanff2020"; }
-    [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
   };
 
-  double BarlowBeestonBanff2020::eval(const SamplePair& samplePair_, int bin_) const {
+  double BarlowBeestonBanff2020::eval(double data_, double pred_, double err_, int bin_) const {
     // From BANFF: origin/OA2020 branch -> BANFFBinnedSample::CalcLLRContrib()
-
-    //Loop over all the bins one by one using their unique bin index.
-    //Use the stored nBins value and bins array so avoid trying to calculate
-    //over underflow or overflow bins.
-    double chisq{0};
-
-    double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
-    double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
-    double mcuncert = samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
 
     //implementing Barlow-Beeston correction for LH calculation the
     //following comments are inspired/copied from Clarence's comments in the
     //MaCh3 implementation of the same feature
+    double dataVal{data_};
+    double predVal{pred_};
+    double mcuncert{err_};
+
+    double chisq{0.};
 
     // The MC used in the likeliihood calculation
     // Is allowed to be changed by Barlow Beeston beta parameters
@@ -79,17 +74,15 @@ namespace JointProbability{
 
     if(std::isinf(chisq)){
       LogAlert << "Infinite chi2 " << predVal << " " << dataVal << " "
-               << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights << " "
-               << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights << std::endl;
+               << err_ << " "
+               << pred_ << std::endl;
     }
 
     LogThrowIf(std::isnan(chisq), "NaN chi2 " << predVal << " " << dataVal
-                                              << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights << " "
-                                              << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights);
+               << err_ << " " << pred_);
 
     return chisq;
   }
-
 }
 
 #endif //GUNDAM_BARLOW_BEESTON_BANFF_2020_H

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -21,6 +21,7 @@ namespace JointProbability{
   public:
     [[nodiscard]] std::string getType() const override { return "BarlowBeestonBanff2022"; }
     [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
 
     void createNominalMc(const Sample& modelSample_) const;
     void printConfiguration() const;
@@ -134,6 +135,13 @@ namespace JointProbability{
         }
       }
     }
+    return eval(dataVal, predVal, mcuncert, bin_);
+  }
+
+  double BarlowBeestonBanff2022::eval(double data_, double pred_, double err_, int bin_) const {
+    double dataVal = data_;
+    double predVal = pred_;
+    double mcuncert = err_;
 
     // Add the (broken) expected value threshold that we saw in the old
     // likelihood. This is here to help understand the old behavior.
@@ -253,7 +261,6 @@ namespace JointProbability{
 
     if( throwIfInfLlh and not std::isfinite(chisq) ) GUNDAM_UNLIKELY_COMPILER_FLAG {
       LogError << "Infinite chi2: " << chisq << std::endl
-               << GET_VAR_NAME_VALUE(samplePair_.model->getName()) << std::endl
                << GET_VAR_NAME_VALUE(bin_) << std::endl
                << GET_VAR_NAME_VALUE(predVal) << std::endl
                << GET_VAR_NAME_VALUE(dataVal) << std::endl
@@ -300,7 +307,4 @@ namespace JointProbability{
   }
 
 }
-
-
-
 #endif //GUNDAM_BARLOW_BEESTON_BANFF_2022_H

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -30,26 +30,31 @@ namespace JointProbability{
     bool throwIfInfLlh{true};
     bool allowZeroMcWhenZeroData{true};
     bool usePoissonLikelihood{false};
-    bool BBNoUpdateWeights{false}; // OA 2021 bug reimplementation
-    // OA2021 and BANFF fractional error limitation is only relevent with
-    // BBNoUpdateWeights is true, and is needed to reproduce bugs when it is
-    // true.  When BBNoUpdateWeights is false, the fractional error will
-    // naturally be limited to less than 100%.  Physically, the fractional
-    // uncertainty should be less than 100% since one MC event in a bin would
-    // have 100% fractional uncertainty [under the "Gaussian" approximation,
-    // so sqrt(1.0)/1.0].  The OA2021 behavior lets the fractional error grow,
-    // but the entire likelihood became discontinuous around a predicted value
-    // of 1E-16. Setting fractionalErrorLimit to 1E+19 matches OA2021 before
-    // the discontinuity.  The BANFF behavior has the likelihood failed around
-    // 1E-154.  Setting fractionalErrorLimit to 1E+150 matchs BANFF.  In both
-    // cases, the new likelihood behaves reasonably all the way to zero.
+    /// BANFF OA 2021 bug reimplementation -- Used to validate against the T2K
+    /// BANFF OA2021 fit.
+    bool BBNoUpdateWeights{false};
+    /// OA2021 and BANFF fractional error limitation is only relevent with
+    /// BBNoUpdateWeights is true, and is needed to reproduce bugs when it is
+    /// true.  When BBNoUpdateWeights is false, the fractional error will
+    /// naturally be limited to less than 100%.  Physically, the fractional
+    /// uncertainty should be less than 100% since one MC event in a bin would
+    /// have 100% fractional uncertainty [under the "Gaussian" approximation,
+    /// so sqrt(1.0)/1.0].  The OA2021 behavior lets the fractional error
+    /// grow, but the entire likelihood became discontinuous around a
+    /// predicted value of 1E-16. Setting fractionalErrorLimit to 1E+19
+    /// matches OA2021 before the discontinuity.  The BANFF behavior has the
+    /// likelihood failed around 1E-154.  Setting fractionalErrorLimit to
+    /// 1E+150 matchs BANFF.  In both cases, the new likelihood behaves
+    /// reasonably all the way to zero.
     double fractionalErrorLimit{1.0E+150};
-    // OA2021 bug reimplmentation (set to numeric_limits::min() to reproduce
-    // the bug).
+    /// BANFF OA2021 bug reimplmentation -- Used to validate against the T2K
+    /// BANFF OA2021 fit (set to numeric_limits::min() to reproduce the bug)
     double expectedValueMinimum{-1.};
 
-    mutable std::map<const Sample*, std::vector<double>> nomMcUncertList{}; // OA 2021 bug reimplementation
-    mutable GenericToolbox::NoCopyWrapper<std::mutex> _mutex_{}; // for creating the nomMC
+    /// OA 2021 bug reimplementation -- Used when BBNoUpdateWeights is true.
+    mutable std::map<const Sample*, std::vector<double>> nomMcUncertList{};
+    /// For creating the nomMC
+    mutable GenericToolbox::NoCopyWrapper<std::mutex> _mutex_{};
   };
 
   void BarlowBeestonBanff2022::configureImpl(){
@@ -77,14 +82,6 @@ namespace JointProbability{
       LogError << samplePair_.model->getName() << "/" << samplePair_.model->getHistogram().getBinContextList()[bin_].bin.getSummary() << ": predicting 0 rate in this bin -> llh not defined / inf" << std::endl;
     }
 
-    {
-      /// the first time we reach this point, we assume the predMC is at its nominal value
-      std::lock_guard<std::mutex> g(_mutex_);
-      if( not GenericToolbox::isIn((const Sample*) samplePair_.model, nomMcUncertList) ){ createNominalMc(*samplePair_.model); }
-    }
-
-    // it should exist past this point
-    auto& nomHistErr = nomMcUncertList[samplePair_.model];
     double mcuncert{0.0};
 
     // From OA2021_Eb branch -> BANFFBinnedSample::CalcLLRContrib
@@ -94,47 +91,39 @@ namespace JointProbability{
     // let the BBH make the sqrt
     // https://github.com/t2k-software/BANFF/blob/9140ec11bd74606c10ab4af9ec525352de119c06/src/BANFFSample/BANFFBinnedSample.cxx#L374
     if (BBNoUpdateWeights) {
+      {
+        // the first time we reach this point, we assume the predMC is at its
+        // nominal value
+        std::lock_guard<std::mutex> g(_mutex_);
+        if( not GenericToolbox::isIn((const Sample*) samplePair_.model, nomMcUncertList) ){ createNominalMc(*samplePair_.model); }
+      }
+
+      // it should exist past this point
+      auto& nomHistErr = nomMcUncertList[samplePair_.model];
+
       mcuncert = nomHistErr[bin_];
       mcuncert *= mcuncert;
 
-      if (not std::isfinite(mcuncert) or mcuncert < 0.0) {
-        if( throwIfInfLlh ){
-          LogError << "BBNoUpdateWeights mcuncert is not valid "
-                   << mcuncert
-                   << std::endl;
-          LogError << "nomMC bin " << bin_
-                   << " error is " << nomHistErr[bin_];
-
-          DEBUG_VAR(bin_);
-          DEBUG_VAR(mcuncert);
-          DEBUG_VAR(nomHistErr[bin_]);
-          DEBUG_VAR(nomHistErr.size());
-          DEBUG_VAR(nomHistErr.size());
-          DEBUG_VAR(GenericToolbox::toString(nomHistErr));
-
-          LogThrow("The mc uncertainty is not a usable number");
-        }
-        else{
-          return std::numeric_limits<double>::infinity();
-        }
-      }
     }
     else {
       mcuncert = samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
       mcuncert *= mcuncert;
+    }
 
-      if(not std::isfinite(mcuncert) or mcuncert < 0.0) {
-        if( throwIfInfLlh ){
-          LogError << "The mcuncert is not finite " << mcuncert << std::endl;
-          LogError << "predMC bin " << bin_
-                   << " error is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
-          LogThrow("The mc uncertainty is not a usable number");
-        }
-        else{
-          return std::numeric_limits<double>::infinity();
-        }
+    if(not std::isfinite(mcuncert) or mcuncert < 0.0) {
+      if( throwIfInfLlh ){
+        LogError << "The mcuncert is not finite " << mcuncert << std::endl;
+        LogError << " bin " << bin_
+                 << " data is " << samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights
+                 << " prediction is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights
+                 << " error is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
+        LogThrow("The mc uncertainty is not a usable number");
+      }
+      else{
+        return std::numeric_limits<double>::infinity();
       }
     }
+
     return eval(dataVal, predVal, mcuncert, bin_);
   }
 
@@ -196,7 +185,7 @@ namespace JointProbability{
 
       // Solve for the positive beta
       double beta = (-1 * temp + sqrt(temp2)) / 2.;
-      newmc = predVal * beta;
+      newmc = std::max(predVal * beta, std::numeric_limits<double>::min());
       // And penalise the movement in beta relative the mc uncertainty
       penalty = (beta - 1) * (beta - 1) / (2 * fractional * fractional);
     }
@@ -209,11 +198,11 @@ namespace JointProbability{
       // equivalent to "dataVal == 0"
       stat = newmc;
     }
-    else if (newmc > std::numeric_limits<double>::epsilon()) {
+    else if (newmc > std::numeric_limits<double>::min()) {
       // The newMC value should not be a lot less than O(1), This protects
       // against small values (intentionally use epsilon() instead of min()
       // since this is relative to 1.0).
-      stat = newmc - dataVal + dataVal * TMath::Log(dataVal / newmc);
+      stat = newmc - dataVal + dataVal*(TMath::Log(dataVal)-TMath::Log(newmc));
     }
     else {
       // The mc predicted value is zero, and the data value is not zero.
@@ -222,40 +211,46 @@ namespace JointProbability{
                                   << "Data: " << dataVal
                                   << " / Barlow Beeston adjusted MC: " << newmc
                                   << std::endl;
+      const double mc = std::numeric_limits<double>::min();
+      stat = mc - dataVal + dataVal*(TMath::Log(dataVal) - TMath::Log(mc));
     }
 
-    double chisq = 0.0;
-    if ((predVal > 0.0) && (dataVal > 0.0)) GUNDAM_LIKELY_COMPILER_FLAG {
-      if (usePoissonLikelihood) GUNDAM_UNLIKELY_COMPILER_FLAG {
-        // Not quite safe, but not used much, so don't protect
-        chisq += 2.0*(predVal - dataVal + dataVal*TMath::Log( dataVal/predVal));
+    // Build the chisq value based on previous calculations.
+    double chisq =  2.0*stat;
+
+    // Possibly apply the Barlow-Beeston penalty.
+    if (not usePoissonLikelihood) chisq += 2.0 * penalty;
+
+    // Warn when the expected value for a bin is going to zero.
+    if (predVal <= 0.0
+        and dataVal < std::numeric_limits<double>::epsilon()) [[unlikely]] {
+      if( allowZeroMcWhenZeroData ) {
+        // Need to warn the user something is wrong with the binning
+        // definition, but they've asked to continue anyway.  This might
+        // indicate that more MC stat would be needed, or the binning needs to
+        // be reconsidered..
+        LogErrorOnce
+          << "Sample bin with no events in the data and MC bin."
+          << "This is an ill conditioned problem. Please check your inputs."
+          << std::endl;
       }
-      else GUNDAM_LIKELY_COMPILER_FLAG {
-        // Barlow-Beeston likelihood.
-        chisq += 2.0 * (stat + penalty);
-      }
-    }
-    else if( predVal > 0.0 ) {
-      if (usePoissonLikelihood) GUNDAM_UNLIKELY_COMPILER_FLAG {
-        chisq += 2.0*predVal;
-      }
-      else GUNDAM_LIKELY_COMPILER_FLAG {
-        // Barlow-Beeston likelihood
-        chisq += 2.0 * (stat + penalty);
-      }
-    }
-    else { // predVal == 0
-      if( allowZeroMcWhenZeroData and dataVal == 0 ){
-        // need to warn the user something is wrong with the binning definition
-        // This might indicate that more MC stat would be needed
-        LogAlertOnce << "allowZeroMcWhenZeroData=true: MC bin(s) with 0 as predicted value. "
-                     << "Data is also 0, null penalty is applied."
-                     << "This is an ill conditioned problem. Please check your inputs."
-                     << std::endl;
-        chisq = 0.;
-      }
-      else{
-        chisq = std::numeric_limits<double>::infinity();
+      else {
+        static int messageBrake = 1000;
+        if (messageBrake > 0) {
+          --messageBrake;
+          LogError
+            << "Ill conditioned statistical LLH --"
+            << " Data: " << dataVal
+            << " / MC: " << predVal
+            << " Adjusted MC: " << newmc
+            << " / Stat: " << stat
+            << " Penalty: " << penalty
+            << " Total ChiSq: " << chisq
+            << std::endl;
+          LogErrorOnce
+            << "Define allowZeroMcWhenZeroData in config to mute message"
+            << std::endl;
+        }
       }
     }
 

--- a/src/StatisticalInference/JointProbability/include/ChiSquared.h
+++ b/src/StatisticalInference/JointProbability/include/ChiSquared.h
@@ -13,12 +13,12 @@ namespace JointProbability{
   class ChiSquared : public JointProbabilityBase {
   public:
     [[nodiscard]] std::string getType() const override { return "ChiSquared"; }
-    [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
   };
 
-  double ChiSquared::eval(const SamplePair& samplePair_, int bin_) const {
-    double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
-    double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
+  double ChiSquared::eval(double data_, double pred_, double err_, int bin_) const {
+    double predVal = pred_;
+    double dataVal = data_;
     if( predVal == 0 ){
       // should not be the case right?
       LogAlert << "Zero MC events in bin " << bin_ << ". predVal = " << predVal << ", dataVal = " << dataVal

--- a/src/StatisticalInference/JointProbability/include/JointProbabilityBase.h
+++ b/src/StatisticalInference/JointProbability/include/JointProbabilityBase.h
@@ -17,13 +17,25 @@ namespace JointProbability{
     // simple rtti, makes the class purely virtual
     [[nodiscard]] virtual std::string getType() const = 0;
 
-    // two choices -> either override bin by bin llh or global eval function
-    [[nodiscard]] virtual double eval( const SamplePair& samplePair_, int bin_ ) const{ return 0; }
+    // Joint probability for observing dataVal given a predicted value (with
+    // an uncertainty).  The predErr is the uncertainty on the predicted
+    // value, not the expected spread for the data around the prediction.
+    // This is separated out so that the evaluation is amenable to unit
+    // testing.
+    virtual double eval(double data_, double pred_, double err_, int bin_) const = 0;
+
+    // Likelihood for a single bin llh from histogram and bin index.  Override this if precalculation is needed.
+    [[nodiscard]] virtual double eval( const SamplePair& samplePair_, int bin_ ) const {
+      const double dataVal{samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights};
+      const double predVal{samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights};
+      const double predErr{samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights};
+      return eval(dataVal, predVal, predErr, bin_);
+    }
 
     // classic binned llh. Could be overriden to introduce correlations for instance.
     [[nodiscard]] virtual double eval( const SamplePair& samplePair_ ) const{
       double out{0};
-      int nBins = int(samplePair_.model->getHistogram().getNbBins());
+      const int nBins{int(samplePair_.model->getHistogram().getNbBins())};
       for( int iBin = 0; iBin < nBins; iBin++ ){ out += this->eval(samplePair_, iBin); }
       return out;
     }

--- a/src/StatisticalInference/JointProbability/include/LeastSquares.h
+++ b/src/StatisticalInference/JointProbability/include/LeastSquares.h
@@ -21,7 +21,7 @@ namespace JointProbability{
 
   public:
     [[nodiscard]] std::string getType() const override { return "PluginJointProbability"; }
-    [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
 
     /// If true the use Poissonian approximation with the variance equal to
     /// the observed value (i.e. the data).
@@ -34,9 +34,10 @@ namespace JointProbability{
     GenericToolbox::Json::fillValue(_config_, lsqPoissonianApproximation, "lsqPoissonianApproximation");
     LogWarning << "Using Least Squares Poissonian Approximation" << std::endl;
   }
-  double LeastSquares::eval(const SamplePair& samplePair_, int bin_) const {
-    double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
-    double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
+
+  double LeastSquares::eval(double data_, double pred_, double err_, int bin_) const {
+    double predVal = pred_;
+    double dataVal = data_;
     double v = dataVal - predVal;
     v = v*v;
     if (lsqPoissonianApproximation && dataVal > 1.0) v /= 0.5*dataVal;

--- a/src/StatisticalInference/JointProbability/include/PluginJointProbability.h
+++ b/src/StatisticalInference/JointProbability/include/PluginJointProbability.h
@@ -18,7 +18,7 @@ namespace JointProbability{
   public:
     [[nodiscard]] std::string getType() const override { return "PluginJointProbability"; }
 
-    [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override;
 
     std::string llhPluginSrc;
     std::string llhSharedLib;
@@ -55,12 +55,10 @@ namespace JointProbability{
     else{ LogThrow("Can't initialize JointProbabilityPlugin without llhSharedLib nor llhPluginSrc."); }
   }
 
-  double PluginJointProbability::eval( const SamplePair& samplePair_, int bin_ ) const{
+  double PluginJointProbability::eval(double data_, double pred_, double err_, int bin_) const {
     LogThrowIf(evalFcn == nullptr, "Library not loaded properly.");
     return reinterpret_cast<double (*)( double, double, double )>(evalFcn)(
-        samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights,
-        samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights,
-        samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights
+        data_, pred_, err_
     );
   }
 

--- a/src/StatisticalInference/JointProbability/include/PoissonLogLikelihood.h
+++ b/src/StatisticalInference/JointProbability/include/PoissonLogLikelihood.h
@@ -16,9 +16,9 @@ namespace JointProbability{
 
   public:
     [[nodiscard]] std::string getType() const override { return "PoissonLogLikelihood"; }
-    [[nodiscard]] double eval(const SamplePair& samplePair_, int bin_) const override {
-      double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
-      double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
+    [[nodiscard]] double eval(double data_, double pred_, double err_, int bin_) const override {
+      double predVal = pred_;
+      double dataVal = data_;
 
       double llhValue{0};
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,9 +35,16 @@ else(SKIP_GOOGLE_TEST)
   # Use the pre cmake 1.10 interface because we set 3.5 as the minimum cmake
   find_package(GTest)
 endif(SKIP_GOOGLE_TEST)
-if (GTEST_FOUND) 
+if (GTEST_FOUND)
   cmessage( STATUS "GTest package enabled for developer unit tests.")
   enable_testing()
+
+  # Setup the GUNDAM specific unit tests.
+  add_executable(gundamGTest_units.exe
+    GTests/unitTest_JointProbability.cpp)
+  target_link_libraries(gundamGTest_units.exe GTest::gtest_main)
+  target_link_libraries(gundamGTest_units.exe GundamStatisticalInference)
+  gtest_discover_tests(gundamGTest_units.exe)
 
   # Setup the hemi test suite for the host
   add_executable(gundamGTest_host.exe
@@ -49,7 +56,7 @@ if (GTEST_FOUND)
   target_link_libraries(gundamGTest_host.exe GundamCacheManager)
   target_compile_definitions(gundamGTest_host.exe PUBLIC HEMI_CUDA_DISABLE)
   gtest_discover_tests(gundamGTest_host.exe)
-  
+
   if(CMAKE_CUDA_COMPILER)
     # Setup the hemi test suite for the device.
     add_executable(gundamGTest_device.exe

--- a/tests/GTests/unitTest_JointProbability.cpp
+++ b/tests/GTests/unitTest_JointProbability.cpp
@@ -2,19 +2,20 @@
 
 #include <string>
 #include <vector>
+#include <limits>
 
 #include "JointProbability.h"
 
 // Test that the joint probability constructor builds things.
 TEST(jointProbability, Construction) {
     std::vector<std::string> names{
-        "PoissonLLH",
         "LeastSquares",
+        "Chi2",
+        "PoissonLLH",
         "BarlowLLH",
         "BarlowLLH_BANFF_OA2020",
         "BarlowLLH_BANFF_OA2021",
         "BarlowLLH_BANFF_OA2021_SFGD",
-        "Chi2",
     };
 
     for (std::string prob : names) {
@@ -41,8 +42,15 @@ TEST(jointProbability, LeastSquares_Continuity) {
     for (double pred = origPred; pred != lastPred; pred *= 0.9) {
         predErr = fracErr*pred;
         double newP = jointProb->eval(data, pred, predErr,0);
-        ASSERT_FALSE(std::isnan(newP)) << "Joint probability is not a number";
-        ASSERT_GE(newP,lastP) << "Joint probability should be monotonic toward zero";
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
         lastP = newP;
         lastPred = pred;
     }
@@ -53,8 +61,267 @@ TEST(jointProbability, LeastSquares_Continuity) {
     for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
         predErr = fracErr*pred;
         double newP = jointProb->eval(data, pred, predErr,0);
-        ASSERT_FALSE(std::isnan(newP)) << "Joint probability is not a number";
-        ASSERT_GE(newP,lastP) << "Joint probability should be monotonic toward infinity";
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+}
+
+TEST(jointProbability, ChiSquared_Continuity) {
+
+    std::unique_ptr<JointProbability::JointProbabilityBase>
+        jointProb(JointProbability::makeJointProbability(
+                      "Chi2"));
+    double data = 20.0;
+    double origPred = std::max(1.0, data);
+    double fracErr = 1.0/sqrt(origPred);
+    double origErr = fracErr * origPred;;
+    double predErr = fracErr * origPred;;
+
+    // Check the continuity for values less than the observation
+    double lastP = -1;
+    double lastPred = 0.0;
+    for (double pred = origPred; pred != lastPred; pred *= 0.9) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation
+    lastP = -1;
+    lastPred = 0.0;
+    for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+}
+
+TEST(jointProbability, PoissonLLH_Continuity) {
+
+    std::unique_ptr<JointProbability::JointProbabilityBase>
+        jointProb(JointProbability::makeJointProbability(
+                      "PoissonLLH"));
+    double data = 20.0;
+    double origPred = std::max(1.0, data);
+    double fracErr = 1.0/sqrt(origPred);
+    double origErr = fracErr * origPred;;
+    double predErr = fracErr * origPred;;
+
+    // Check the continuity for values less than the observation
+    double lastP = -1;
+    double lastPred = 0.0;
+    for (double pred = origPred; pred != lastPred; pred *= 0.9) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation
+    lastP = -1;
+    lastPred = 0.0;
+    for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+}
+
+TEST(jointProbability, OA2021_NoUpdateErr_Continuity) {
+
+    std::unique_ptr<JointProbability::JointProbabilityBase>
+        jointProb(JointProbability::makeJointProbability(
+                      "BarlowLLH_BANFF_OA2021"));
+    double data = 20.0;
+    double origPred = std::max(1.0, data);
+    double overSample = 10.0;
+    double fracErr = 1.0/sqrt(overSample*origPred);
+    double origErr = fracErr * origPred;;
+    double predErr = fracErr * origPred;;
+
+    // Check the continuity for values less than the observation
+    double lastP = -1;
+    double lastPred = 0.0;
+    for (double pred = origPred; pred != lastPred; pred *= 0.9) {
+        predErr = origErr;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,(0.99999)*lastP)
+            << "Not monotonic for"
+            << " data: " << data
+            << " prediction: " << pred
+            << " error: " << predErr
+            << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation
+    lastP = -1;
+    lastPred = 0.0;
+    for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
+        predErr = origErr;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation with zero
+    // data.
+    lastP = -1;
+    lastPred = 0.0;
+    data = 0.0;
+    for (double pred = 0.0; pred < 20.0;
+         pred += std::numeric_limits<double>::min() + 1.01*pred) {
+        predErr = origErr;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+}
+
+TEST(jointProbability, OA2021_UpdateErr_Continuity) {
+
+    std::unique_ptr<JointProbability::JointProbabilityBase>
+        jointProb(JointProbability::makeJointProbability(
+                      "BarlowLLH_BANFF_OA2021"));
+    double data = 20.0;
+    double origPred = std::max(1.0, data);
+    double overSample = 10.0;
+    double fracErr = 1.0/sqrt(overSample*origPred);
+    double origErr = fracErr * origPred;;
+    double predErr = fracErr * origPred;;
+
+    // Check the continuity for values less than the observation
+    double lastP = -1;
+    double lastPred = 0.0;
+    for (double pred = origPred; pred != lastPred; pred *= 0.9) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,(0.99999)*lastP)
+            << "Not monotonic for"
+            << " data: " << data
+            << " prediction: " << pred
+            << " error: " << predErr
+            << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation
+    lastP = -1;
+    lastPred = 0.0;
+    for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation with zero
+    // data.
+    lastP = -1;
+    lastPred = 0.0;
+    data = 0.0;
+    for (double pred = 0.0; pred < 20.0;
+         pred += std::numeric_limits<double>::min() + 1.01*pred) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Not a number for"
+                                       << " data: " << data
+                                       << " prediction: " << pred
+                                       << " error: " << predErr;
+        ASSERT_GE(newP,lastP) << "Not monotonic for"
+                              << " data: " << data
+                              << " prediction: " << pred
+                              << " error: " << predErr
+                              << " prob: " << newP << " (" << lastP << ")";
         lastP = newP;
         lastPred = pred;
     }

--- a/tests/GTests/unitTest_JointProbability.cpp
+++ b/tests/GTests/unitTest_JointProbability.cpp
@@ -1,0 +1,62 @@
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+#include "JointProbability.h"
+
+// Test that the joint probability constructor builds things.
+TEST(jointProbability, Construction) {
+    std::vector<std::string> names{
+        "PoissonLLH",
+        "LeastSquares",
+        "BarlowLLH",
+        "BarlowLLH_BANFF_OA2020",
+        "BarlowLLH_BANFF_OA2021",
+        "BarlowLLH_BANFF_OA2021_SFGD",
+        "Chi2",
+    };
+
+    for (std::string prob : names) {
+        std::unique_ptr<JointProbability::JointProbabilityBase>
+            jointProb(JointProbability::makeJointProbability(prob));
+        EXPECT_NE(jointProb,nullptr) << prob << " not constructed";
+    }
+}
+
+TEST(jointProbability, LeastSquares_Continuity) {
+
+    std::unique_ptr<JointProbability::JointProbabilityBase>
+        jointProb(JointProbability::makeJointProbability(
+                      "LeastSquares"));
+    double data = 20.0;
+    double origPred = std::max(1.0, data);
+    double fracErr = 1.0/sqrt(origPred);
+    double origErr = fracErr * origPred;;
+    double predErr = fracErr * origPred;;
+
+    // Check the continuity for values less than the observation
+    double lastP = -1;
+    double lastPred = 0.0;
+    for (double pred = origPred; pred != lastPred; pred *= 0.9) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Joint probability is not a number";
+        ASSERT_GE(newP,lastP) << "Joint probability should be monotonic toward zero";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+    // Check the continuity for values greater than the observation
+    lastP = -1;
+    lastPred = 0.0;
+    for (double pred = origPred; pred < 20*origPred; pred *= 1.01) {
+        predErr = fracErr*pred;
+        double newP = jointProb->eval(data, pred, predErr,0);
+        ASSERT_FALSE(std::isnan(newP)) << "Joint probability is not a number";
+        ASSERT_GE(newP,lastP) << "Joint probability should be monotonic toward infinity";
+        lastP = newP;
+        lastPred = pred;
+    }
+
+}


### PR DESCRIPTION
Refactor JointProbabilityBase and the derived classes so that the critical numeric calculations are isolated from the data manipulation.  The new API enables more robust testing of the calculations. 

Tests have been added for the "commonly used" joint probabilities (mostly BarlowLLH_BANFF_OA2021, and PoissonLLH).  The BarlowLLH_BANFF_OA2021 implementation has been updated to include all of the fixes from LTS, and now has the correct continuity for numerically representable values of data and predicted greater than zero (most importantly, no extra minima).