### PR TITLE
adding maxNbPoints to the gradient descent scan

### DIFF
--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -1396,6 +1396,11 @@ void RootMinimizer::saveGradientSteps(){
 
   LogInfo << "Saving " << gradientDescentMonitor.stepPointList.size() << " gradient steps..." << std::endl;
 
+  int nPointsPerStep{8};
+  int maxNbPoints{1000}; // don't spend too much time eval the steps
+  nPointsPerStep = std::min(nPointsPerStep, maxNbPoints/int(gradientDescentMonitor.stepPointList.size()));
+  if( nPointsPerStep <= 1 ){ nPointsPerStep = 2; }
+
   // make sure the parameter states get restored as we leave
   auto currentParState = getModelPropagator().getParametersManager().exportParameterInjectorConfig();
   GenericToolbox::ScopedGuard g{
@@ -1432,7 +1437,7 @@ void RootMinimizer::saveGradientSteps(){
     }
 
     // line scan from previous point
-    getParameterScanner().scanSegment( nullptr, gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, 8 );
+    getParameterScanner().scanSegment( nullptr, gradientDescentMonitor.stepPointList[iGradStep].parState, lastParStep, nPointsPerStep );
     lastParStep = gradientDescentMonitor.stepPointList[iGradStep].parState;
 
     if( globalGraphList.empty() ){


### PR DESCRIPTION
Gradient descent scans happen after the fit to show how the minimisation find the best-fit point. In certain cases, especially failing fits, the descent takes many steps (few 100s) and plotting the graphs can take quite a long time. This caps the maximum number of points to draw on the graphs