### PR TITLE
Fix/barlow llh

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -6,8 +6,11 @@
 
 if( WITH_TESTS )
   message("")
-  cmessage( WARNING "Defining tests...")
+  cmessage( STATUS "Defining tests...")
   include( CTest )
   add_subdirectory( ${CMAKE_SOURCE_DIR}/tests )
+else()
+  message("")
+  cmessage( WARNING "Skipping tests...")
 endif()
 

--- a/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeeston.h
@@ -30,9 +30,10 @@ namespace JointProbability{
   }
 
   double BarlowBeeston::eval(double data_, double pred_, double err_, int bin_) const {
-    const double dataVal = data_;
-    const double predVal = pred_;
-    const double mcUncert = err_;
+    // Impose "physical" constraints
+    const double dataVal = std::max(data_,0.0);
+    const double predVal = std::max(pred_,std::sqrt(std::numeric_limits<double>::min()));
+    const double mcUncert = std::max(err_,std::numeric_limits<double>::min());
 
     _buf_.rel_var = mcUncert / TMath::Sq(predVal);
     _buf_.b       = (predVal * _buf_.rel_var) - 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,9 +34,14 @@ if( WITH_GOOGLE_TEST )
   find_package(GTest QUIET)
 
   if(GTEST_FOUND)
-    if( WITH_CACHE_MANAGER )
+    cmessage( STATUS "Compiling google tests" )
+    add_executable(gundamGTest_unitTest.exe
+      GTests/unitTest_JointProbability.cpp)
+    target_link_libraries(gundamGTest_unitTest.exe GTest::gtest_main)
+    target_link_libraries(gundamGTest_unitTest.exe GundamFitter)
+    gtest_discover_tests(gundamGTest_unitTest.exe)
 
-      cmessage( STATUS "Compiling google tests..." )
+    if( WITH_CACHE_MANAGER )
       # Setup the hemi test suite for the host
 
       add_executable(gundamGTest_host.exe
@@ -64,12 +69,14 @@ if( WITH_GOOGLE_TEST )
 
     else( WITH_CACHE_MANAGER )
 
-      cmessage( WARNING "WITH_CACHE_MANAGER is set to false. Skipping Google test executables." )
+      cmessage( WARNING "WITH_CACHE_MANAGER is set to false. Skipping Cache::Manager test executables." )
 
     endif( WITH_CACHE_MANAGER )
 
   else(GTEST_FOUND)
-    cmessage( FATAL_ERROR "Google test is not available." )
+    cmessage( WARNING "Google test is not available." )
   endif(GTEST_FOUND)
 
+else(WITH_GOOGLE_TEST)
+  cmessage( STATUS "Unit tests will not be used")
 endif()


### PR DESCRIPTION
Make BarlowLLH numerically stable.  Fix the naive implementation so that it works for the full range of doubles.  It includes a unit test to check the continuity as the predicted value goes to zero, and becomes very large.
