### PR TITLE
Update Cache::Manager to so it stays in sync with gundam classes

### DIFF
--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -61,7 +61,7 @@ if( ${CMAKE_BUILD_TYPE} MATCHES DEBUG OR ${ENABLE_DEV_MODE} )
   add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILELINE}"\\\" )
 else()
   cmessage( STATUS "Logger set in RELEASE mode." )
-  add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILELINE}"\\\" )
+  add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILENAME}"\\\" )
 endif()
 
 if(NOT ENABLE_COLOR_OUTPUT)

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -61,7 +61,7 @@ if( ${CMAKE_BUILD_TYPE} MATCHES DEBUG OR ${ENABLE_DEV_MODE} )
   add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILELINE}"\\\" )
 else()
   cmessage( STATUS "Logger set in RELEASE mode." )
-  add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILENAME}"\\\" )
+  add_definitions( -D LOGGER_PREFIX_FORMAT="\\\"{TIME} {SEVERITY} {FILELINE}"\\\" )
 endif()
 
 if(NOT ENABLE_COLOR_OUTPUT)

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -142,7 +142,7 @@ int main(int argc, char** argv){
   // decision has been made
   Cache::Manager::SetIsEnabled( useCacheManager );
 
-  Cache::Manager::setIsForceCpuCalculation( clParser.isOptionTriggered("forceDirect") );
+  Cache::Manager::SetIsForceCpuCalculation( clParser.isOptionTriggered("forceDirect") );
   Cache::Manager::SetEnableDebugPrintouts( clParser.isOptionTriggered("debugVerbose") );
 #endif
 

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -21,7 +21,7 @@
 // some (peculiar) data sets.
 #include "CacheIndexedSums.h"
 namespace Cache {
-    using HistogramSum = Cache::IndexedSums;
+  using HistogramSum = Cache::IndexedSums;
 }
 #else
 // A GPU optimized implementation of histogram summing that will be faster
@@ -73,9 +73,6 @@ private:
 
     // Set to true when the cache needs an update.
     bool fUpdateRequired{true};
-
-    // Keep track of the state of the CacheManager
-    bool fIsCacheManagerBuilt{false};
 
     // Pointers to the Propagator member the CacheManger has to take care of
     SampleSet* fSampleSetPtr{nullptr};
@@ -180,7 +177,7 @@ public:
   /// Check if the caches for the manager have been built.  This will only be
   /// true when the Cache::Manager is enabled, and the Cache::Manager::Build()
   /// method has been called.
-  static bool IsBuilt(){ return fParameters.fIsCacheManagerBuilt; }
+  static bool IsBuilt() {return Cache::Manager::Get() != nullptr;;}
 
 private:
 

--- a/src/CacheManager/include/CacheManager.h
+++ b/src/CacheManager/include/CacheManager.h
@@ -59,30 +59,37 @@ private:
     // You get one guess...
     Manager* fSingleton{nullptr};
 
-    // By default, the use of CacheManager is set to false. This parameter replaces the ones that
-    // was present in GundamGlobals.h
-    // This parameter should be set in the front-end applications
+    /// Control whether the Cache::Manager should be constructed.  This
+    /// parameter should be set in the front-end applications.  This replaces a
+    /// flag that was in GundamGlobals.h
     bool fIsEnabled{false};
 
-    // Enabled printouts when moving data between host and device
+    /// Enabled printouts when moving data between host and device
     bool fEnableDebugPrintouts{false};
 
-    // forceCpuCalculation allows to also do the propagation of parameters with the CPU
-    // routine in order to check the accuracy of the CPU computation
+    /// Control if a propagator should fill the histograms with the GPU (when
+    /// avavailable), or force a parallel CPU calculation.  This really
+    /// belongs in the propagator, but it's dynamic object, so put it here.
+    /// The parallel calculation is used to check the accuracy of the CPU
+    /// computation
     bool fForceCpuCalculation{false};
-
-    // Set to true when the cache needs an update.
-    bool fUpdateRequired{true};
 
     // Pointers to the Propagator member the CacheManger has to take care of
     SampleSet* fSampleSetPtr{nullptr};
     EventDialCache* fEventDialCachePtr{nullptr};
-    // A map between the fit parameter pointers and the parameter index used
-    // by the fitter.
+
+    /// A map between the fit parameter pointers and the parameter index used
+    /// by the fitter.
     std::map<const Parameter*, int> ParameterMap{};
 
-    // Keep track of when we want to get back from the GPU once the propagation is complete
-    bool fIsHistContentCopyEnabled{false};
+    /// True if the histogram content should be copied back from the GPU.
+    /// This should almost always be true.  This should be a private class
+    /// field.
+    bool fIsHistContentCopyEnabled{true};
+
+    /// True if the individual event weights should be copied back from the
+    /// GPU.  This should almost always be false.  This should be a private
+    /// class field.
     bool fIsEventWeightCopyEnabled{false};
 
     /// Declare all of the actual GPU caches here.  There is one GPU, so this
@@ -93,7 +100,6 @@ private:
     // Time monitoring
     GenericToolbox::Time::AveragedTimer<10> cacheFillTimer;
     GenericToolbox::Time::AveragedTimer<10> pullFromDeviceTimer;
-
   };
 
   // instance defined in cpp file
@@ -117,9 +123,6 @@ public:
   /// before the cached weights can be used.  This is used in Propagator.cpp.
   static bool Fill();
 
-  /// Dedicated setter for fUpdateRequired flag
-  static void SetUpdateRequired(bool isUpdateRequired_){ fParameters.fUpdateRequired = isUpdateRequired_; };
-
   /// Set addresses of the Propagator objects the CacheManager should take care of
   static void SetSampleSetPtr(SampleSet& sampleSet_){ fParameters.fSampleSetPtr = &sampleSet_; }
   static void SetEventDialSetPtr(EventDialCache& eventDialCache_){ fParameters.fEventDialCachePtr = &eventDialCache_; }
@@ -139,10 +142,6 @@ public:
   /// needs to be changed.  It forages all of the information from the
   /// original sample list and event dials.
   static bool Update();
-
-  /// Flag that the Cache::Manager internal caches must be updated from the
-  /// SampleSet and EventDialCache before it can be used.
-  static void RequireUpdate(){ SetUpdateRequired(true); }
 
   /// This returns the index of the parameter in the cache.  If the
   /// parameter isn't defined, this will return a negative value.
@@ -293,6 +292,9 @@ private:
 
   // The rough size of all the caches.
   std::size_t fTotalBytes;
+
+  // Set to true when the cache needs an update.
+  bool fUpdateRequired{true};
 
 public:
   virtual ~Manager() = default;

--- a/src/CacheManager/include/CacheSampleHistFiller.h
+++ b/src/CacheManager/include/CacheSampleHistFiller.h
@@ -17,7 +17,8 @@ public:
 
   /// Check that the GUNDAM Histogram contents matches the Cache::Manager
   /// histogram cache.
-  bool validateHistogram(const double* fSumHostPtr_, const double* fSum2HostPtr_);
+  bool validateHistogram(bool quiet, const double* fSumHostPtr_, const double* fSum2HostPtr_);
+
 private:
   Histogram* histPtr{nullptr};
   int cacheManagerIndexOffset{-1};

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -418,8 +418,6 @@ bool Cache::Manager::Build() {
 
   Cache::Manager::RequireUpdate();
 
-  fParameters.fIsCacheManagerBuilt = true;
-
   return true;
 }
 

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -416,7 +416,7 @@ bool Cache::Manager::Build() {
     return false;
   }
 
-  Cache::Manager::RequireUpdate();
+  Cache::Manager::Get()->fUpdateRequired = true;
 
   return true;
 }
@@ -431,8 +431,14 @@ bool Cache::Manager::Update() {
     return false;
   }
 
-  // This is the updated that is required!
-  SetUpdateRequired( false );
+  if (!Cache::Manager::Get()->fUpdateRequired) {
+    // This is not the update that you are looking for.
+    LogError << "Update called when not required" << std::endl;
+    LogThrow("Invalid Cache::Manager::Update()");
+  }
+
+  // This is the update that is required!
+  Cache::Manager::Get()->fUpdateRequired = false;
 
   LogInfo << "Update the internal caches" << std::endl;
 
@@ -705,7 +711,7 @@ bool Cache::Manager::Update() {
 bool Cache::Manager::Fill() {
   Cache::Manager* cache = Cache::Manager::Get();
   if (!cache) return false;
-  if (fParameters.fUpdateRequired) {
+  if (cache->fUpdateRequired) {
     LogError << "Fill while an update is required" << std::endl;
     LogThrow("Fill while an update is required");
   }
@@ -758,11 +764,6 @@ bool Cache::Manager::PropagateParameters(){
     // if disabled, leave
     if (Cache::Manager::Get() == nullptr) {
       return false;
-    }
-
-    // update the cache if necessary
-    if (fParameters.fUpdateRequired) {
-      Cache::Manager::Update();
     }
 
     // do the propagation on the device

--- a/src/CacheManager/src/CacheSampleHistFiller.cpp
+++ b/src/CacheManager/src/CacheSampleHistFiller.cpp
@@ -18,7 +18,9 @@ void CacheSampleHistFiller::copyHistogram(const double* fSumHostPtr_, const doub
   }
 }
 
-bool CacheSampleHistFiller::validateHistogram(const double* fSumHostPtr_, const double* fSum2HostPtr_) {
+bool CacheSampleHistFiller::validateHistogram(bool quiet,
+                                              const double* fSumHostPtr_,
+                                              const double* fSum2HostPtr_) {
   bool ok{true};
 #if HAS_CPP_17
   for( auto [binContent, binContext] : histPtr->loop() ){
@@ -32,12 +34,15 @@ bool CacheSampleHistFiller::validateHistogram(const double* fSumHostPtr_, const 
         or not GundamUtils::almostEqual(binContent.sqrtSumSqWeights,hErr)) {
       double dSum = binContent.sumWeights - hSum;
       double dErr = binContent.sqrtSumSqWeights - hErr;
-      LogError << "Invalid bin[" << binContext.bin.getIndex() << "] --"
-               << " GPU: " << hSum << " +/- " << hErr
-               << " CPU: " << binContent.sumWeights
-               << " +/- " << binContent.sqrtSumSqWeights
-               << " Difference: " << dSum << " +/- " << dErr
-               << std::endl;
+      if (not quiet) {
+        LogError << "Invalid bin[" << binContext.bin.getIndex()
+                 << "+" << cacheManagerIndexOffset << "] --"
+                 << " GPU: " << hSum << " +/- " << hErr
+                 << " CPU: " << binContent.sumWeights
+                 << " +/- " << binContent.sqrtSumSqWeights
+                 << " Difference: " << dSum << " +/- " << dErr
+                 << std::endl;
+      }
       ok = false;
     }
   }

--- a/src/CacheManager/src/WeightTabulated.cpp
+++ b/src/CacheManager/src/WeightTabulated.cpp
@@ -42,6 +42,13 @@ Cache::Weight::Tabulated::Tabulated(
   LogInfo << "Approximate Memory Size for " << GetName()
           << ": " << GetResidentMemory()/1E+9
           << " GB" << std::endl;
+  LogInfo << "  Tables " << std::endl;
+  for (const auto& table : fTables) {
+    LogInfo << "    Table: " << (void*) table.first
+            << " Size: " << table.first->size()
+            << " Start: " << table.second
+            << std::endl;
+  }
 
   try {
     // Get the CPU/GPU memory for the spline index tables.  These are
@@ -155,9 +162,10 @@ bool Cache::Weight::Tabulated::Apply() {
   if (GetUsed() < 1) return false;
 
   // Fill the table.
-  for (auto table : fTables) {
+  for (const auto& table : fTables) {
     int offset = table.second;
-    for (double entry : (*table.first)) {
+    for (const double entry : (*table.first)) {
+      LogThrowIf(not std::isfinite(entry),"Table entry is not finite");
       fData->hostPtr()[offset++] = entry;
     }
   }

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -346,10 +346,9 @@ void FitterEngine::fit(){
   }
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if( Cache::Manager::IsBuilt() ){
-    // To calculate the llh, we only need to grab the bin content, not individual weight
-    Cache::Manager::SetIsEventWeightCopyEnabled( false );
-  }
+  // To calculate the llh, we only need to grab the bin content, not
+  // individual weight
+  bool origCopy = Cache::Manager::SetIsEventWeightCopyEnabled( false );
 #endif
 
   LogInfo << "Minimizing LLH..." << std::endl;
@@ -361,9 +360,9 @@ void FitterEngine::fit(){
 #ifdef GUNDAM_USING_CACHE_MANAGER
   if( Cache::Manager::IsBuilt() ){
     LogWarning << "Pulling back individual weight from device..." << std::endl;
-    Cache::Manager::CopyEventWeights();
-    Cache::Manager::SetIsEventWeightCopyEnabled( true );
+    Cache::Manager::Get()->CopyEventWeights();
   }
+  Cache::Manager::SetIsEventWeightCopyEnabled(origCopy);
 #endif
 
   LogWarning << "Saving post-fit par state..." << std::endl;
@@ -414,10 +413,9 @@ void FitterEngine::fit(){
   else{
     if( _minimizer_->isErrorCalcEnabled() ){
 #ifdef GUNDAM_USING_CACHE_MANAGER
-      if( Cache::Manager::IsBuilt() ){
-        // To calculate the llh, we only need to grab the bin content, not individual weight
-        Cache::Manager::SetIsEventWeightCopyEnabled( false );
-      }
+      // To calculate the llh, we only need to grab the bin content, not
+      // individual weight
+      bool origCopy = Cache::Manager::SetIsEventWeightCopyEnabled( false );
 #endif
 
       LogInfo << "Computing post-fit errors..." << std::endl;
@@ -425,12 +423,11 @@ void FitterEngine::fit(){
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
       if( Cache::Manager::IsBuilt() ){
-        LogWarning << "Pulling back individual weight from device..." << std::endl;
-        Cache::Manager::CopyEventWeights();
-
-        // return to default behavior
-        Cache::Manager::SetIsEventWeightCopyEnabled( true );
+        LogWarning << "Copy event weights from device..." << std::endl;
+        Cache::Manager::Get()->CopyEventWeights();
       }
+      // return to default behavior
+      Cache::Manager::SetIsEventWeightCopyEnabled( origCopy);
 #endif
     }
   }

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -156,6 +156,9 @@ void Propagator::propagateParameters(){
       LogError << GundamUtils::Backtrace;
       LogError << "Parallel GPU and CPU calculations disagree" << std::endl;
     }
+    else {
+      LogError << "Success: Parallel GPU and CPU calculations OK" << std::endl;
+    }
   }
 #endif
 }
@@ -295,8 +298,7 @@ void Propagator::initializeCacheManager(){
   Cache::Manager::SetSampleSetPtr( _sampleSet_ );
   Cache::Manager::SetEventDialSetPtr( _eventDialCache_ );
 
-  Cache::Manager::Build();
-  Cache::Manager::Update();
+  Cache::Manager::Build(_sampleSet_, _eventDialCache_);
 
   // By default, make sure every data is copied to the CPU part
   // Some of those part might get disabled for faster calculation

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -11,13 +11,12 @@
 #include "ParameterSet.h"
 #include "GundamGlobals.h"
 #include "ConfigUtils.h"
+#include "GundamBacktrace.h"
 
 #include "GenericToolbox.Utils.h"
 
-
 #include <memory>
 #include <vector>
-
 
 void Propagator::muteLogger(){ Logger::setIsMuted( true ); }
 void Propagator::unmuteLogger(){ Logger::setIsMuted( false ); }
@@ -141,7 +140,7 @@ void Propagator::propagateParameters(){
   // Trigger the reweight on the GPU.  This will fill the histograms, but most
   // of the time, leaves the event weights on the GPU.
   usedCacheManager = Cache::Manager::PropagateParameters();
-  if( usedCacheManager and not Cache::Manager::isForceCpuCalculation() ){ return; }
+  if(usedCacheManager and not Cache::Manager::isForceCpuCalculation()) return;
 #endif
 
   // Trigger the reweight on the CPU.  Override the dial update inside of
@@ -154,8 +153,8 @@ void Propagator::propagateParameters(){
   if (usedCacheManager and Cache::Manager::isForceCpuCalculation()) {
     bool valid = Cache::Manager::ValidateHistogramContents();
     if (not valid) {
+      LogError << GundamUtils::Backtrace;
       LogError << "Parallel GPU and CPU calculations disagree" << std::endl;
-      std::exit(EXIT_FAILURE);
     }
   }
 #endif

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -296,12 +296,12 @@ void Propagator::initializeCacheManager(){
   Cache::Manager::SetEventDialSetPtr( _eventDialCache_ );
 
   Cache::Manager::Build();
+  Cache::Manager::Update();
 
   // By default, make sure every data is copied to the CPU part
   // Some of those part might get disabled for faster calculation
   Cache::Manager::SetIsEventWeightCopyEnabled( true );
   Cache::Manager::SetIsHistContentCopyEnabled( true );
-
   Cache::Manager::PropagateParameters();
 }
 #endif

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -140,7 +140,7 @@ void Propagator::propagateParameters(){
   // Trigger the reweight on the GPU.  This will fill the histograms, but most
   // of the time, leaves the event weights on the GPU.
   usedCacheManager = Cache::Manager::PropagateParameters();
-  if(usedCacheManager and not Cache::Manager::isForceCpuCalculation()) return;
+  if(usedCacheManager and not Cache::Manager::IsForceCpuCalculation()) return;
 #endif
 
   // Trigger the reweight on the CPU.  Override the dial update inside of
@@ -150,7 +150,7 @@ void Propagator::propagateParameters(){
   this->refillHistograms();
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if (usedCacheManager and Cache::Manager::isForceCpuCalculation()) {
+  if (usedCacheManager and Cache::Manager::IsForceCpuCalculation()) {
     bool valid = Cache::Manager::ValidateHistogramContents();
     if (not valid) {
       LogError << GundamUtils::Backtrace;
@@ -295,9 +295,6 @@ void Propagator::initializeCacheManager(){
   // the MC has been copied for the Asimov fit, or the "data" use the MC
   // reweighting cache.  This must also be before the first use of
   // reweightMcEvents that is done using the GPU.
-  Cache::Manager::SetSampleSetPtr( _sampleSet_ );
-  Cache::Manager::SetEventDialSetPtr( _eventDialCache_ );
-
   Cache::Manager::Build(_sampleSet_, _eventDialCache_);
 
   // By default, make sure every data is copied to the CPU part

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -156,9 +156,6 @@ void Propagator::propagateParameters(){
       LogError << GundamUtils::Backtrace;
       LogError << "Parallel GPU and CPU calculations disagree" << std::endl;
     }
-    else {
-      LogError << "Success: Parallel GPU and CPU calculations OK" << std::endl;
-    }
   }
 #endif
 }

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -338,7 +338,7 @@ void LikelihoodInterface::loadModelPropagator(){
   });
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
-  if( Cache::Manager::isCacheManagerEnabled() ){
+  if( Cache::Manager::IsCacheManagerEnabled() ){
     _modelPropagator_.initializeCacheManager();
   }
 #endif

--- a/tests/fast-tests/200NormalizationFit.sh
+++ b/tests/fast-tests/200NormalizationFit.sh
@@ -27,6 +27,6 @@ OUTPUT_FILE=${DATA_DIR}/${BASE}.root
 echo ${OUTPUT_FILE}
 echo ${CONFIG_FILE}
 
-gundamFitter -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
+gundamFitter --cpu -t 1 -s 10000 -c ${CONFIG_FILE} -o ${OUTPUT_FILE}
 
 # End of the script


### PR DESCRIPTION
Move away from static class fields and reduce the number of static methods.  Make sure that the Cache::Manager internals can only be updated at expected locations.  Removed a couple places where fields that need to be immutable could be changed.  The caches are now only filled once, and will trap if a second fill is attempted.  It seems that we are still copying more data from the GPU to CPU than we need, but this doesn't attempt to address that.  The usage of the Cache::Manager is still more "serial" than it should be, but I didn't rearrange the likelihood calculation (yet).