### PR TITLE
Promises, futures and deferments

### DIFF
--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -659,8 +659,8 @@ void FitterEngine::checkNumericalAccuracy(){
           parSet.getParameterList()[iPar].setParameterValue( throws[iThrow][iParSet][iPar] );
         }
       }
-      getLikelihoodInterface().getModelPropagator().propagateParameters();
-      getLikelihoodInterface().evalLikelihood();
+      std::future<bool> eventually = getLikelihoodInterface().getModelPropagator().applyParameters();
+      getLikelihoodInterface().evalLikelihood(eventually);
 
       if( responses[iThrow] == responses[iThrow] ){ // not nan
         LogThrowIf(getLikelihoodInterface().getLastLikelihood() != responses[iThrow], "Not accurate: " << getLikelihoodInterface().getLastLikelihood() - responses[iThrow] << " / "

--- a/src/Propagator/include/Propagator.h
+++ b/src/Propagator/include/Propagator.h
@@ -18,13 +18,11 @@
 #include <map>
 #include <future>
 
-
 class Propagator : public JsonBaseClass {
 
 protected:
   void configureImpl() override;
   void initializeImpl() override;
-
 
 public:
   static void muteLogger();
@@ -59,7 +57,22 @@ public:
   void clearContent();
   void shrinkDialContainers();
   void buildDialCache();
+
+  /// Apply the current parameters and wait for it to finish.  This reweights
+  /// the events, and refills the histograms.  This is a convenience wrapper
+  /// around applyParameters().get().
   void propagateParameters();
+
+  /// Promise to eventually apply the current parameters.  This returns a
+  /// future that becomes available after reweighting and the histograms are
+  /// refilled.  With The CPU, the parameters are applied synchronously so the
+  /// future is basically a "dummy".  When a GPU is used, the promise is
+  /// returned before the information is copied from the GPU, so accessing it
+  /// may cause a wait.  The future will be valid if the calculation was
+  /// successfully started, true if the calculation has completed correctly,
+  /// and false if the calculation started correctly, but failed.
+  std::future<bool> applyParameters();
+
   void reweightEvents(bool updateDials = true);
 
   // misc

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -143,7 +143,7 @@ std::future<bool> Propagator::applyParameters(){
 #ifdef GUNDAM_USING_CACHE_MANAGER
   // Trigger the reweight on the GPU.  This will fill the histograms, but most
   // of the time, leaves the event weights on the GPU.
-  auto cacheManager = Cache::Manager::Fill(getSampleSet(),getEventDialCache());
+  std::future<bool> cacheManager = Cache::Manager::Fill(getSampleSet(),getEventDialCache());
   if (cacheManager.valid() and not Cache::Manager::IsForceCpuCalculation()) {
     return cacheManager;  // The cacheManager future could be returned.
   }

--- a/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
+++ b/src/StatisticalInference/Likelihood/include/LikelihoodInterface.h
@@ -90,8 +90,8 @@ public:
   void propagateAndEvalLikelihood();
 
   // core
-  double evalLikelihood() const;
-  double evalStatLikelihood() const;
+  double evalLikelihood(std::future<bool>& propagation) const;
+  double evalStatLikelihood(std::future<bool>& propagation) const;
   double evalPenaltyLikelihood() const;
   [[nodiscard]] double evalStatLikelihood(const SamplePair& samplePair_) const;
   [[nodiscard]] std::string getSummary() const;


### PR DESCRIPTION
Implements the promise pattern for parameter propagation.  In practical terms, this lets the likelihood calculate the penalty part of the likelihood while the event reweighting may still be happening.  For now, when using a pure, possibly thread based, CPU calculation the operations are synchronous, but the GPU calculation becomes asynchronous.  

The promise is implemented with a deferred async object.  There may be a bit to be gained using an asynchronous async object (i.e. put the GPU wait into a thread), but that needs to be benchmarked.