### PR TITLE
Feature/check config syntax

### DIFF
--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -181,6 +181,25 @@ int main(int argc, char** argv){
 
   auto gundamFitterConfig(configHandler.getConfig());
 
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(gundamFitterConfig,
+                           "TOP LEVEL",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {{"outputFolder"},
+                            {"minGundamVersion"},
+                           },
+                           // Expected fields (must be present)
+                           {{"fitterEngineConfig"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {{"generateSamplePlots"},
+                            {"allParameterVariations"},
+                           },
+                           // Replaced field (allowed, but cause a warning)
+                           {});
+
   // Output file path
   std::string outFileName;
   if( clParser.isOptionTriggered("outputFilePath") ){

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -34,6 +34,39 @@
 
 void DataDispenser::configureImpl(){
 
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/datasetList(DataDispenser)",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {
+                             {"name"},
+                             {"fromHistContent"},
+                             {"variablesTransform"},
+                             {"variableDict"},
+                             {"eventVariableAsWeight"},
+                             {"tree"},
+                             {"filePathList"},
+                             {"additionalLeavesStorage"},
+                             {"dummyVariablesList"},
+                             {"useReweightEngine"},
+                             {"dialIndexFormula"},
+                             {"overridePropagatorConfig"},
+                             {"selectionCutFormula"},
+                             {"nominalWeightFormula"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                           },
+                           // Replaced fields (allowed, but cause a warning)
+                           {
+                           });
+
   GenericToolbox::Json::fillValue(_config_, _parameters_.name, "name");
   LogExitIf(_parameters_.name.empty(), "Dataset name not set.");
 

--- a/src/DatasetManager/src/DatasetDefinition.cpp
+++ b/src/DatasetManager/src/DatasetDefinition.cpp
@@ -14,6 +14,36 @@
 
 void DatasetDefinition::configureImpl() {
 
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/datasetList/(dataset)",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {
+                             {"isEnabled"},
+                             {"selectedDataEntry"},
+                             {"selectedToyEntry"},
+                             {"showSelectedEventCount"},
+                             {"devSingleThreadEventLoaderAndIndexer"},
+                             {"devSingleThreadEventSelection"},
+                             {"sortLoadedEvents"},
+                             {"nbMaxThreadsForLoad"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                             {"name"},
+                             {"model"},
+                             {"data"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {},
+                           // Replaced fields (allowed, but cause a warning)
+                           {
+                             {{"mc"}, {"model"}}
+                           });
+
   // mandatory
   _name_ = GenericToolbox::Json::fetchValue<std::string>(_config_, "name");
 

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -27,8 +27,50 @@
 
 #include <sstream>
 
-
 void DialCollection::configureImpl() {
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/propagatorConfig/parametersManagerConfig"
+                           "/dialSetDefinitions",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {
+                             {"dialType"},
+                             {"options"},
+                             {"dialSubType"},
+                             {"isEnabled"},
+                             {"treeExpression"},
+                             {"dialLeafName"},
+                             {"minDialResponse"},
+                             {"maxDialResponse"},
+                             {"useMirrorDial"},
+                             {"mirrorLowEdge"},
+                             {"mirrorHighEdge"},
+                             {"allowDialExtrapolation"},
+                             {"applyCondition"},
+                             {"applyOnDataSets"},
+                             {"definitionRange"},
+                             {"mirrorDefinitionRange"},
+                             {"dialInputList"},
+                             {"binningFilePath"},
+                             {"tableConfig"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                             {"parameterLimits"},
+                             {"dialsType"},
+                             {"type"},
+                           },
+                           // Replaced fields (allowed, but cause a warning)
+                           {
+                             {{"dialsType"}, {"dialType"}},
+                             {{"type"}, {"dialType"}}
+                           });
 
   _dataSetNameList_ = GenericToolbox::Json::fetchValue<std::vector<std::string>>(
       _config_, "applyOnDataSets", std::vector<std::string>());
@@ -257,7 +299,7 @@ void DialCollection::setupDialInterfaceReferences(){
 void DialCollection::readParametersFromConfig(const JsonType &config_) {
   // globals for the dialSet
   GenericToolbox::Json::fillValue(config_, _enableDialsSummary_, "printDialsSummary");
-  GenericToolbox::Json::fillValue(config_, _dialType_, {{"type"}, {"dialsType"}, {"dialType"}});
+  GenericToolbox::Json::fillValue(config_, _dialType_, {{"dialType"}, {"type"},  {"dialsType"}});
   GenericToolbox::Json::fillValue(config_, _dialOptions_, {{"options"}, {"dialSubType"}});
   GenericToolbox::Json::fillValue(config_, _dialLeafName_, {{"treeExpression"}, {"dialLeafName"}});
   GenericToolbox::Json::fillValue(config_, _minDialResponse_, {{"minDialResponse"}, {"minimumSplineResponse"}});
@@ -530,7 +572,7 @@ bool DialCollection::initializeDialsWithTabulation(const JsonType& dialsDefiniti
 
 bool DialCollection::initializeDialsWithBinningFile(const JsonType& dialsDefinition) {
   if(not GenericToolbox::Json::doKeyExist(dialsDefinition, "binningFilePath") ) return false;
-  
+
   // A binning file has been provided, so this is a binned dial.  Create
   // the dials for each bin here.  The dials will be assigned to the
   // events in DataDispenser.

--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -56,6 +56,8 @@ void DialCollection::configureImpl() {
                              {"dialInputList"},
                              {"binningFilePath"},
                              {"tableConfig"},
+                             {"parametersBinningPath"},
+                             {"printDialSummary"},
                            },
                            // Expected fields (must be present)
                            {
@@ -69,7 +71,8 @@ void DialCollection::configureImpl() {
                            // Replaced fields (allowed, but cause a warning)
                            {
                              {{"dialsType"}, {"dialType"}},
-                             {{"type"}, {"dialType"}}
+                             {{"type"}, {"dialType"}},
+                             {{"printDialsSummary"}, {"printDialSummary"}}
                            });
 
   _dataSetNameList_ = GenericToolbox::Json::fetchValue<std::vector<std::string>>(
@@ -209,12 +212,14 @@ void DialCollection::setupDialInterfaceReferences(){
   if( _dialInputBufferList_.empty() ){
     if( _supervisedParameterIndex_ == -1 ){
       // one dial interface per parameter
-      LogThrowIf(_dialInterfaceList_.size() != _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size(),
-                 "Nb of dial base don't match the number of parameters of the selected set: nDials="
-                     << _dialInterfaceList_.size() << " != " << "nPars="
-                     << _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size()
-                     << std::endl << "is the defined dial binning matching the number of parameters?"
-      );
+      if (_dialInterfaceList_.size() != _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size()) {
+        LogError << "Nb of dial base don't match the number of parameters of the selected set: nDials="
+                 << _dialInterfaceList_.size() << " != " << "nPars="
+                 << _parameterSetListPtr_->at(_supervisedParameterSetIndex_).getParameterList().size()
+                 << std::endl << "is the defined dial binning matching the number of parameters?" << std::endl;
+        LogExit("Bad dial definition");
+      }
+
       _dialInputBufferList_.resize(_dialInterfaceList_.size());
       for( int iDial = 0 ; iDial < int(_dialInterfaceList_.size()) ; iDial++ ){
         DialInputBuffer::ParameterReference p{};
@@ -298,7 +303,7 @@ void DialCollection::setupDialInterfaceReferences(){
 // init protected
 void DialCollection::readParametersFromConfig(const JsonType &config_) {
   // globals for the dialSet
-  GenericToolbox::Json::fillValue(config_, _enableDialsSummary_, "printDialsSummary");
+  GenericToolbox::Json::fillValue(config_, _enableDialsSummary_, {{"printDialSummary"}, {"printDialsSummary"}});
   GenericToolbox::Json::fillValue(config_, _dialType_, {{"dialType"}, {"type"},  {"dialsType"}});
   GenericToolbox::Json::fillValue(config_, _dialOptions_, {{"options"}, {"dialSubType"}});
   GenericToolbox::Json::fillValue(config_, _dialLeafName_, {{"treeExpression"}, {"dialLeafName"}});

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -13,6 +13,29 @@
 
 TabulatedDialFactory::TabulatedDialFactory(const JsonType& config_) {
     auto tableConfig = GenericToolbox::Json::fetchValue<JsonType>(config_, "tableConfig");
+    ConfigUtils::checkFields(tableConfig,
+                             "tableConfig",
+                             // Allowed fields (don't need to list fields in
+                             // expected, or deprecated).
+                             {
+                             },
+                             // Expected fields (must be present)
+                             {
+                                 {"name"},
+                                 {"libraryPath"},
+                                 {"initFunction"},
+                                 {"initArguments"},
+                                 {"updateFunction"},
+                                 {"binningFunction"},
+                                 {"binningVariables"},
+                             },
+                             // Deprecated fields (allowed, but cause a warning)
+                             {
+                             },
+                             // Replaced fields (allowed, but cause a warning)
+                             {
+                             });
+
 
     _name_ =  GenericToolbox::Json::fetchValue<std::string>(tableConfig, "name", _name_);
 

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -26,6 +26,44 @@ void FitterEngine::configureImpl(){
   LogInfo << "Reading FitterEngine config..." << std::endl;
   GenericToolbox::setT2kPalette();
 
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(_config_,"/fitterEngineConfig",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {{"enablePCA"},
+                            {"runPcaCheck"},
+                            {"fixGhostFitParameters"},
+                            {"pcaThreshold"},
+                            {"scanConfig"},
+                            {"parameterScanner"},
+                            {"pcaThreshold"},
+                            {"enablePreFitScan"},
+                            {"enablePostFitScan"},
+                            {"enablePreFitToPostFitScan"},
+                            {"generateSamplePlots"},
+                            {"generateOneSigmaPlots"},
+                            {"enableParamVariations"},
+                            {"paramVariationsSigmas"},
+                            {"scaleParStepWithChi2Response"},
+                            {"parStepGain"},
+                            {"throwMcBeforeFit"},
+                            {"throwMcBeforeFitGain"},
+                            {"savePostfitEventTrees"},
+                           },
+                           // Expected fields (must be present)
+                           {{"minimizerConfig"},
+                            {"likelihoodInterfaceConfig"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {{"mcmcConfig"},
+                            {"engineType"},
+                            {"propagatorConfig"},
+                            {"monitorRefreshRateInMs"},
+                           },
+                           // Replaced fields (allowed, but cause a warning)
+                           {});
+
   // need to determine the type before defining the minimizer
   JsonType minimizerConfig{};
   std::string minimizerTypeStr{"RootMinimizer"};
@@ -343,7 +381,7 @@ void FitterEngine::fit(){
               + parList[parIndex].getStdDevValue()
                 * GenericToolbox::Json::fetchValue<double>(entry, "nbSigmaAway");
 
-          LogWarning << "Pushing #" << parIndex << " to " << pushVal << std::endl;
+          LogAlert << "Pushing #" << parIndex << " to " << pushVal << std::endl;
           parList[parIndex].setParameterValue( pushVal );
 
           if( parSet.isEnableEigenDecomp() ){
@@ -360,10 +398,10 @@ void FitterEngine::fit(){
     } // parSet
 
 
-    LogAlert << "Current LLH state:" << std::endl;
+    LogInfo << "Current LLH state:" << std::endl;
     getLikelihoodInterface().propagateAndEvalLikelihood();
 
-    LogAlert << getLikelihoodInterface().getSummary() << std::endl;
+    LogInfo << getLikelihoodInterface().getSummary() << std::endl;
   }
 
   // Leaving now?

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -11,6 +11,9 @@
 
 void MinimizerBase::configureImpl(){
 
+  // Do not use checkFields here.  All of the fields should be checked in the
+  // derived classes.
+
   // nested objects first
   int monitorRefreshRateInMs(5000);
   GenericToolbox::Json::fillValue(_config_, monitorRefreshRateInMs, "monitorRefreshRateInMs");

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -69,7 +69,10 @@ void RootMinimizer::configureImpl(){
                              {"max_fcn"},
                            },
                            // Replaced fields (allowed, but cause a warning}
-                           {});
+                           {
+                             {{"max_iter"}, {"maxIterations"}},
+                             {{"max_fcn"}, {"maxFcnCalls"}},
+                           });
 
   // read general parameters first
   this->MinimizerBase::configureImpl();

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -25,6 +25,52 @@
 void RootMinimizer::configureImpl(){
   LogDebugIf(GundamGlobals::isDebug()) << "Configuring RootMinimizer..." << std::endl;
 
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/minimizerConfig(RootMinimizer)",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {// fields handled by MinimizerBase
+                             {"monitorRefreshRateInMs"},
+                             {"showParametersOnFitMonitor"},
+                             {"maxNbParametersPerLineOnMonitor"},
+                             {"enablePostFitErrorFit"},
+                             {"useNormalizedFitSpace"},
+                             {"writeLlhHistory"},
+                             {"checkParameterValidity"},
+                             // Fields handled here
+                             {"monitorGradientDescent"},
+                             {"strategy"},
+                             {"print_level"},
+                             {"tolerance"},
+                             {"tolerancePerDegreeOfFreedom"},
+                             {"maxIterations"},
+                             {"maxFcnCalls"},
+                             {"enableSimplexBeforeMinimize"},
+                             {"simplexMaxFcnCalls"},
+                             {"simplexToleranceLoose"},
+                             {"simplexStrategy"},
+                             {"errors"},
+                             {"generatePostFitParBreakdown"},
+                             {"generatePostFitEigenBreakdown"},
+
+                           },
+                           // Expected fields (must be present)
+                           {
+                             {"type"},
+                             {"minimizer"},
+                             {"algorithm"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                             {"stepSizeScaling"},
+                             {"errorsAlgo"},
+                             {"restoreStepSizeBeforeHesse"},
+                             {"max_iter"},
+                             {"max_fcn"},
+                           },
+                           // Replaced fields (allowed, but cause a warning}
+                           {});
+
   // read general parameters first
   this->MinimizerBase::configureImpl();
 
@@ -44,7 +90,7 @@ void RootMinimizer::configureImpl(){
   GenericToolbox::Json::fillValue(_config_, _simplexToleranceLoose_, "simplexToleranceLoose");
   GenericToolbox::Json::fillValue(_config_, _simplexStrategy_, "simplexStrategy");
 
-  GenericToolbox::Json::fillValue(_config_, _errorAlgo_, {{"errorsAlgo"},{"errors"}});
+  GenericToolbox::Json::fillValue(_config_, _errorAlgo_, {{"errors"},{"errorsAlgo"}});
 
   GenericToolbox::Json::fillValue(_config_, _generatedPostFitParBreakdown_, "generatedPostFitParBreakdown");
   GenericToolbox::Json::fillValue(_config_, _generatedPostFitEigenBreakdown_, "generatedPostFitEigenBreakdown");

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -30,6 +30,61 @@ void SimpleMcmc::configureImpl(){
   this->MinimizerBase::configureImpl();
   LogInfo << "Configure MCMC: " << _config_ << std::endl;
 
+
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/minimizerConfig(SimpleMcmc)",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {// fields handled by MinimizerBase
+                             {"monitorRefreshRateInMs"},
+                             {"showParametersOnFitMonitor"},
+                             {"maxNbParametersPerLineOnMonitor"},
+                             {"enablePostFitErrorFit"},
+                             {"useNormalizedFitSpace"},
+                             {"writeLlhHistory"},
+                             {"checkParameterValidity"},
+                             // Fields handled here
+                             {"algorithm"},
+                             {"proposal"},
+                             {"mcmcOutputTree"},
+                             {"likelihoodValidity"},
+                             {"randomStart"},
+                             {"saveRawSteps"},
+                             {"modelSaveStride"},
+                             {"burninCycles"},
+                             {"burninSteps"},
+                             {"saveBurnin"},
+                             {"burninSequence"},
+                             {"sequence"},
+                             {"burninCovWindow"},
+                             {"burninCovDeweight"},
+                             {"burninWindow"},
+                             {"adaptiveRestore"},
+                             {"adaptiveCovFile"},
+                             {"adaptiveCovName"},
+                             {"adaptiveCovTrials"},
+                             {"adaptiveCovWindow"},
+                             {"covarianceDeweighting"},
+                             {"adaptiveFreezeCorrelations"},
+                             {"adaptiveFreezeLength"},
+                             {"acceptanceWindow"},
+                             {"fixedSigma"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                             {"type"},
+                             {"cycles"},
+                             {"steps"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                             {"burninResets"},
+                             {"burninFreezeAfter"},
+                             {"adaptiveWindow"},
+                           },
+                           // Replaced fields (allowed, but cause a warning}
+                           {});
+
   // The type of algorithm to be using.  It should be left at the default
   // value (metropolis is the only supported MCMC algorithm right now).
   GenericToolbox::Json::fillValue(_config_, _algorithmName_, "algorithm");

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -19,7 +19,7 @@ void Parameter::configureImpl(){
                            "/parameterDefinitions/(parameter)",
                            // Allowed fields (don't need to list fields in
                            // expected, or deprecated).
-                           {{"name"},          // handled in parameter set.
+                           {{"parameterName"}, // handled in parameter set.
                             {"isEnabled"},
                             {"isFixed"},
                             {"priorValue"},
@@ -39,7 +39,7 @@ void Parameter::configureImpl(){
                            },
                            // Replaced field names (allowed, but warn)
                            {
-                             {{"parameterName"}, {"name"}},
+                             {{"name"}, {"parameterName"}},
                            }
 );
 

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -13,6 +13,35 @@
 
 
 void Parameter::configureImpl(){
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/propagatorConfig/parametersManagerConfig"
+                           "/parameterDefinitions/(parameter)",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {{"name"},          // handled in parameter set.
+                            {"isEnabled"},
+                            {"isFixed"},
+                            {"priorValue"},
+                            {"isThrown"},
+                            {"parameterStepSize"},
+                            {"parameterLimits"},
+                            {"throwLimits"},
+                            {"mirrorRange"},
+                            {"dialSetDefinitions"},
+                            {"priorType"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                           },
+                           // Replaced field names (allowed, but warn)
+                           {
+                             {{"parameterName"}, {"name"}},
+                           }
+);
 
   GenericToolbox::Json::fillValue(_config_, _isEnabled_, "isEnabled");
   if( not _isEnabled_ ) { return; }

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -27,6 +27,7 @@ void ParameterSet::configureImpl(){
                            // Allowed fields (don't need to list fields in
                            // expected, or deprecated).
                            {
+                             {"parameterDefinitions"},
                              {"isEnabled"},
                              {"isScanEnabled"},
                              {"numberOfParameters"},
@@ -48,7 +49,6 @@ void ParameterSet::configureImpl(){
                              {"parameterLowerBoundsList"},
                              {"parameterUpperBoundsList"},
                              {"throwEnabledList"},
-                             {"parameterDefinitions"},
                              {"dialSetDefinitions"},
                              {"enableOnlyParameters"},
                              {"disableParameters"},
@@ -69,17 +69,17 @@ void ParameterSet::configureImpl(){
                            {
                              {"maskForToyGeneration"},
                              {"devUseParLimitsOnEigen"},
-                             {"allowPca"},
-                             {"fixGhostFitParameters"},
-                             {"parameterNameTObjArray"},
-                             {"parameterPriorTVectorD"},
-                             {"parameterLowerBoundsTVectorD"},
-                             {"parameterUpperBoundsTVectorD"},
-                             {"useEigenDecompInFit"},
                            },
                            // Field names that got replaced.
                            {
                              {{"allowPca"},{"enablePca"}},
+                             {{"fixGhostFitParameters"},{"enablePca"}},
+                             {{"parameterNameTObjArray"},{"parameterNameList"}},
+                             {{"parameterPriorTVectorD"},{"parameterPriorValueList"}},
+
+                             {{"parameterLowerBoundsTVectorD"},{"parameterLowerBoundsList"}},
+                             {{"parameterUpperBoundsTVectorD"},{"parameterUpperBoundsList"}},
+                             {{"useEigenDecompInFit"},{"enableEigenDecomp"}},
                            });
 
 
@@ -144,7 +144,6 @@ void ParameterSet::configureImpl(){
   // dev option -> was used for validation
   GenericToolbox::Json::fillValue(_config_, _devUseParLimitsOnEigen_, "devUseParLimitsOnEigen");
 
-
   // individual parameter definitions:
   if( not _parameterDefinitionFilePath_.empty() ){ readParameterDefinitionFile(); }
 
@@ -178,6 +177,10 @@ void ParameterSet::configureImpl(){
     }
 
     LogExitIf(_nbParameterDefinition_==-1, "Could not figure out the number of parameters to be defined for the set: " << _name_ );
+  }
+
+  if (_nbParameterDefinition_ < 1) {
+    LogError << "CONFIG ERROR: Parameter set \"" << getName() << "\" without parameters." << std::endl;
   }
 
   this->defineParameters();
@@ -1055,6 +1058,10 @@ void ParameterSet::readParameterDefinitionFile(){
 void ParameterSet::defineParameters(){
   _parameterList_.resize(_nbParameterDefinition_, Parameter(this));
   int parIndex{0};
+
+  if (_parameterList_.size() < 1) {
+    LogError << "CONFIG ERROR: Parameter set \"" << getName() << "\"<< defined without any parameters" << std::endl;
+  }
 
   for( auto& par : _parameterList_ ){
     par.setParameterIndex(parIndex++);

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -18,6 +18,70 @@
 
 
 void ParameterSet::configureImpl(){
+  // All of the fields that should (or may) be at this level in the YAML.
+  // This provides a rudimentary syntax check for user inputs.
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/propagatorConfig/parametersManagerConfig"
+                           "/parameterSetList",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {
+                             {"isEnabled"},
+                             {"isScanEnabled"},
+                             {"numberOfParameters"},
+                             {"nominalStepSize"},
+                             {"printDialSetsSummary"},
+                             {"useOnlyOneParameterPerEvent"},
+                             {"printParametersSummary"},
+                             {"parameterLimits"},
+                             {"enablePca"},
+                             {"enableThrowToyParameters"},
+                             {"customFitParThrow"},
+                             {"releaseFixedParametersOnHess"},
+                             {"parameterDefinitionFilePath"},
+                             {"covarianceMatrixFilePath"},
+                             {"covarianceMatrix"},
+                             {"covarianceMatrixTMatrixD"},
+                             {"parameterNameList"},
+                             {"parameterPriorValueList"},
+                             {"parameterLowerBoundsList"},
+                             {"parameterUpperBoundsList"},
+                             {"throwEnabledList"},
+                             {"parameterDefinitions"},
+                             {"dialSetDefinitions"},
+                             {"enableOnlyParameters"},
+                             {"disableParameters"},
+                             {"useMarkGenerator"},
+                             {"useEigenDecompForThrows"},
+                             {"enableEigenDecomp"},
+                             {"allowEigenDecompWithBounds"},
+                             {"maxNbEigenParameters"},
+                             {"maxEigenFraction"},
+                             {"eigenSvdThreshold"},
+                             {"eigenParBounds"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                             {"name"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                             {"maskForToyGeneration"},
+                             {"devUseParLimitsOnEigen"},
+                             {"allowPca"},
+                             {"fixGhostFitParameters"},
+                             {"parameterNameTObjArray"},
+                             {"parameterPriorTVectorD"},
+                             {"parameterLowerBoundsTVectorD"},
+                             {"parameterUpperBoundsTVectorD"},
+                             {"useEigenDecompInFit"},
+                           },
+                           // Field names that got replaced.
+                           {
+                             {{"allowPca"},{"enablePca"}},
+                           });
+
 
   GenericToolbox::Json::fillValue(_config_, _name_, "name");
   LogExitIf(_name_.empty(), "Config error -- parameter set without a name.");
@@ -51,8 +115,8 @@ void ParameterSet::configureImpl(){
   GenericToolbox::Json::fillValue(_config_, _parameterNameListPath_, {{"parameterNameList"},{"parameterNameTObjArray"}});
   GenericToolbox::Json::fillValue(_config_, _parameterPriorValueListPath_, {{"parameterPriorValueList"},{"parameterPriorTVectorD"}});
 
-  GenericToolbox::Json::fillValue(_config_, _parameterLowerBoundsTVectorD_, "parameterLowerBoundsTVectorD");
-  GenericToolbox::Json::fillValue(_config_, _parameterUpperBoundsTVectorD_, "parameterUpperBoundsTVectorD");
+  GenericToolbox::Json::fillValue(_config_, _parameterLowerBoundsTVectorD_, {{"parameterLowerBoundsList"}, {"parameterLowerBoundsTVectorD"}});
+  GenericToolbox::Json::fillValue(_config_, _parameterUpperBoundsTVectorD_, {{"parameterUpperBoundsList"}, {"parameterUpperBoundsTVectorD"}});
   GenericToolbox::Json::fillValue(_config_, _throwEnabledListPath_, "throwEnabledList");
 
   GenericToolbox::Json::fillValue(_config_, _parameterDefinitionConfig_, "parameterDefinitions");

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -19,6 +19,24 @@ void ParametersManager::unmuteLogger(){ Logger::setIsMuted( false ); }
 
 // config
 void ParametersManager::configureImpl(){
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/propagatorConfig/parametersManagerConfig",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {{"throwToyParametersWithGlobalCov"},
+                            {"reThrowParSetIfOutOfBounds"},
+                            {"reThrowParSetIfOutOfPhysical"},
+                           },
+                           // Expected fields (must be present)
+                           {{"parameterSetList"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                           },
+                           // Renamed fields  (allowed, but cause a warning)
+                           {
+                           });
 
   GenericToolbox::Json::fillValue(_config_, _throwToyParametersWithGlobalCov_, "throwToyParametersWithGlobalCov");
   GenericToolbox::Json::fillValue(_config_, _reThrowParSetIfOutOfPhysical_, {{"reThrowParSetIfOutOfBounds"},{"reThrowParSetIfOutOfPhysical"}});

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -78,6 +78,10 @@ void ParametersManager::initializeImpl(){
   }
   LogInfo << "Total number of parameters: " << nEnabledPars << std::endl;
 
+  if (nEnabledPars < 1) {
+    LogError << "CONFIG ERROR: No parameters have been defined" << std::endl;
+  }
+
   LogInfo << "Building global covariance matrix (" << nEnabledPars << "x" << nEnabledPars << ")" << std::endl;
   _globalCovarianceMatrix_ = std::make_shared<TMatrixD>(nEnabledPars, nEnabledPars );
   int parSetOffset = 0;

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -23,6 +23,32 @@ void Propagator::unmuteLogger(){ Logger::setIsMuted( false ); }
 
 void Propagator::configureImpl(){
 
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig"
+                           "/propagatorConfig",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {{"showNbEventParameterBreakdown"},
+                            {"showNbEventPerSampleParameterBreakdown"},
+                            {"parameterInjection"},
+                            {"debugPrintLoadedEvents"},
+                            {"debugPrintLoadedEventsNbPerSample"},
+                            {"devSingleThreadReweight"},
+                            {"devSingleThreadHistFill"},
+                            {"globalEventReweightCap"},
+                           },
+                           // Expected fields (must be present)
+                           {{"sampleSetConfig"},
+                            {"parametersManagerConfig"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {{"fitSampleSetConfig"},
+                            {"parameterSetListConfig"},
+                            {"throwToyParametersWithGlobalCov"},
+                           },
+                           // Replaced field names (allowed, but case a warning)
+                           {});
+
   // nested objects
   GenericToolbox::Json::fillValue(_config_, _sampleSet_.getConfig(), {{"sampleSetConfig"}, {"fitSampleSetConfig"}});
   _sampleSet_.configure();

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -42,12 +42,18 @@ void Propagator::configureImpl(){
                             {"parametersManagerConfig"},
                            },
                            // Deprecated fields (allowed, but cause a warning)
-                           {{"fitSampleSetConfig"},
-                            {"parameterSetListConfig"},
-                            {"throwToyParametersWithGlobalCov"},
+                           {
                            },
-                           // Replaced field names (allowed, but case a warning)
-                           {});
+                           // Replaced fields (allowed, but case a warning)
+                           {
+                             {{"fitSampleSetConfig"},{"sampleSetConfig"}},
+                             {{"parameterSetListConfig"},
+                              {"parametersManagerConfig"
+                               "/parameterSetList"}},
+                             {{"throwToyParametersWithGlobalCov"},
+                              {"parametersManagerConfig"
+                               "/throwToyParametersWithGlobalCov"}},
+                           });
 
   // nested objects
   GenericToolbox::Json::fillValue(_config_, _sampleSet_.getConfig(), {{"sampleSetConfig"}, {"fitSampleSetConfig"}});

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -19,6 +19,29 @@ void LikelihoodInterface::configureImpl(){
 
   _threadPool_.setNThreads(GundamGlobals::getNbCpuThreads() );
 
+  ConfigUtils::checkFields(_config_,
+                           "/fitterEngineConfig/likelihoodInterfaceConfig",
+                           // Allowed fields (don't need to list fields in
+                           // expected, or deprecated).
+                           {
+                             {"plotGeneratorConfig"},
+                             {"enableStatThrowInToys"},
+                             {"gaussStatThrowInToys"},
+                             {"enableEventMcThrow"},
+                           },
+                           // Expected fields (must be present)
+                           {
+                             {"propagatorConfig"},
+                             {"dataSetList"},
+                             {"jointProbabilityConfig"},
+                           },
+                           // Deprecated fields (allowed, but cause a warning)
+                           {
+                           },
+                           {
+                             {{"datasetList"}, {"dataSetList"}},
+                           });
+
   // reading the configuration of the propagator
   // allows to implement
   GenericToolbox::Json::fillValue(_config_, _modelPropagator_.getConfig(), "propagatorConfig");
@@ -60,7 +83,7 @@ void LikelihoodInterface::configureImpl(){
 
 
   // defining datasets:
-  GenericToolbox::Json::fillValue(_config_, datasetListConfig, {{"datasetList"}, {"dataSetList"}});
+  GenericToolbox::Json::fillValue(_config_, datasetListConfig, {{"dataSetList"}, {"datasetList"}});
   _datasetList_.reserve(datasetListConfig.size() );
   for( const auto& dataSetConfig : datasetListConfig ){
     _datasetList_.emplace_back(dataSetConfig, int(_datasetList_.size()));

--- a/src/Utils/include/ConfigUtils.h
+++ b/src/Utils/include/ConfigUtils.h
@@ -5,13 +5,11 @@
 #ifndef GUNDAM_CONFIG_UTILS_H
 #define GUNDAM_CONFIG_UTILS_H
 
-
 #include "GenericToolbox.Json.h"
 
 #include "yaml-cpp/yaml.h"
 
 #include <string>
-
 
 // shortcuts
 typedef GenericToolbox::Json::JsonType JsonType;
@@ -32,6 +30,17 @@ namespace ConfigUtils {
   void forwardConfig(JsonType& config_);
   void unfoldConfig(JsonType& config_);
 
+  /// Check that the config only contains fields in the allowed_ vector, and
+  /// has all of the fields in the expected_ vector.  Fields that are in the
+  /// "deprecated_ vector will generate an warning, but are still considered
+  /// valid.
+  bool checkFields(JsonType& config_,
+                   std::string parent_,
+                   std::vector<std::string> allowed_,
+                   std::vector<std::string> expected_ = {},
+                   std::vector<std::string> deprecated_ = {},
+                   std::vector<std::pair<std::string,std::string>>
+                   replaced_ = {});
 
   // handle all the hard work for us
   class ConfigHandler{

--- a/src/Utils/src/ConfigUtils.cpp
+++ b/src/Utils/src/ConfigUtils.cpp
@@ -146,19 +146,7 @@ namespace ConfigUtils {
                    std::vector<std::pair<std::string,std::string>> replaced_) {
     bool ok = true;
 
-    // Check that all of the expected items exist
-    for (std::string& expect : expected_) {
-      try {
-        GenericToolbox::Json::fetchValue<JsonType>(config_, expect);
-      }
-      catch (...) {
-        LogError << "CONFIG ERROR: Required field \"" << expect
-                 << "\" is missing for " << parent_ <<std::endl;
-        ok = false;
-      }
-    }
-
-    // Check that all of the items are in allowed, expected, or deprecated
+    // Check that only items in allowed, expected, or deprecated are found.
     int index{0};
     for (auto& entry : config_.items()) {
       bool found = false;
@@ -182,9 +170,9 @@ namespace ConfigUtils {
       if (found) continue;
       for (std::pair<std::string,std::string> target : replaced_) {
         if (target.first == key) {
-          LogWarning << "CONFIG WARNING: \"" << target.first
-                     << "\" is replaced by \"" << target.second
-                     << "\" for " << parent_
+          LogWarning << "CONFIG WARNING: Deprecated field \"" << target.first
+                     << "\" replaced by \"" << target.second
+                     << "\" in " << parent_
                      << std::endl;
           found = true;
           break;
@@ -193,22 +181,34 @@ namespace ConfigUtils {
       if (found) continue;
       for (std::string target : deprecated_) {
         if (target == key) {
-          LogWarning << "CONFIG WARNING: \"" << target
-                     << "\" is deprecated for " << parent_
+          LogWarning << "CONFIG WARNING: Deprecated field \"" << target
+                     << "\" in " << parent_
                      << std::endl;
           found = true;
           break;
         }
       }
       if (found) continue;
-      LogError << "CONFIG ERROR: field \"" << key
-               << "\" not supported for " << parent_
+      LogError << "CONFIG ERROR: Unsupported field \"" << key
+               << "\" in " << parent_
                << std::endl;
       ok = false;
     }
 
+    // Check that all of the expected items exist
+    for (std::string& expect : expected_) {
+      try {
+        GenericToolbox::Json::fetchValue<JsonType>(config_, expect);
+      }
+      catch (...) {
+        LogError << "CONFIG ERROR: Missing field \"" << expect
+                 << "\" required in " << parent_ <<std::endl;
+        ok = false;
+      }
+    }
+
     if (not ok) {
-      LogError << "CONFIG ERROR: \"" << parent_ << "\" YAML record is invalid"
+      LogError << "CONFIG ERROR: Invalid YAML record for \"" << parent_
                << std::endl;
     }
 


### PR DESCRIPTION
Provide better feed back to help users debug configuration files.  This flags any field that won't be understood by gundam, explicitly looks for the usage of deprecated fields (not dependent on special code), and provides messages for preferred field names.  

Comment: Since this is retrofitting the json design, it's not following the usual pattern used to validate inputs, but doing that would mean a fairly significant rework of both GenericToolkit::Json, and the gundam classes.  We will have to make sure that the actual Json accessors, and the "syntax" checking remain synchronised (think of it as double entry bookkeeping).

Second Comment: This doesn't check all of the possible configuration options, or the entire hierarchy, but I've tried to catch most of the big stuff.  A lot of replaced field names are simply flagged as deprecated, so we still need to add the information providing user feedback for the best name.