### PR TITLE
Handling partial steps when the minimizer doesn't move all the parameters

### DIFF
--- a/src/Applications/src/gundamFitReader.cxx
+++ b/src/Applications/src/gundamFitReader.cxx
@@ -232,9 +232,7 @@ int main(int argc, char** argv){
       LogScopeIndent;
 
       RootUtils::ObjectReader::readObject<TNamed>(f.get(), GenericToolbox::joinPath(pathPreFit, "llhState_TNamed"), [&](TNamed* injectorStr){
-        if( clParser.isOptionTriggered("verbose") ){
-          LogInfo << blueLightText << "Pre-fit Likelihood state: " << resetColor << injectorStr->GetTitle() << std::endl;
-        }
+        LogInfo << blueLightText << "Pre-fit Likelihood state: " << resetColor << injectorStr->GetTitle() << std::endl;
         if( clParser.isOptionTriggered("extractDataToDisk") ){
           auto outSubDir{GenericToolbox::joinPath( outDir, pathPreFit)};
           if( not GenericToolbox::isDir( outSubDir ) ){ GenericToolbox::mkdir( outSubDir ); }

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -194,6 +194,10 @@ void FitterEngine::initializeImpl(){
         GenericToolbox::toCorrelationMatrix(parSet.getPriorCovarianceMatrix().get()),
         "correlationMatrix"
     );
+    GenericToolbox::writeInTFileWithObjTypeExt(
+        GenericToolbox::mkdirTFile( _saveDir_, saveFolder ),
+        parSet.getInverseCovarianceMatrix().get(), "invCovarianceMatrix"
+    );
 
     auto parsSaveFolder = GenericToolbox::joinPath( saveFolder, "parameters" );
     for( auto& par : parSet.getParameterList() ){

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -350,6 +350,9 @@ void FitterEngine::fit(){
   LogInfo << "Minimizing LLH..." << std::endl;
   this->_minimizer_->minimize();
 
+  // re-evaluating since the minimizer could have not triggered an eval of the llh
+  getLikelihoodInterface().propagateAndEvalLikelihood();
+
 #ifdef GUNDAM_USING_CACHE_MANAGER
   if( Cache::Manager::IsBuilt() ){
     LogWarning << "Pulling back individual weight from device..." << std::endl;

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -191,7 +191,8 @@ void FitterEngine::initializeImpl(){
     );
     GenericToolbox::writeInTFileWithObjTypeExt(
         GenericToolbox::mkdirTFile(_saveDir_, saveFolder ),
-        parSet.getPriorCorrelationMatrix().get(), "correlationMatrix"
+        GenericToolbox::toCorrelationMatrix(parSet.getPriorCovarianceMatrix().get()),
+        "correlationMatrix"
     );
 
     auto parsSaveFolder = GenericToolbox::joinPath( saveFolder, "parameters" );

--- a/src/Fitter/Minimizer/include/MinimizerBase.h
+++ b/src/Fitter/Minimizer/include/MinimizerBase.h
@@ -61,58 +61,6 @@ protected:
     GenericToolbox::VariablesMonitor convergenceMonitor;
 
     std::unique_ptr<TTree> historyTree{nullptr};
-
-    struct GradientDescentMonitor{
-      bool isEnabled{false};
-
-      struct ValueDefinition{
-        std::string name{};
-        std::function<double(const MinimizerBase* this_)> getValueFct{};
-
-        ValueDefinition(const std::string& name_, const std::function<double(const MinimizerBase* this_)>& getValueFct_){
-          name = name_;
-          getValueFct = getValueFct_;
-        }
-      };
-      std::vector<ValueDefinition> valueDefinitionList{};
-
-      struct StepPoint{
-        JsonType parState;
-        double fitCallNb{0};
-        std::vector<double> valueMonitorList{}; // .size() = valueDefinitionList.size()
-      };
-      std::vector<StepPoint> stepPointList{};
-
-      void addStep(const MinimizerBase* this_){
-        stepPointList.emplace_back();
-        stepPointList.back().valueMonitorList.reserve( valueDefinitionList.size() );
-        fillLastStep(this_);
-      }
-      void fillLastStep(const MinimizerBase* this_){
-        stepPointList.back().parState = this_->getModelPropagator().getParametersManager().exportParameterInjectorConfig();
-        stepPointList.back().fitCallNb = this_->getMonitor().nbEvalLikelihoodCalls;
-        for( auto& valueDefinition : valueDefinitionList ){
-          stepPointList.back().valueMonitorList.emplace_back( valueDefinition.getValueFct(this_) );
-        }
-      }
-
-      [[nodiscard]] int getValueIndex(const std::string& name_) const {
-        int idx = GenericToolbox::findElementIndex(name_, valueDefinitionList, [](const ValueDefinition& elm){ return elm.name; });
-        LogThrowIf(idx == -1, "Could not find element " << name_);
-        return idx;
-      }
-      [[nodiscard]] double getLastStepValue(const std::string& name_) const {
-        LogThrowIf(stepPointList.empty());
-        return stepPointList.back().valueMonitorList[getValueIndex(name_)];
-      }
-      [[nodiscard]] double getLastStepDeltaValue(const std::string& name_) const {
-        if( stepPointList.size() < 2 ){ return 0; }
-        auto idx = getValueIndex(name_);
-        return stepPointList[stepPointList.size()-2].valueMonitorList[idx] - stepPointList.back().valueMonitorList[idx];
-      }
-
-    };
-    GradientDescentMonitor gradientDescentMonitor{};
   };
 
 public:
@@ -199,11 +147,14 @@ protected:
   bool useNormalizedFitSpace() const {return _useNormalizedFitSpace_;}
   int* getNbFreeParametersPtr() {return &_nbFreeParameters_;}
 
+protected:
+  std::vector<Parameter*> _minimizerParameterPtrList_{};
+  Monitor _monitor_{};
+
 private:
   /// Save a copy of the address of the engine that owns this object.
   FitterEngine* _owner_{nullptr};
 
-  std::vector<Parameter*> _minimizerParameterPtrList_{};
   int _minimizerStatus_{-1}; // -1: invalid, 0: success, >0: errors
   int _nbFreeParameters_{0};
 
@@ -212,7 +163,6 @@ private:
   bool _useNormalizedFitSpace_{true};
   bool _checkParameterValidity_{false};
   bool _isEnabledCalcError_{true};
-  Monitor _monitor_{};
 
 };
 

--- a/src/Fitter/Minimizer/src/AdaptiveMcmc.cpp
+++ b/src/Fitter/Minimizer/src/AdaptiveMcmc.cpp
@@ -337,7 +337,7 @@ bool AdaptiveMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
       int in2 = par2->getParameterIndex();
       if (in2 <= in1) continue;
       const std::shared_ptr<TMatrixDSym>& corr
-          = set1->getPriorCorrelationMatrix();
+          = GenericToolbox::toCorrelationMatrix(set1->getPriorCovarianceMatrix());
       if (!corr) continue;
       double correlation = (*corr)(in1,in2);
       // Don't impose very small correlations, let them be discovered.

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -66,28 +66,6 @@ void MinimizerBase::initializeImpl(){
   _monitor_.convergenceMonitor.addVariable("Stat");
   _monitor_.convergenceMonitor.addVariable("Syst");
 
-  if( _monitor_.gradientDescentMonitor.isEnabled ){
-    _monitor_.convergenceMonitor.defineNewQuantity({ "LastStep", "Last step descent", [&](GenericToolbox::VariableMonitor& v){
-      return GenericToolbox::parseUnitPrefix(_monitor_.gradientDescentMonitor.getLastStepDeltaValue(v.getName()), 8); }
-    });
-    _monitor_.convergenceMonitor.addDisplayedQuantity("LastStep");
-    _monitor_.convergenceMonitor.getQuantity("LastStep").title = "Last step descent";
-
-    _monitor_.gradientDescentMonitor.valueDefinitionList.emplace_back(
-        "Total/dof", [](const MinimizerBase* this_){ return this_->getLikelihoodInterface().getLastLikelihood() / this_->fetchNbDegreeOfFreedom(); }
-    );
-    _monitor_.gradientDescentMonitor.valueDefinitionList.emplace_back(
-        "Total", [](const MinimizerBase* this_){ return this_->getLikelihoodInterface().getBuffer().totalLikelihood; }
-    );
-    _monitor_.gradientDescentMonitor.valueDefinitionList.emplace_back(
-        "Stat", [](const MinimizerBase* this_){ return this_->getLikelihoodInterface().getBuffer().statLikelihood; }
-    );
-    _monitor_.gradientDescentMonitor.valueDefinitionList.emplace_back(
-        "Syst", [](const MinimizerBase* this_){ return this_->getLikelihoodInterface().getBuffer().penaltyLikelihood; }
-    );
-  }
-
-
   LogWarning << "MinimizerBase initialized." << std::endl;
 }
 
@@ -177,53 +155,6 @@ double MinimizerBase::evalFit( const double* parArray_ ){
     _monitor_.nbEvalLikelihoodCalls++;
 
     if( _monitor_.historyTree != nullptr ){ _monitor_.historyTree->Fill(); }
-    if( _monitor_.gradientDescentMonitor.isEnabled ){
-
-      auto& gradient = _monitor_.gradientDescentMonitor;
-
-      // When gradient descent base minimizer probe a point toward the
-      // minimum, every parameter get updated
-      size_t nbValidPars = std::count_if(
-              _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
-              [](const Parameter* par_){ return not ( par_->isFixed() or not par_->isEnabled() ); } );
-      size_t nParUpdated = std::count_if(
-              _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
-              [](const Parameter* par_){ return par_->gotUpdated(); } );
-
-      bool isGradientDescentStep = (nParUpdated == nbValidPars);
-
-      if( nParUpdated >= 5 ) {
-        // It's a partial gradient step (should be more than 5 since HESSE can change 4 params at a time)
-        // Some parameters can be left unchanged by the minimizer: could indicate some problems in the parametrization
-        isGradientDescentStep = true;
-      }
-
-      if( isGradientDescentStep or gradient.stepPointList.empty() ){
-
-        if( gradient.stepPointList.empty() ){
-          // add the initial point
-          LogWarning << "Adding initial point of the gradient monitor: ";
-          gradient.addStep( this );
-        }
-        else{
-          if( gradient.stepPointList.back().fitCallNb == _monitor_.nbEvalLikelihoodCalls - 1 ){
-            LogWarning << "Minimizer is adjusting the step size: ";
-            gradient.fillLastStep( this );
-          }
-          else{
-            LogWarning << "Gradient step detected at iteration #" << _monitor_.nbEvalLikelihoodCalls;
-            if(nParUpdated != nbValidPars){ LogWarning << " (PARTIAL: " << nParUpdated << "/" << nbValidPars << ")"; }
-            LogWarning << ": ";
-            gradient.addStep( this );
-          }
-        }
-
-        if( gradient.stepPointList.size() >= 2 ){
-          LogWarning << gradient.getLastStepValue("Total") + gradient.getLastStepDeltaValue("Total") << " -> ";
-        }
-        LogWarning << gradient.getLastStepValue("Total") << std::endl;
-      }
-    }
     if( _monitor_.convergenceMonitor.isGenerateMonitorStringOk() ){
 
       _monitor_.iterationCounterClock.count( _monitor_.nbEvalLikelihoodCalls );

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -28,7 +28,7 @@ void RootMinimizer::configureImpl(){
   // read general parameters first
   this->MinimizerBase::configureImpl();
 
-  GenericToolbox::Json::fillValue(_config_, getMonitor().gradientDescentMonitor.isEnabled, "monitorGradientDescent");
+  GenericToolbox::Json::fillValue(_config_, gradientDescentMonitor.isEnabled, "monitorGradientDescent");
   GenericToolbox::Json::fillValue(_config_, _minimizerType_, "minimizer");
   GenericToolbox::Json::fillValue(_config_, _minimizerAlgo_, "algorithm");
 
@@ -55,6 +55,27 @@ void RootMinimizer::configureImpl(){
 }
 void RootMinimizer::initializeImpl(){
   MinimizerBase::initializeImpl();
+
+  if( gradientDescentMonitor.isEnabled ){
+    _monitor_.convergenceMonitor.defineNewQuantity({ "LastStep", "Last step descent", [&](GenericToolbox::VariableMonitor& v){
+      return GenericToolbox::parseUnitPrefix(gradientDescentMonitor.getLastStepDeltaValue(v.getName()), 8); }
+    });
+    _monitor_.convergenceMonitor.addDisplayedQuantity("LastStep");
+    _monitor_.convergenceMonitor.getQuantity("LastStep").title = "Last step descent";
+
+    gradientDescentMonitor.valueDefinitionList.emplace_back(
+        "Total/dof", [](const RootMinimizer* this_){ return this_->getLikelihoodInterface().getLastLikelihood() / this_->fetchNbDegreeOfFreedom(); }
+    );
+    gradientDescentMonitor.valueDefinitionList.emplace_back(
+        "Total", [](const RootMinimizer* this_){ return this_->getLikelihoodInterface().getBuffer().totalLikelihood; }
+    );
+    gradientDescentMonitor.valueDefinitionList.emplace_back(
+        "Stat", [](const RootMinimizer* this_){ return this_->getLikelihoodInterface().getBuffer().statLikelihood; }
+    );
+    gradientDescentMonitor.valueDefinitionList.emplace_back(
+        "Syst", [](const RootMinimizer* this_){ return this_->getLikelihoodInterface().getBuffer().penaltyLikelihood; }
+    );
+  }
 
   LogWarning << "Initializing RootMinimizer..." << std::endl;
 
@@ -238,7 +259,7 @@ void RootMinimizer::minimize(){
     GenericToolbox::writeInTFileWithObjTypeExt(getOwner().getSaveDir(), getMonitor().historyTree.get());
   }
 
-  if( getMonitor().gradientDescentMonitor.isEnabled ){ saveGradientSteps(); }
+  if( gradientDescentMonitor.isEnabled ){ saveGradientSteps(); }
 
   if( _fitHasConverged_ ){ LogInfo << "Minimization has converged!" << std::endl; }
   else{ LogError << "Minimization did not converged." << std::endl; }
@@ -455,6 +476,64 @@ void RootMinimizer::scanParameters( TDirectory* saveDir_ ){
 
   GenericToolbox::triggerTFileWrite(saveDir_);
 }
+double RootMinimizer::evalFit(const double *parArray_){
+  auto out = MinimizerBase::evalFit(parArray_);
+
+  // check the gradient steps
+  if( GenericToolbox::toLowerCase(_minimizerType_) == "minuit2" ){
+
+    if( gradientDescentMonitor.isEnabled ){
+
+      auto& gradient = gradientDescentMonitor;
+
+      // When gradient descent base minimizer probe a point toward the
+      // minimum, every parameter get updated
+      size_t nbValidPars = std::count_if(
+              _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
+              [](const Parameter* par_){ return not ( par_->isFixed() or not par_->isEnabled() ); } );
+      size_t nParUpdated = std::count_if(
+              _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
+              [](const Parameter* par_){ return par_->gotUpdated(); } );
+
+      bool isGradientDescentStep = (nParUpdated == nbValidPars);
+
+      if( nParUpdated >= 5 ) {
+        // It's a partial gradient step (should be more than 5 since HESSE can change 4 params at a time)
+        // Some parameters can be left unchanged by the minimizer: could indicate some problems in the parametrization
+        isGradientDescentStep = true;
+      }
+
+      if( isGradientDescentStep or gradient.stepPointList.empty() ){
+
+        if( gradient.stepPointList.empty() ){
+          // add the initial point
+          LogWarning << "Adding initial point of the gradient monitor: ";
+          gradient.addStep( this );
+        }
+        else{
+          if( gradient.stepPointList.back().fitCallNb == _monitor_.nbEvalLikelihoodCalls - 1 ){
+            LogWarning << "Minimizer is adjusting the step size: ";
+            gradient.fillLastStep( this );
+          }
+          else{
+            LogWarning << "Gradient step detected at iteration #" << _monitor_.nbEvalLikelihoodCalls;
+            if(nParUpdated != nbValidPars){ LogWarning << " (PARTIAL: " << nParUpdated << "/" << nbValidPars << ")"; }
+            LogWarning << ": ";
+            gradient.addStep( this );
+          }
+        }
+
+        if( gradient.stepPointList.size() >= 2 ){
+          LogWarning << gradient.getLastStepValue("Total") + gradient.getLastStepDeltaValue("Total") << " -> ";
+        }
+        LogWarning << gradient.getLastStepValue("Total") << std::endl;
+      }
+    }
+  }
+
+  return out;
+}
+
 
 // const getters
 double RootMinimizer::getTargetEdm() const{
@@ -1234,7 +1313,7 @@ void RootMinimizer::saveGradientSteps(){
     return;
   }
 
-  LogInfo << "Saving " << getMonitor().gradientDescentMonitor.stepPointList.size() << " gradient steps..." << std::endl;
+  LogInfo << "Saving " << gradientDescentMonitor.stepPointList.size() << " gradient steps..." << std::endl;
 
   // make sure the parameter states get restored as we leave
   auto currentParState = getModelPropagator().getParametersManager().exportParameterInjectorConfig();
@@ -1256,24 +1335,24 @@ void RootMinimizer::saveGradientSteps(){
   auto lastParStep{getOwner().getPreFitParState()};
 
   std::vector<ParameterScanner::GraphEntry> globalGraphList;
-  for(size_t iGradStep = 0 ; iGradStep < getMonitor().gradientDescentMonitor.stepPointList.size() ; iGradStep++ ){
-    GenericToolbox::displayProgressBar(iGradStep, getMonitor().gradientDescentMonitor.stepPointList.size(), LogInfo.getPrefixString() + "Saving gradient steps...");
+  for(size_t iGradStep = 0 ; iGradStep < gradientDescentMonitor.stepPointList.size() ; iGradStep++ ){
+    GenericToolbox::displayProgressBar(iGradStep, gradientDescentMonitor.stepPointList.size(), LogInfo.getPrefixString() + "Saving gradient steps...");
 
     // why do we need to remute the logger at each loop??
     ParameterSet::muteLogger(); Propagator::muteLogger(); ParametersManager::muteLogger();
-    getModelPropagator().getParametersManager().injectParameterValues(getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState );
+    getModelPropagator().getParametersManager().injectParameterValues(gradientDescentMonitor.stepPointList[iGradStep].parState );
 
     getLikelihoodInterface().propagateAndEvalLikelihood();
 
     if( not GundamGlobals::isLightOutputMode() ) {
       auto outDir = GenericToolbox::mkdirTFile(getOwner().getSaveDir(), Form("fit/gradient/step_%i", int(iGradStep)));
-      GenericToolbox::writeInTFileWithObjTypeExt(outDir, TNamed("parState", GenericToolbox::Json::toReadableString(getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState).c_str()));
+      GenericToolbox::writeInTFileWithObjTypeExt(outDir, TNamed("parState", GenericToolbox::Json::toReadableString(gradientDescentMonitor.stepPointList[iGradStep].parState).c_str()));
       GenericToolbox::writeInTFileWithObjTypeExt(outDir, TNamed("llhState", getLikelihoodInterface().getSummary().c_str()));
     }
 
     // line scan from previous point
-    getParameterScanner().scanSegment( nullptr, getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, 8 );
-    lastParStep = getMonitor().gradientDescentMonitor.stepPointList[iGradStep].parState;
+    getParameterScanner().scanSegment( nullptr, gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, 8 );
+    lastParStep = gradientDescentMonitor.stepPointList[iGradStep].parState;
 
     if( globalGraphList.empty() ){
       // copy

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -79,10 +79,10 @@ public:
   [[nodiscard]] const JsonType &getDialSetDefinitions() const{ return _dialSetDefinitions_; }
   [[nodiscard]] const TMatrixD* getInvertedEigenVectors() const{ return _eigenVectorsInv_.get(); }
   [[nodiscard]] const TMatrixD* getEigenVectors() const{ return _eigenVectors_.get(); }
-  [[nodiscard]] const TMatrixD* getInverseStrippedCovarianceMatrix() const{ return _inverseCovarianceMatrix_.get(); }
   [[nodiscard]] const TVectorD* getDeltaVectorPtr() const{ return _deltaVectorPtr_.get(); }
   [[nodiscard]] const std::vector<JsonType>& getCustomParThrow() const{ return _customParThrow_; }
-  [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorFullCovarianceMatrix_; }
+  [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+  [[nodiscard]] const std::shared_ptr<TMatrixD> &getInverseCovarianceMatrix() const{ return _inverseCovarianceMatrix_; }
 
   /// True if all of the enabled parameters have valid values.
   [[nodiscard]] bool isValid() const;
@@ -114,7 +114,7 @@ public:
 
   void updateDeltaVector() const;
 
-  /// Set all of the parameters to their prior values.
+  /// Set all the parameters to their prior values.
   void moveParametersToPrior();
 
   /// Set the parameter values based on a random throw with fluctuations
@@ -246,7 +246,7 @@ private:
   std::shared_ptr<TMatrixDSym> _priorFullCovarianceMatrix_{nullptr};
   // matrices stripped from fixed/freed parameters
   std::shared_ptr<TMatrixDSym> _priorCovarianceMatrix_{nullptr};
-  std::shared_ptr<TMatrixD>    _inverseCovarianceMatrix_{nullptr}; // inverse matrix used for chi2
+  std::shared_ptr<TMatrixD> _inverseCovarianceMatrix_{nullptr}; // inverse matrix used for chi2
 
   std::shared_ptr<TVectorD>  _parameterPriorList_{nullptr};
   std::shared_ptr<TVectorD>  _parameterLowerBoundsList_{nullptr};

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -79,11 +79,10 @@ public:
   [[nodiscard]] const JsonType &getDialSetDefinitions() const{ return _dialSetDefinitions_; }
   [[nodiscard]] const TMatrixD* getInvertedEigenVectors() const{ return _eigenVectorsInv_.get(); }
   [[nodiscard]] const TMatrixD* getEigenVectors() const{ return _eigenVectors_.get(); }
-  [[nodiscard]] const TMatrixD* getInverseStrippedCovarianceMatrix() const{ return _inverseStrippedCovarianceMatrix_.get(); }
+  [[nodiscard]] const TMatrixD* getInverseStrippedCovarianceMatrix() const{ return _inverseCovarianceMatrix_.get(); }
   [[nodiscard]] const TVectorD* getDeltaVectorPtr() const{ return _deltaVectorPtr_.get(); }
   [[nodiscard]] const std::vector<JsonType>& getCustomParThrow() const{ return _customParThrow_; }
-  [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCorrelationMatrix() const{ return _priorCorrelationMatrix_; }
-  [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+  [[nodiscard]] const std::shared_ptr<TMatrixDSym> &getPriorCovarianceMatrix() const { return _priorFullCovarianceMatrix_; }
 
   /// True if all of the enabled parameters have valid values.
   [[nodiscard]] bool isValid() const;
@@ -243,11 +242,11 @@ private:
   std::shared_ptr<TVectorD> _originalParBuffer_{nullptr};
   std::shared_ptr<TMatrixD> _projectorMatrix_{nullptr};
 
-
-  std::shared_ptr<TMatrixDSym> _priorCovarianceMatrix_{nullptr};        // matrix coming from the file
-  std::shared_ptr<TMatrixDSym> _priorCorrelationMatrix_{nullptr};        // matrix coming from the file
-  std::shared_ptr<TMatrixDSym> _strippedCovarianceMatrix_{nullptr};        // matrix stripped from fixed/freed parameters
-  std::shared_ptr<TMatrixD>    _inverseStrippedCovarianceMatrix_{nullptr}; // inverse matrix used for chi2
+  // original loaded from file
+  std::shared_ptr<TMatrixDSym> _priorFullCovarianceMatrix_{nullptr};
+  // matrices stripped from fixed/freed parameters
+  std::shared_ptr<TMatrixDSym> _priorCovarianceMatrix_{nullptr};
+  std::shared_ptr<TMatrixD>    _inverseCovarianceMatrix_{nullptr}; // inverse matrix used for chi2
 
   std::shared_ptr<TVectorD>  _parameterPriorList_{nullptr};
   std::shared_ptr<TVectorD>  _parameterLowerBoundsList_{nullptr};

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -249,7 +249,7 @@ void ParameterSet::processCovarianceMatrix(){
     double eigenTotal = _eigenValues_->Sum();
 
     _inverseCovarianceMatrix_ = std::make_shared<TMatrixD>(_priorCovarianceMatrix_->GetNrows(), _priorCovarianceMatrix_->GetNrows());
-    _projectorMatrix_                 = std::make_shared<TMatrixD>(_priorCovarianceMatrix_->GetNrows(), _priorCovarianceMatrix_->GetNrows());
+    _projectorMatrix_         = std::make_shared<TMatrixD>(_priorCovarianceMatrix_->GetNrows(), _priorCovarianceMatrix_->GetNrows());
 
     auto eigenState = std::make_unique<TVectorD>(_eigenValues_->GetNrows());
 

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -279,7 +279,7 @@ double LikelihoodInterface::evalPenaltyLikelihood(const ParameterSet& parSet_) {
       // compute penalty term with covariance
       buffer =
           (*parSet_.getDeltaVectorPtr())
-          * ( (*parSet_.getInverseStrippedCovarianceMatrix()) * (*parSet_.getDeltaVectorPtr()) );
+          * ( (*parSet_.getInverseCovarianceMatrix()) * (*parSet_.getDeltaVectorPtr()) );
     }
   }
 

--- a/tests/gundam-tests.sh
+++ b/tests/gundam-tests.sh
@@ -103,13 +103,13 @@ echo ' See gundam-tests.sh for more usage documentation.'
 TESTS="fast-tests"
 
 # Handle any input arguments
-if [[ -t 0 && -t 1 ]]; then
-    echo "Running in interactive mode"
-    TEMP=$(getopt "$0" "$@")
-else
-    echo "Running in non-interactive mode"
+#if [[ -t 0 && -t 1 ]]; then
+#    echo "Running in interactive mode"
+#    TEMP=$(getopt "$0" "$@")
+#else
+#    echo "Running in non-interactive mode"
     TEMP=$(getopt -o 'afres' -n "$0" -- "$@")
-fi
+#fi
 
 if [ $? -ne 0 ]; then
     echo "Error ..."

--- a/tests/gundam-tests.sh
+++ b/tests/gundam-tests.sh
@@ -103,7 +103,14 @@ echo ' See gundam-tests.sh for more usage documentation.'
 TESTS="fast-tests"
 
 # Handle any input arguments
-  TEMP=$(getopt -o 'afres' -n "$0" -- "$@")
+if [[ -t 0 && -t 1 ]]; then
+    echo "Running in interactive mode"
+    TEMP=$(getopt "$0" "$@")
+else
+    echo "Running in non-interactive mode"
+    TEMP=$(getopt -o 'afres' -n "$0" -- "$@")
+fi
+
 if [ $? -ne 0 ]; then
     echo "Error ..."
     exit 1
@@ -260,7 +267,7 @@ for d in ${TESTS}; do
     done
 done
 
-if [ ${#EXPECTED} -gt 0 ]; then
+if [ ${#EXPECTED[@]} -gt 0 ]; then
     echo
     echo Expected Failures:
     for i in ${EXPECTED}; do
@@ -268,7 +275,7 @@ if [ ${#EXPECTED} -gt 0 ]; then
     done
 fi
 
-if [ ${#FAILURES} -gt 0 ]; then
+if [ ${#FAILURES[@]} -gt 0 ]; then
     echo
     echo Failed Jobs:
     for i in ${FAILURES}; do

--- a/tests/gundam-tests.sh
+++ b/tests/gundam-tests.sh
@@ -103,13 +103,13 @@ echo ' See gundam-tests.sh for more usage documentation.'
 TESTS="fast-tests"
 
 # Handle any input arguments
-#if [[ -t 0 && -t 1 ]]; then
-#    echo "Running in interactive mode"
-#    TEMP=$(getopt "$0" "$@")
-#else
-#    echo "Running in non-interactive mode"
+if [[ -t 0 && -t 1 ]]; then
+    echo "Running in interactive mode"
+    TEMP=$(getopt "$0" "$@")
+else
+    echo "Running in non-interactive mode"
     TEMP=$(getopt -o 'afres' -n "$0" -- "$@")
-#fi
+fi
 
 if [ $? -ne 0 ]; then
     echo "Error ..."
@@ -267,7 +267,7 @@ for d in ${TESTS}; do
     done
 done
 
-if [ ${#EXPECTED[@]} -gt 0 ]; then
+if [ ${#EXPECTED} -gt 0 ]; then
     echo
     echo Expected Failures:
     for i in ${EXPECTED}; do
@@ -275,7 +275,7 @@ if [ ${#EXPECTED[@]} -gt 0 ]; then
     done
 fi
 
-if [ ${#FAILURES[@]} -gt 0 ]; then
+if [ ${#FAILURES} -gt 0 ]; then
     echo
     echo Failed Jobs:
     for i in ${FAILURES}; do


### PR DESCRIPTION
For some bad fit parametrization, MIGRAD can do partial gradient steps in which some of the parameters stay still. This makes the gradient descent missing most of the steps. A minor display bug was spotted when printing the post-fit llh state.