### PR TITLE
Bug fix: parameter thrower get triggered even without toy (no effect on fits)

### DIFF
--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -120,7 +120,7 @@ void FitterEngine::initializeImpl(){
   _parameterScanner_.setLikelihoodInterfacePtr( &getLikelihoodInterface() );
   _parameterScanner_.initialize();
 
-  if( getLikelihoodInterface().isThrowAsimovToyParameters() ){
+  if( _likelihoodInterface_.getDataType() == LikelihoodInterface::DataType::Toy ){
     LogInfo << "Writing throws in TTree..." << std::endl;
     auto* throwsTree = new TTree("throws", "throws");
 

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -1043,17 +1043,21 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
             } // norm
           } // par
 
-          if( getLikelihoodInterface().isThrowAsimovToyParameters() ){
+          if( getLikelihoodInterface().getDataType() == LikelihoodInterface::DataType::Toy ){
             bool draw{false};
 
             for( auto& par : parList_ ){
               double val{par.getThrowValue()};
-              val == val ? draw = true : val = par.getPriorValue();
-              if( isNorm_ ) val = ParameterSet::toNormalizedParValue(val, par);
+
+              if( not std::isnan(val) ){ draw = true; }
+              else{ val = par.getPriorValue(); }
+
+              if( isNorm_ ){ val = ParameterSet::toNormalizedParValue(val, par);}
               toyParametersLine->SetBinContent(1+par.getParameterIndex(), val);
             }
 
-            if( !draw ) toyParametersLine = nullptr;
+            // don't draw the throw line if none is valid
+            if( not draw ){ toyParametersLine = nullptr;}
           }
 
           auto yBounds = GenericToolbox::getYBounds({preFitErrorHist.get(), postFitErrorHist.get(), toyParametersLine.get()});

--- a/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
+++ b/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
@@ -64,7 +64,6 @@ public:
   void setToyParameterInjector(const JsonType& toyParameterInjector_){ _toyParameterInjector_ = toyParameterInjector_; }
 
   // const getters
-  [[nodiscard]] bool isThrowAsimovToyParameters() const{ return _throwAsimovToyParameters_; }
   [[nodiscard]] int getNbParameters() const{ return _nbParameters_; }
   [[nodiscard]] int getNbSampleBins() const{ return _nbSampleBins_; }
   [[nodiscard]] double getLastLikelihood() const{ return _buffer_.totalLikelihood; }
@@ -120,7 +119,6 @@ protected:
 private:
   // parameters
   bool _forceAsimovData_{false};
-  bool _throwAsimovToyParameters_{true};
   bool _enableStatThrowInToys_{true};
   bool _gaussStatThrowInToys_{false};
   bool _enableEventMcThrow_{true};

--- a/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
+++ b/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
@@ -76,6 +76,7 @@ public:
   [[nodiscard]] const std::vector<DatasetDefinition>& getDatasetList() const { return _datasetList_; }
   [[nodiscard]] const std::vector<SamplePair>& getSamplePairList() const { return _samplePairList_; }
   [[nodiscard]] const Buffer& getBuffer() const { return _buffer_; }
+  [[nodiscard]] const DataType& getDataType() const { return _dataType_; }
 
   // mutable getters
   Buffer& getBuffer(){ return _buffer_; }

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -29,10 +29,6 @@ void LikelihoodInterface::configureImpl(){
   std::string jointProbabilityTypeStr{"PoissonLLH"};
 
   // prior to this version a few parameters were set in the propagator itself
-  GenericToolbox::Json::deprecatedAction(_modelPropagator_.getConfig(), "throwAsimovFitParameters", [&]{
-    LogAlert << R"("throwAsimovFitParameters" should now be set under "likelihoodInterfaceConfig" instead of "propagatorConfig".)" << std::endl;
-    GenericToolbox::Json::fillValue(_modelPropagator_.getConfig(), _throwAsimovToyParameters_, "throwAsimovFitParameters");
-  });
   GenericToolbox::Json::deprecatedAction(_modelPropagator_.getConfig(), "enableStatThrowInToys", [&]{
     LogAlert << R"("enableStatThrowInToys" should now be set under "likelihoodInterfaceConfig" instead of "propagatorConfig".)" << std::endl;
     GenericToolbox::Json::fillValue(_modelPropagator_.getConfig(), _enableStatThrowInToys_, "enableStatThrowInToys");
@@ -83,7 +79,6 @@ void LikelihoodInterface::configureImpl(){
   _plotGenerator_.configure();
 
   // reading local parameters
-  GenericToolbox::Json::fillValue(_config_, _throwAsimovToyParameters_, "throwAsimovFitParameters");
   GenericToolbox::Json::fillValue(_config_, _enableStatThrowInToys_, "enableStatThrowInToys");
   GenericToolbox::Json::fillValue(_config_, _gaussStatThrowInToys_, "gaussStatThrowInToys");
   GenericToolbox::Json::fillValue(_config_, _enableEventMcThrow_, "enableEventMcThrow");
@@ -376,7 +371,7 @@ void LikelihoodInterface::loadDataPropagator(){
 
   if( isAsimov ){
     // don't reload, just use the _modelPropagator_
-    if( _dataType_ == DataType::Toy and _throwAsimovToyParameters_ ){
+    if( _dataType_ == DataType::Toy ){
       throwToyParameters(_modelPropagator_);
     }
 
@@ -387,7 +382,7 @@ void LikelihoodInterface::loadDataPropagator(){
     _dataPropagator_.buildDialCache();
 
     // move the model back to the prior
-    if( _dataType_ == DataType::Toy and _throwAsimovToyParameters_ ){
+    if( _dataType_ == DataType::Toy ){
       _modelPropagator_.getParametersManager().moveParametersToPrior();
       _modelPropagator_.reweightEvents();
     }
@@ -436,7 +431,7 @@ void LikelihoodInterface::loadDataPropagator(){
     _dataPropagator_.shrinkDialContainers();
     _dataPropagator_.buildDialCache();
 
-    if( _throwAsimovToyParameters_ ){
+    if( _dataType_ == DataType::Toy ){
       throwToyParameters(_dataPropagator_);
     } // throw asimov?
 


### PR DESCRIPTION
This bug generates some printouts since the parameter throws routine gets triggered because of an old class member. This bug had no effect on the data fits since the data don't keep the engine loaded. The thrown parameter where thrown but not propagated.