### PR TITLE
Adding config option to mute zero pred bin in BarlowBeestonBanff2022

### DIFF
--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -27,6 +27,7 @@ namespace JointProbability{
     void printConfiguration() const;
 
     mutable int verboseLevel{0};
+    bool doWarnZeroPredBin{true};
     bool throwIfInfLlh{true};
     bool allowZeroMcWhenZeroData{true};
     bool usePoissonLikelihood{false};
@@ -59,6 +60,7 @@ namespace JointProbability{
 
   inline void BarlowBeestonBanff2022::configureImpl(){
     _config_.defineFields({
+      {"doWarnZeroPredBin"},
       {"allowZeroMcWhenZeroData"},
       {"usePoissonLikelihood"},
       {"BBNoUpdateWeights"},
@@ -69,6 +71,7 @@ namespace JointProbability{
     });
     _config_.checkConfiguration();
 
+    _config_.fillValue(doWarnZeroPredBin, "doWarnZeroPredBin");
     _config_.fillValue(allowZeroMcWhenZeroData, "allowZeroMcWhenZeroData");
     _config_.fillValue(usePoissonLikelihood, "usePoissonLikelihood");
     _config_.fillValue(BBNoUpdateWeights, "BBNoUpdateWeights");
@@ -89,7 +92,7 @@ namespace JointProbability{
     double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
     double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
 
-    if( predVal == 0 and dataVal != 0 ){
+    if( predVal == 0 and dataVal != 0 and doWarnZeroPredBin ){
       LogError << samplePair_.model->getName() << "/" << samplePair_.model->getHistogram().getBinContextList()[bin_].bin.getSummary() << ": predicting 0 rate in this bin -> llh not defined / inf" << std::endl;
     }
 

--- a/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
+++ b/src/StatisticalInference/JointProbability/include/BarlowBeestonBanff2022.h
@@ -27,7 +27,7 @@ namespace JointProbability{
     void printConfiguration() const;
 
     mutable int verboseLevel{0};
-    bool doWarnZeroPredBin{true};
+    bool muteZeroPredBinWarn{false};
     bool throwIfInfLlh{true};
     bool allowZeroMcWhenZeroData{true};
     bool usePoissonLikelihood{false};
@@ -60,7 +60,7 @@ namespace JointProbability{
 
   inline void BarlowBeestonBanff2022::configureImpl(){
     _config_.defineFields({
-      {"doWarnZeroPredBin"},
+      {"muteZeroPredBinWarn"},
       {"allowZeroMcWhenZeroData"},
       {"usePoissonLikelihood"},
       {"BBNoUpdateWeights"},
@@ -71,7 +71,7 @@ namespace JointProbability{
     });
     _config_.checkConfiguration();
 
-    _config_.fillValue(doWarnZeroPredBin, "doWarnZeroPredBin");
+    _config_.fillValue(muteZeroPredBinWarn, "muteZeroPredBinWarn");
     _config_.fillValue(allowZeroMcWhenZeroData, "allowZeroMcWhenZeroData");
     _config_.fillValue(usePoissonLikelihood, "usePoissonLikelihood");
     _config_.fillValue(BBNoUpdateWeights, "BBNoUpdateWeights");
@@ -92,7 +92,7 @@ namespace JointProbability{
     double dataVal = samplePair_.data->getHistogram().getBinContentList()[bin_].sumWeights;
     double predVal = samplePair_.model->getHistogram().getBinContentList()[bin_].sumWeights;
 
-    if( predVal == 0 and dataVal != 0 and doWarnZeroPredBin ){
+    if( not muteZeroPredBinWarn and verboseLevel >= 0 and predVal == 0 and dataVal != 0 ){
       LogError << samplePair_.model->getName() << "/" << samplePair_.model->getHistogram().getBinContextList()[bin_].bin.getSummary() << ": predicting 0 rate in this bin -> llh not defined / inf" << std::endl;
     }
 


### PR DESCRIPTION
In OA2024, we expect to have some systematics to suppress events in some low populated bins. When only a few events has been measured in the data for a given bin, the fitter might want to try to suppress the prediction in the model. This leads to 0 predicted events in bins for which the llh isn't defined.

Those states are expected and temporary during the minimisation. The error message that is printed can be spamming for quite while, which fills up the logs.

This PR adds an option to disable the printouts: `doWarnZeroPredBin`. It is set to true bu default (no change wrt main).