### PR TITLE
Fix issue #800: Trap missing parameter sets

### DIFF
--- a/resources/examples/mcmc/gundamPlotMCMC.C
+++ b/resources/examples/mcmc/gundamPlotMCMC.C
@@ -129,6 +129,13 @@ void readParameterSets() {
     std::vector<double> *parSigma = 0;
     std::vector<double> *parMin = 0;
     std::vector<double> *parMax = 0;
+
+    if (not parSets) {
+        std::cout << "FitterEngine/fit/parameterSets not found in "
+                  << gFile->GetName() << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
     parSets->SetBranchAddress("parameterSetNames", &parSetNames);
     parSets->SetBranchAddress("parameterSetOffsets", &parSetOffsets);
     parSets->SetBranchAddress("parameterSetCounts", &parSetCounts);


### PR DESCRIPTION
Validate the input file (a little) to make sure that the required trees can be found.  This is an "interactive" macro that is mostly an example, so it prints diagnostics and exits.

Closes #800 