### PR TITLE
Fix/kriging and thread safety

### DIFF
--- a/src/CacheManager/include/WeightKriged.h
+++ b/src/CacheManager/include/WeightKriged.h
@@ -73,10 +73,10 @@ public:
     std::size_t GetWeightsUsed() const {return fWeightsUsed;}
 
     /// Get the space reserved for the tables.
-    std::size_t GetDataReserved() const { return fDataReserved; }
+    std::size_t GetTableReserved() const { return fTableReserved; }
 
     /// Get the space used by the the tables.
-    std::size_t GetDataUsed() const { return fDataUsed; }
+    std::size_t GetTableUsed() const { return fTableUsed; }
 
 private:
 
@@ -105,13 +105,13 @@ private:
 
     /// An array for the data in the tables.  This is copied from the CPU to
     /// the GPU for each iteration.
-    std::size_t    fDataReserved;
-    std::size_t    fDataUsed;
-    std::unique_ptr<hemi::Array<WEIGHT_BUFFER_FLOAT>> fData;
+    std::size_t    fTableReserved;
+    std::size_t    fTableUsed;
+    std::unique_ptr<hemi::Array<WEIGHT_BUFFER_FLOAT>> fTable;
 
-    /// The offsets for each table in the data. This is used whill filling the
-    /// fIndices, fConstants, and fData tables, but not for the calculation.
-    const std::map<const std::vector<double>*, int> fTables;
+    /// The offsets for each table in the data. This is used while filling the
+    /// fIndices, fConstants, and fTable tables, but not for the calculation.
+    const std::map<const std::vector<double>*, int> fTableOffsets;
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/hemi/hemi_error.h
+++ b/src/CacheManager/include/hemi/hemi_error.h
@@ -40,12 +40,13 @@ namespace hemi {
     // can be wrapped around any runtime API call. No-op in release builds.
     inline cudaError_t checkCuda(cudaError_t result)
     {
-#if defined(DEBUG) || defined(_DEBUG) || defined(HEMI_DEBUG)
         if (result != cudaSuccess) {
             fprintf(stderr, "CUDA Runtime Error: %s\n", cudaGetErrorString(result));
+#if defined(DEBUG) || defined(_DEBUG) || defined(HEMI_DEBUG)
             assert(result == cudaSuccess);
-        }
 #endif
+            std::exit(EXIT_FAILURE);
+        }
         return result;
     }
 

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -361,7 +361,7 @@ bool Cache::Manager::Build(SampleSet& sampleSet,
              <<" ("<< 1.0*config.tabulated/config.events <<" per event)"
              << std::endl;
     LogInfo  << "    Kriged:    " << config.kriged
-             <<" ("<< 1.0*config.tabulated/config.events <<" per event)"
+             <<" ("<< 1.0*config.kriged/config.events <<" per event)"
              << std::endl;
     LogInfo  << "    Bilinear: " << config.bilinear
              <<" ("<< 1.0*config.bilinear/config.events <<" per event)"

--- a/src/DatasetManager/src/EventVarTransformLib.cpp
+++ b/src/DatasetManager/src/EventVarTransformLib.cpp
@@ -49,6 +49,7 @@ void EventVarTransformLib::initInputFormulas(){
   _inputBuffer_.resize(_inputFormulaList_.size(), std::nan("unset"));
 }
 double EventVarTransformLib::evalTransformation( const Event& event_, std::vector<double>& inputBuffer_) const{
+  std::lock_guard<std::mutex> guard(GundamGlobals::getGlobalMutEx());
   // Eval the requested variables
   size_t nFormula{_inputFormulaList_.size()};
   for( size_t iFormula = 0 ; iFormula < nFormula ; iFormula++ ){

--- a/src/DialDictionary/DialDefinitions/include/Kriged.h
+++ b/src/DialDictionary/DialDefinitions/include/Kriged.h
@@ -16,7 +16,7 @@ public:
     ~Kriged() = default;
     Kriged() = delete;
     Kriged(const std::vector<double>* table_,
-           std::vector<int> index_, std::vector<double> weight_,
+           int entries_, std::vector<int> index_, std::vector<double> weight_,
            const std::string& options_="");
 
     [[nodiscard]] std::unique_ptr<DialBase> clone() const override { return std::make_unique<Kriged>(*this); }

--- a/src/DialDictionary/DialDefinitions/src/CompiledLibDial.cpp
+++ b/src/DialDictionary/DialDefinitions/src/CompiledLibDial.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "CompiledLibDial.h"
+#include "GundamGlobals.h"
 
 #include "Logger.h"
 
@@ -11,6 +12,7 @@
 
 double CompiledLibDial::evalResponse( const DialInputBuffer &input_ ) const{
   // Eval with dynamic function
+  std::lock_guard<std::mutex> guard(GundamGlobals::getGlobalMutEx());
   return reinterpret_cast<double(*)(double*)>(_evalFct_)((double*) &input_.getInputBuffer()[0]);
 }
 
@@ -35,7 +37,3 @@ bool CompiledLibDial::loadLibrary(const std::string& path_){
 
   return true;
 }
-
-
-
-

--- a/src/DialDictionary/DialDefinitions/src/Kriged.cpp
+++ b/src/DialDictionary/DialDefinitions/src/Kriged.cpp
@@ -1,12 +1,13 @@
 #include "Kriged.h"
 
 Kriged::Kriged(const std::vector<double>* table_,
-                std::vector<int> index_, std::vector<double> weight_,
-                const std::string& options_)
+               int entries_, std::vector<int> index_, std::vector<double> weight_,
+               const std::string& options_)
     : _table_{table_} {
-    _weights_.reserve(index_.size());
-    for (int i=0; i<index_.size(); ++i) {
-        _weights_.emplace_back(index_[i],weight_[i]);
+    _weights_.resize(entries_);
+    for (int i=0; i<entries_; ++i) {
+        _weights_[i].first = index_[i];
+        _weights_[i].second = weight_[i];
     }
 }
 

--- a/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
+++ b/src/DialDictionary/DialFactories/src/TabulatedDialFactory.cpp
@@ -62,6 +62,7 @@ TabulatedDialFactory::TabulatedDialFactory(const ConfigReader& config_) {
         std::exit(EXIT_FAILURE); // Exit, not throw!
     }
 
+    std::lock_guard<std::mutex> guard(GundamGlobals::getGlobalMutEx());
     void* library = dlopen(expandedPath.c_str(), RTLD_LAZY );
     if( library == nullptr ){
         LogError << "Cannot load library: " << dlerror() << std::endl;
@@ -130,6 +131,7 @@ TabulatedDialFactory::TabulatedDialFactory(const ConfigReader& config_) {
 }
 
 void TabulatedDialFactory::updateTable(DialInputBuffer& inputBuffer) {
+    std::lock_guard<std::mutex> guard(GundamGlobals::getGlobalMutEx());
     _updateFunc_(_name_.c_str(),
                  _table_.data(),
                  (int) _table_.size(),
@@ -138,6 +140,7 @@ void TabulatedDialFactory::updateTable(DialInputBuffer& inputBuffer) {
 }
 
 DialBase* TabulatedDialFactory::makeDial(const Event& event) {
+    std::lock_guard<std::mutex> guard(GundamGlobals::getGlobalMutEx());
     int i=0;
     for (const std::string& varName : getBinningVariables()) {
         double v = event.getVariables().fetchVariable(varName).getVarAsDouble();


### PR DESCRIPTION
A meta fix:  This was triggered by the thread-safety problems, but also includes fixes for over-allocation of memory in the kriging dial, cleanups to the CacheManager::WeightKriged initialization summary.  

Resolves #817 : The kriging dial now allocates the right amount of memory for a vector (no extra capacity)

Resolves #815, Resolves #814, Resolves #813 and Resolves #812 : Adds a global mutex that is acquired before accessing a symbol defined in a dynamically loaded library. This makes the pessimistic assumption that the library address may have been acquired multiple times, and that the offsets into the library can only be used in a single GUNDAM thread.  The library may or may not be thread safe, and may or may not allocate other devices (making them temporarily inaccessible to GUNDAM).