### PR TITLE
Generalise legacy parameter range config parsing

### DIFF
--- a/docs/configuration/ParameterSet.md
+++ b/docs/configuration/ParameterSet.md
@@ -52,35 +52,34 @@ so an `eigenValueThreshold` of 1E-12 is usually appropriate.
 
 ### Parameter set config options
 
-| Field                                | Type       | Description                                                  | Default |
-|--------------------------------------|------------|--------------------------------------------------------------|---------|
-| name                                 | string     | Required: The parameter set name                             |         |
-| [parameterDefinitions](Parameter.md) | list(Json) | The list parameters that are part of this set                |         |
-| [dialSetDefinitions](Dial.md)     | list(Json) | The list of "dials" that modify the model                    |         |
-| isEnabled                            | bool       | Is the set is enabled for the fit                            |         |
-| isScanEnabled                        | bool       | Should the set be "scanned" by the parameter scanner         |         |
-| nominalStepSize                      | double     | The step scale used by the minimizer                         | 1.0     |
-| printDialSetSummary                  | bool       | Should the dial set summary be printed                       | false   |
-| printParameterSummary                | bool       | Should the parameter set summary be printed                  | false   |
-| parameterLimits/minValue             | double     | Define a minimum value for all parameters in this set        | -inf    |
-| parameterLimits/maxValue             | double     | Define a maximum value for all parameters in this set        | +inf    |
-| enablePca                            | bool       | Fix parameter if 1 sigma scan doesn't change LLH (DANGEROUS) | false   |
-| enableThrowToyParameters             | bool       | This set should be thrown when generating toy data           | true    |
-| releaseFixedParametersOnHesse        | bool       | Fixed parameters are considered for HESSIAN                  | false   |
-| parameterDefinitionFilePath          | string     | Name of a file defining parameters and covariance            | empty   |
-| covarianceMatrix                     | string     | Name of TH2D covariance in parameter definition file         | empty   |
-| parameterNameList                    | string     | Name of TObjArray of strings for parameter names             | empty   |
-| parameterPriorValueList              | string     | Name of TVectorD with prior values for each parameter        | empty   |
-| parameterLowerBoundsList             | string     | Name of TVectorD with parameter lower bounds                 | empty   |
-| parameterUpperBoundsList             | string     | Name of TVectorD with parameter lower bounds                 | empty   |
-| enableOnlyParameters                 | list       | List of enabled parameter for this set (others disabled)     | empty   |
-| disableParameters                    | list       | List of disabled parameters for this set (others enabled)    | empty   |
-| useEigenDecompForThrows              | bool       | Throw toys in eigen decomposed basis                         | false   |
-| enableEigenDecomp                    | bool       | Eigen decompose the prior covariance matrix                  | false   |
-| allowEigenDecompWithBounds           | bool       | Allow bounds to be ignored when eigen decomposing            | false   |
-| maxNbEigenParameters                 | int        | Only use this many eigen parameters                          | inf     |
-| maxEigenFraction                     | double     | Fraction of total "eigen" power to use                       | 1.0     |
-| eigenValueThreshold                  | double     | Ignore eigenvectors with eigenvalues below this threshold    | 0.0     |
+| Field                                | Type             | Description                                                  | Default |
+|--------------------------------------|------------------|--------------------------------------------------------------|---------|
+| name                                 | string           | Required: The parameter set name                             |         |
+| [parameterDefinitions](Parameter.md) | list(Json)       | The list parameters that are part of this set                |         |
+| [dialSetDefinitions](Dial.md)        | list(Json)       | The list of "dials" that modify the model                    |         |
+| isEnabled                            | bool             | Is the set is enabled for the fit                            |         |
+| isScanEnabled                        | bool             | Should the set be "scanned" by the parameter scanner         |         |
+| nominalStepSize                      | double           | The step scale used by the minimizer                         | 1.0     |
+| printDialSetSummary                  | bool             | Should the dial set summary be printed                       | false   |
+| printParameterSummary                | bool             | Should the parameter set summary be printed                  | false   |
+| parameterLimits                      | [double, double] | Define a range for all parameters in this set                |         |
+| enablePca                            | bool             | Fix parameter if 1 sigma scan doesn't change LLH (DANGEROUS) | false   |
+| enableThrowToyParameters             | bool             | This set should be thrown when generating toy data           | true    |
+| releaseFixedParametersOnHesse        | bool             | Fixed parameters are considered for HESSIAN                  | false   |
+| parameterDefinitionFilePath          | string           | Name of a file defining parameters and covariance            | empty   |
+| covarianceMatrix                     | string           | Name of TH2D covariance in parameter definition file         | empty   |
+| parameterNameList                    | string           | Name of TObjArray of strings for parameter names             | empty   |
+| parameterPriorValueList              | string           | Name of TVectorD with prior values for each parameter        | empty   |
+| parameterLowerBoundsList             | string           | Name of TVectorD with parameter lower bounds                 | empty   |
+| parameterUpperBoundsList             | string           | Name of TVectorD with parameter lower bounds                 | empty   |
+| enableOnlyParameters                 | list             | List of enabled parameter for this set (others disabled)     | empty   |
+| disableParameters                    | list             | List of disabled parameters for this set (others enabled)    | empty   |
+| useEigenDecompForThrows              | bool             | Throw toys in eigen decomposed basis                         | false   |
+| enableEigenDecomp                    | bool             | Eigen decompose the prior covariance matrix                  | false   |
+| allowEigenDecompWithBounds           | bool             | Allow bounds to be ignored when eigen decomposing            | false   |
+| maxNbEigenParameters                 | int              | Only use this many eigen parameters                          | inf     |
+| maxEigenFraction                     | double           | Fraction of total "eigen" power to use                       | 1.0     |
+| eigenValueThreshold                  | double           | Ignore eigenvectors with eigenvalues below this threshold    | 0.0     |
 
 ### JSON sub-structures
 

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -23,8 +23,6 @@ void Parameter::prepareConfig(ConfigReader& config_){
     {"parameterStepSize"},
     {"parameterIndex"},
     {"parameterLimits"},
-    {"parameterLimits/minValue"},
-    {"parameterLimits/maxValue"},
     {"physicalLimits"},
     {"throwLimits"},
     {"mirrorRange"},
@@ -57,15 +55,7 @@ void Parameter::configureImpl(){
   _config_.fillValue(_mirrorRange_, "mirrorRange");
   _config_.fillValue(_dialDefinitionsList_, "dialSetDefinitions");
 
-  if( _config_.hasField("parameterLimits/minValue") or _config_.hasField("parameterLimits/maxValue") ){
-    // legacy
-    _config_.fillValue(_parameterLimits_.min, "parameterLimits/minValue");
-    _config_.fillValue(_parameterLimits_.max, "parameterLimits/maxValue");
-  }
-  else{
-    // use range definition instead `parameterLimits: [0, 1]`
-    _config_.fillValue(_parameterLimits_, "parameterLimits");
-  }
+  _config_.fillValue(_parameterLimits_, "parameterLimits");
 
   _config_.fillEnum(_priorType_, "priorType");
   if( _priorType_ == PriorType::Flat ){ _isFree_ = true; }


### PR DESCRIPTION
While running some old config files I realised some config options were not parsing the range as the LTS used to do. This PR generalise the legacy range parsing by implementing it directly in the generic toolbox