### PR TITLE
Feature/dial and data diagnostics

### DIFF
--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -39,7 +39,7 @@ void DataDispenser::configureImpl(){
   _threadPool_.setNThreads(GundamGlobals::getNbCpuThreads() );
 
   GenericToolbox::Json::fillValue(_config_, _parameters_.name, "name");
-  LogThrowIf(_parameters_.name.empty(), "Dataset name not set.");
+  LogExitIf(_parameters_.name.empty(), "Dataset name not set.");
 
   // histograms don't need other parameters
   if( GenericToolbox::Json::doKeyExist( _config_, "fromHistContent" ) ) {
@@ -147,7 +147,7 @@ void DataDispenser::load(Propagator& propagator_){
 
   for( const auto& file: _parameters_.filePathList){
     std::string path = GenericToolbox::expandEnvironmentVariables(file);
-    LogThrowIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.globalTreePath}), "Invalid file: " << path);
+    LogExitIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.globalTreePath}), "Invalid file: " << path);
   }
 
   this->parseStringParameters();
@@ -184,7 +184,7 @@ void DataDispenser::parseStringParameters() {
 
   auto replaceToyIndexFct = [&](std::string& formula_){
     if( GenericToolbox::hasSubStr(formula_, "<I_TOY>") ){
-      LogThrowIf(_cache_.propagatorPtr->getIThrow()==-1, "<I_TOY> not set.");
+      LogExitIf(_cache_.propagatorPtr->getIThrow()==-1, "<I_TOY> not set.");
       GenericToolbox::replaceSubstringInsideInputString(formula_, "<I_TOY>", std::to_string(_cache_.propagatorPtr->getIThrow()));
     }
   };
@@ -235,7 +235,7 @@ void DataDispenser::doEventSelection(){
     auto treeChain{this->openChain(true)};
     nEntries = treeChain->GetEntries();
   }
-  LogThrowIf(nEntries == 0, "TChain is empty.");
+  LogExitIf(nEntries == 0, "TChain is empty.");
   LogInfo << "Will read " << nEntries << " event entries." << std::endl;
 
   _cache_.threadSelectionResults.resize(nThreads);
@@ -581,12 +581,12 @@ void DataDispenser::loadFromHistContent(){
     LogScopeIndent;
 
     auto* sampleHistDef = _parameters_.fromHistContent.getSampleHistPtr(sample->getName());
-    LogThrowIf(sampleHistDef== nullptr, "Could not find sample histogram: " << sample->getName());
+    LogExitIf(sampleHistDef== nullptr, "Could not find sample histogram: " << sample->getName());
 
     LogInfo << "Filling sample \"" << sample->getName() << "\" using hist with name: " << sampleHistDef->hist << std::endl;
 
     auto* hist = fHist->Get<THnD>( sampleHistDef->hist.c_str() );
-    LogThrowIf( hist == nullptr, "Could not find THnD \"" << sampleHistDef->hist << "\" within " << fHist->GetPath() );
+    LogExitIf( hist == nullptr, "Could not find THnD \"" << sampleHistDef->hist << "\" within " << fHist->GetPath() );
 
     int nBins = 1;
     for( int iDim = 0 ; iDim < hist->GetNdimensions() ; iDim++ ){
@@ -632,17 +632,17 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_){
     auto chunks = GenericToolbox::splitString(name, ":", true);
     if( chunks.size() > 1 ){ treePath = chunks[1]; name = chunks[0];  }
 
-    LogThrowIf( treePath.empty(), "TTree path not set." );
+    LogExitIf( treePath.empty(), "TTree path not set." );
 
-    LogThrowIf( not GenericToolbox::doesTFileIsValid(name, {treePath}), "Could not open TFile: " << name << " with TTree " << treePath);
+    LogExitIf( not GenericToolbox::doesTFileIsValid(name, {treePath}), "Could not open TFile: " << name << " with TTree " << treePath);
 
     Long64_t nMaxEntries{TTree::kMaxEntries};
     if( _parameters_.fractionOfEntries != 1. ){
       std::unique_ptr<TFile> temp{TFile::Open(name.c_str())};
-      LogThrowIf(temp== nullptr, "Error while opening TFile: " << name);
+      LogExitIf(temp== nullptr, "Error while opening TFile: " << name);
 
       auto* tree = temp->Get<TTree>(treePath.c_str());
-      LogThrowIf(tree== nullptr, "Error while opening TTree: " << treePath << " in " << name);
+      LogExitIf(tree== nullptr, "Error while opening TTree: " << treePath << " in " << name);
 
       nMaxEntries = Long64_t( double(tree->GetEntries()) * _parameters_.fractionOfEntries );
       if( verbose_ ){

--- a/src/DialDictionary/DialDefinitions/include/Tabulated.h
+++ b/src/DialDictionary/DialDefinitions/include/Tabulated.h
@@ -14,8 +14,12 @@ public:
     ~Tabulated() = default;
     Tabulated() = delete;
     Tabulated(const std::vector<double>* table_, int index_, double fraction_,
-        const std::string& options_="")
-        : _table_{table_}, _fraction_{(float) fraction_}, _index_{index_} {};
+              const std::string& options_="")
+        : _table_{table_}, _fraction_{(float) fraction_}, _index_{index_} {
+#ifdef TABULATED_DEBUG_DIAL
+        _options_ = options_;
+#endif
+    };
 
     [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Tabulated>(*this); }
     [[nodiscard]] std::string getDialTypeName() const override { return {"Tabulated"}; }
@@ -28,6 +32,12 @@ public:
     const std::vector<double>* getTable() const { return _table_; }
     int getIndex() const { return _index_; }
     double getFraction() const { return _fraction_; }
+
+#ifdef TABULATED_DEBUG_DIAL
+    [[nodiscard]] virtual std::string getSummary() const override {
+        return _options_;
+    };
+#endif
 
 private:
     // A pointer to the table being used.  The table is owned by the
@@ -45,5 +55,9 @@ private:
 
     // The precalculated point in the table to use for interpolation.
     int _index_{0};
+
+#ifdef TABULATED_DEBUG_DIAL
+    std::string _options_;
+#endif
 };
 #endif //GUNDAM_TABULATED_H

--- a/src/DialDictionary/DialEngine/include/DialInputBuffer.h
+++ b/src/DialDictionary/DialEngine/include/DialInputBuffer.h
@@ -87,7 +87,7 @@ public:
   void addParameterReference( const ParameterReference& parReference_);
 
   /// Simple printout function for debug info on error
-  [[nodiscard]] std::string getSummary() const;
+  [[nodiscard]] std::string getSummary(bool shallow_ = true) const;
 
 private:
   /// Flag if the member can be still edited.

--- a/src/DialDictionary/DialEngine/include/DialResponseSupervisor.h
+++ b/src/DialDictionary/DialEngine/include/DialResponseSupervisor.h
@@ -25,7 +25,7 @@ public:
   [[nodiscard]] double getMaxResponse() const{ return _maxResponse_; }
 
   [[nodiscard]] double process(double reponse_) const;
-  [[nodiscard]] std::string getSummary() const;
+  [[nodiscard]] std::string getSummary(bool shallow_ = true) const;
 
 
 private:

--- a/src/DialDictionary/DialEngine/include/EventDialCache.h
+++ b/src/DialDictionary/DialEngine/include/EventDialCache.h
@@ -65,14 +65,14 @@ public:
     Event* event;
     std::vector<DialResponseCache> dialResponseCacheList{};
 
-    [[nodiscard]] std::string getSummary() const {
+    [[nodiscard]] std::string getSummary(bool shallow_ = true) const {
       std::stringstream ss;
       if( event == nullptr ){ return {"No event attached to this cache entry."}; }
       ss << *event;
       if( not dialResponseCacheList.empty() ){
         ss << std::endl << "Dials{";
         for( auto& dialResponseCache : dialResponseCacheList ){
-          ss << std::endl << "  { " << dialResponseCache.dialInterface->getSummary() << " }";
+          ss << std::endl << "  { " << dialResponseCache.dialInterface->getSummary(shallow_) << " }";
         }
         ss << std::endl << "}";
       }
@@ -90,7 +90,7 @@ public:
     /// associated with the event.
     std::size_t interfaceIndex {std::size_t(-1)};
 
-    [[nodiscard]] std::string getSummary() const{
+    [[nodiscard]] std::string getSummary(bool shallow_ = true) const{
       std::stringstream ss;
       ss << "collection: " << collectionIndex << ", interface: " << interfaceIndex;
       return ss.str();
@@ -113,7 +113,7 @@ public:
     /// by Sample::getMcContainer()
     std::size_t eventIndex {std::size_t(-1)};
 
-    [[nodiscard]] std::string getSummary() const{
+    [[nodiscard]] std::string getSummary(bool shallow_ = true) const{
       std::stringstream ss;
       ss << "sample: " << sampleIndex << ", idx: " << eventIndex;
       return ss.str();
@@ -131,7 +131,7 @@ public:
     EventIndexCacheEntry event;
     std::vector<DialIndexCacheEntry> dials;
 
-    [[nodiscard]] std::string getSummary() const{
+    [[nodiscard]] std::string getSummary(bool shallow_ = true) const{
       std::stringstream ss;
       ss << "Event{" << event << "}";
       ss << " -> Dials" << GenericToolbox::toString(dials);

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -103,7 +103,7 @@ std::string DialCollection::getSummary(bool shallow_){
     // print parameters
     for( auto& dialInterface : _dialInterfaceList_ ){
       if( not isEventByEvent() ){
-        ss << std::endl << "  " << dialInterface.getSummary();
+        ss << std::endl << "  " << dialInterface.getSummary(shallow_);
       }
     }
   }

--- a/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInputBuffer.cpp
@@ -93,7 +93,7 @@ void DialInputBuffer::addParameterReference( const ParameterReference& parRefere
   auto& parRef = _inputParameterReferenceList_.back();
   parRef.bufferIndex = int(_inputParameterReferenceList_.size())-1;
 }
-std::string DialInputBuffer::getSummary() const{
+std::string DialInputBuffer::getSummary(bool shallow_) const{
   std::stringstream ss;
   ss << GenericToolbox::toString(_inputParameterReferenceList_, [&]( const ParameterReference& parRef_){
     std::stringstream ss;

--- a/src/DialDictionary/DialEngine/src/DialInterface.cpp
+++ b/src/DialDictionary/DialEngine/src/DialInterface.cpp
@@ -16,16 +16,16 @@ std::string DialInterface::getSummary(bool shallow_) const {
   ss << _dialBaseRef_->getDialTypeName() << ":";
 
   if( _inputBufferRef_ != nullptr ){
-    ss << " input(" << _inputBufferRef_->getSummary() << ")";
+    ss << " input(" << _inputBufferRef_->getSummary(shallow_) << ")";
   }
 
   // apply on?
   if( _dialBinRef_ != nullptr ){
-    ss << " applyOn(" << _dialBinRef_->getSummary() << ")";
+    ss << " applyOn(" << _dialBinRef_->getSummary(shallow_) << ")";
   }
 
   if( _responseSupervisorRef_ != nullptr ){
-    ss << " supervisor(" << _responseSupervisorRef_->getSummary() << ")";
+    ss << " supervisor(" << _responseSupervisorRef_->getSummary(shallow_) << ")";
   }
 
   ss << " response=" << this->evalResponse();

--- a/src/DialDictionary/DialEngine/src/DialResponseSupervisor.cpp
+++ b/src/DialDictionary/DialEngine/src/DialResponseSupervisor.cpp
@@ -16,7 +16,7 @@ double DialResponseSupervisor::process(double reponse_) const {
 
   return reponse_;
 }
-std::string DialResponseSupervisor::getSummary() const{
+std::string DialResponseSupervisor::getSummary(bool shallow_ ) const{
   std::stringstream ss;
 
   if(not std::isnan(_minResponse_)){

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -147,6 +147,28 @@ DialBase* TabulatedDialFactory::makeDial(const Event& event) {
     if (fracBin < 0.0) fracBin = 0.0;
     if (fracBin > 1.0) fracBin = 1.0;
 
+#ifdef TABULATED_DIAL_FACTORY_DUMP
+    // Summarize which table is being applied to the event.  This can be quite
+    // useful for debugging parameter configurations, but is not compiled by
+    // default since it will dominate the debug output.  We need to implement
+    // different debug levels, and conditions.
+    if (GundamGlobals::isDebug()) {
+        std::ostringstream out;
+        out << getName()
+            << " " << iBin
+            << " " << fracBin;
+        std::size_t j = 0;
+        for (const std::string& varName : getBinningVariables()) {
+            out << " [" << j
+                << "] " << varName
+                << "=" << _binningVariableCache_[j];
+            ++j;
+        }
+        out << std::endl;
+        LogDebug << out.str() << std::endl;
+    }
+#endif
+
     // Do the unique_ptr dance in case there are exceptions.
     std::unique_ptr<Tabulated> dialBase = std::make_unique<Tabulated>(&_table_, iBin, fracBin);
     return dialBase.release();

--- a/src/Utils/include/Bin.h
+++ b/src/Utils/include/Bin.h
@@ -27,7 +27,7 @@ public:
     // utils
     [[nodiscard]] bool isOverlapping(const Edges& other_) const;
     [[nodiscard]] double getCenterValue() const { return min + (max-min)/2.; }
-    [[nodiscard]] std::string getSummary() const;
+    [[nodiscard]] std::string getSummary(bool shallow_ = true) const;
 
     bool isConditionVar{false};
     int index{-1};
@@ -75,7 +75,7 @@ public:
   [[nodiscard]] std::vector<std::string> buildVariableNameList() const;
 
   // Misc
-  [[nodiscard]] std::string getSummary() const;
+  [[nodiscard]] std::string getSummary(bool shallow_ = true) const;
   [[nodiscard]] std::vector<double> generateBinTarget(const std::vector<std::string>& varNameList_ = {}) const;
 
 private:

--- a/src/Utils/src/Bin.cpp
+++ b/src/Utils/src/Bin.cpp
@@ -45,7 +45,7 @@ bool Bin::Edges::isOverlapping( const Edges& other_) const{
 
   return false;
 }
-std::string Bin::Edges::getSummary() const {
+std::string Bin::Edges::getSummary(bool shallow_) const {
   std::stringstream ss;
   if( not this->varName.empty() ){ ss << this->varName << ": "; }
   ss << "[" << this->min;
@@ -175,14 +175,14 @@ std::vector<std::string> Bin::buildVariableNameList() const{
 }
 
 // Misc
-std::string Bin::getSummary() const{
+std::string Bin::getSummary(bool shallow_) const{
   std::stringstream ss;
 
   if( _binEdgesList_.empty() ) ss << "bin not set.";
   else{
     for( auto& edges : _binEdgesList_ ){
       if( edges.index != 0 ){ ss << ", "; }
-      ss << edges.getSummary();
+      ss << edges.getSummary(shallow_);
     }
   }
   return ss.str();
@@ -196,4 +196,3 @@ std::vector<double> Bin::generateBinTarget( const std::vector<std::string>& varN
   }
   return out;
 }
-


### PR DESCRIPTION
An example of why you should "eat your own stew."  These are tweaks for user interface glitches found while writing inputs for a different future US oscillation experiment.  

1) Prefer exit over throw for user input problems.  Prefer throw over exit for GUNDAM internal errors.
2) Unify the API for getSummary().  The change is not "source visible", but now all of the getSummary() methods take an optional `shallow` argument.  The original behavior is unchanged.
 