### PR TITLE
Fix/missing dialInputList key

### DIFF
--- a/src/DialDictionary/DialEngine/src/DialCollection.cpp
+++ b/src/DialDictionary/DialEngine/src/DialCollection.cpp
@@ -31,6 +31,7 @@
 void DialCollection::prepareConfig(ConfigReader &config_){
   config_.clearFields();
   config_.defineFields({
+      {"name"},
       {"isEnabled"},
       {"applyOnDataSets"},
       {"dialInputList"},

--- a/src/Utils/src/ConfigUtils.cpp
+++ b/src/Utils/src/ConfigUtils.cpp
@@ -340,9 +340,9 @@ namespace ConfigUtils {
         for( auto& invalidKey : invalidKeyList ){
           LogAlert << _parentPath_ << ": key \"" << invalidKey << "\" has an invalid name. It won't be recognized by GUNDAM." << std::endl;
 #ifdef DEBUG_BUILD
-          LogError << "Possible missing key declaration: " << invalidKey << std::endl;
-          LogError << "BackTrace: " << std::endl
-                   << GundamUtils::Backtrace << std::endl;
+          LogWarning << "Possible missing key declaration: " << invalidKey << std::endl;
+          LogWarning << "BackTrace: " << std::endl
+                     << GundamUtils::Backtrace << std::endl;
 #endif
         }
       }

--- a/src/Utils/src/ConfigUtils.cpp
+++ b/src/Utils/src/ConfigUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "ConfigUtils.h"
 #include "GundamUtils.h"
+#include "GundamBacktrace.h"
 
 #include "GenericToolbox.Root.h"
 #include "GenericToolbox.Yaml.h"
@@ -338,6 +339,11 @@ namespace ConfigUtils {
       if( not invalidKeyList.empty() ){
         for( auto& invalidKey : invalidKeyList ){
           LogAlert << _parentPath_ << ": key \"" << invalidKey << "\" has an invalid name. It won't be recognized by GUNDAM." << std::endl;
+#ifdef DEBUG_BUILD
+          LogError << "Possible missing key declaration: " << invalidKey << std::endl;
+          LogError << "BackTrace: " << std::endl
+                   << GundamUtils::Backtrace << std::endl;
+#endif
         }
       }
     }


### PR DESCRIPTION
Closes #826 

This adds the missing "name" key.  Also adds a useful trick when DEBUG_BUILD is set to help track down where the key was expected.  