### PR TITLE
Fix/Event dial updates

### DIFF
--- a/src/DialDictionary/DialEngine/include/DialCollection.h
+++ b/src/DialDictionary/DialEngine/include/DialCollection.h
@@ -136,13 +136,13 @@ public:
   // but this provides a handle for collections that precalculate values prior
   // to doing the event reweighting.  An example of that would be the
   // Tabulated dials (which can be used in implement things like oscillation
-  // weights).  Update callbacks are std::function<void(void)>, and can be
-  // added with addUpdate();
+  // weights).  Update callbacks are std::function<void(DialCollection*)>, and
+  // can be added with addUpdate();
   void update();
 
   // Add a dial collection update callback.  These are called in the order
   // that they are added.  They are activated by the "update()" method.
-  void addUpdate(std::function<void(void)> callback);
+  void addUpdate(std::function<void(DialCollection* dc)> callback);
 
   // Check if the dial will need to be recalculated.  A recalculation
   // happens when a parameter value has changed since the last calculation.
@@ -236,7 +236,7 @@ private:
   std::vector<std::shared_ptr<DialCollection::CollectionData>>  _dialCollectionData_;
 
   // The callbacks for this dial collection
-  std::vector<std::function<void(void)>> _dialCollectionCallbacks_;
+  std::vector<std::function<void(DialCollection*)>> _dialCollectionCallbacks_;
 
   // external refs
   std::vector<ParameterSet>* _parameterSetListPtr_{nullptr};

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -514,17 +514,22 @@ bool DialCollection::initializeDialsWithTabulation(const JsonType& dialsDefiniti
   std::unique_ptr<TabulatedDialFactory> tabulated
       = std::make_unique<TabulatedDialFactory>(dialsDefinition_);
 
-  // Save the new object.
+  // Save the new object (the move releases the pointer).
   _dialCollectionData_.emplace_back(std::move(tabulated));
 
+  // Get the index of the new dial collection data entry.  This is "back()",
+  // but the index will be needed for the update closure, so use that instead.
+  int index = _dialCollectionData_.size()-1;
+
   for (const std::string& var :
-      getCollectionData<TabulatedDialFactory>()->getBinningVariables()) {
+       getCollectionData<TabulatedDialFactory>(index)->getBinningVariables()) {
     addExtraLeafName(var);
   }
 
   addUpdate(
-      [this]{getCollectionData<TabulatedDialFactory>()->updateTable(
-          getDialInputBufferList().front());
+      [index](DialCollection* dc){
+        dc->getCollectionData<TabulatedDialFactory>(index)
+        ->updateTable(dc->getDialInputBufferList().front());
       });
 
   return true;
@@ -794,12 +799,12 @@ JsonType DialCollection::fetchDialsDefinition(const JsonType &definitionsList_) 
 }
 
 void DialCollection::update() {
-  for (std::function<void(void)>& func : _dialCollectionCallbacks_) {
-    func();
+  for (std::function<void(DialCollection*)>& func : _dialCollectionCallbacks_) {
+    func(this);
   }
 }
 
-void DialCollection::addUpdate(std::function<void(void)> callback) {
+void DialCollection::addUpdate(std::function<void(DialCollection*)> callback) {
   _dialCollectionCallbacks_.emplace_back(callback);
 }
 

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -86,6 +86,10 @@ TabulatedDialFactory::TabulatedDialFactory(const JsonType& config_) {
     }
     _table_.resize(bins);
 
+    // Make sure things are going to fail badly if the table is used before
+    // it is filled.
+    for (auto& t : _table_) t = std::nan("not-set");
+
     // Get the update function
     void* updateFunc = dlsym(library, getUpdateFunction().c_str());
     if( updateFunc == nullptr ){
@@ -138,7 +142,7 @@ DialBase* TabulatedDialFactory::makeDial(const Event& event) {
     // Determine the bin index and the fractional part of the bin.
     int iBin = bin;
     if (iBin < 0) iBin = 0;     // Shouldn't happen, but just in case.
-    if (iBin > _table_.size()-1) iBin = _table_.size()-1;
+    if (iBin > _table_.size()-2) iBin = _table_.size()-2;
     double fracBin = bin - iBin;
     if (fracBin < 0.0) fracBin = 0.0;
     if (fracBin > 1.0) fracBin = 1.0;

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -196,12 +196,13 @@ void ParameterSet::processCovarianceMatrix(){
                << _strippedCovarianceMatrix_->GetNrows() << std::endl;
     _inverseStrippedCovarianceMatrix_ = std::shared_ptr<TMatrixD>((TMatrixD*)(_strippedCovarianceMatrix_->Clone()));
 
-    double det;
+    double det{-1};
     _inverseStrippedCovarianceMatrix_->Invert(&det);
 
     bool failed{false};
-    if( det == 0 ){
-      LogError << "Determinant is null." << std::endl;
+    if( det <= 0 ){
+      _strippedCovarianceMatrix_->Print();
+      LogError << "Stripped covariance must be positive definite: " << det << std::endl;
       failed = true;
     }
 

--- a/src/Propagator/include/Propagator.h
+++ b/src/Propagator/include/Propagator.h
@@ -60,7 +60,7 @@ public:
   void shrinkDialContainers();
   void buildDialCache();
   void propagateParameters();
-  void reweightEvents();
+  void reweightEvents(bool updateDials = true);
 
   // misc
   void copyEventsFrom(const Propagator& src_);

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -113,11 +113,15 @@ namespace JointProbability{
     if(not std::isfinite(mcuncert) or mcuncert < 0.0) {
       if( throwIfInfLlh ){
         LogError << "The mcuncert is not finite " << mcuncert << std::endl;
-        LogError << " bin " << bin_
+        LogError << samplePair_.model->getName()
+                 << "/" << samplePair_.model->getHistogram().getBinContextList()[bin_].bin.getSummary()
+                 << std::endl;
+        LogError << " Bin number " << bin_
                  << " data is " << samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights
-                 << " prediction is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights
-                 << " error is " << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights;
-        LogThrow("The mc uncertainty is not a usable number");
+                 << " with prediction " << samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights
+                 << " +/- " << samplePair_.model->getHistogram().getBinContentList()[bin_].sqrtSumSqWeights
+                 << std::endl;
+        std::exit(EXIT_FAILURE);
       }
       else{
         return std::numeric_limits<double>::infinity();


### PR DESCRIPTION
Apply fixes for four (connected) issues, along with a couple of diagnostic changes that helped to debug and track the problems.

Fix #730 : The dial state was updated prior to filling the histograms so that tabulated dials didn't work as expected

Fix #729 : The DialInterface dial value calculation code was making incorrect assumptions about when a dial needed to be updated.  This mean that dial values updates could be missed.

Fix #724 : The DialCollection update code was capturing 'this" in a closure for later use, but the object exists in a vector and can be moved.  Fix so that the closure doesn't depend on the parent object.

Tabulated dial fix: (didn't get an issue report) The table lookup had a "one past" bug at the high end of the table.  
