### PR TITLE
Adding evalModelAt option to define data histograms

### DIFF
--- a/docs/configuration/DatasetLoader.md
+++ b/docs/configuration/DatasetLoader.md
@@ -42,8 +42,11 @@ As an entry list
 
 All options from MC
 
-| Option | Type   | Description                                                               | Default |
-|--------|--------|---------------------------------------------------------------------------|---------|
-| name   | string | Name of the data/toy entry                                                |         |
-| fromMc | bool   | Inherit all parameter from MC. All other entries are treated as overrides | false   |
+| Option                   | Type   | Description                                                                                                                     | Default |
+|--------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------|---------|
+| name                     | string | Name of the data/toy entry                                                                                                      |         |
+| fromModel                | bool   | Use config from model as a base for a data entry                                                                                | false   |
+| useReweightEngine        | bool   | Force to load the dials while loading the data. Used for custom toys that use the reweight engine for generating the histograms | false   |
+| evalModelAt              | json   | Specify which sets of parameters to eval the model and copy the events from. Parameter injector format                          |         |
+| overridePropagatorConfig | json   | Use a custom set of config option that will override the propagator config. Any parameter can be changed from here              |         |
 

--- a/src/DatasetManager/include/DataDispenserUtils.h
+++ b/src/DatasetManager/include/DataDispenserUtils.h
@@ -68,8 +68,9 @@ struct DataDispenserParameters{
   };
   FromHistContent fromHistContent;
 
-//  JsonType fromHistContent{};
-  JsonType overridePropagatorConfig{};
+//  JsonType fromHistContent;
+  JsonType overridePropagatorConfig;
+  JsonType evalModelAt;
 
   [[nodiscard]] std::string getSummary() const;
 };

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -51,7 +51,8 @@ void DataDispenser::prepareConfig(ConfigReader &config_){
     {"selectionCutFormula"},
     {"nominalWeightFormula"},
     {"variableDict", {"overrideLeafDict"}},
-    {"fromMc"},
+    {"fromModel", {"fromMc"}},
+    {"evalModelAt"},
   });
   config_.checkConfiguration();
 }
@@ -126,6 +127,7 @@ void DataDispenser::configureImpl(){
   _config_.fillValue(_parameters_.debugNbMaxEventsToLoad, "debugNbMaxEventsToLoad");
   _config_.fillValue(_parameters_.dialIndexFormula, "dialIndexFormula");
   _config_.fillValue(_parameters_.overridePropagatorConfig, "overridePropagatorConfig");
+  _config_.fillValue(_parameters_.evalModelAt, "evalModelAt");
 
   _config_.fillFormula(_parameters_.selectionCutFormulaStr, "selectionCutFormula", "&&");
   _config_.fillFormula(_parameters_.nominalWeightFormulaStr, "nominalWeightFormula", "*");
@@ -159,7 +161,6 @@ void DataDispenser::load(Propagator& propagator_){
 
   _cache_.clear();
   _cache_.propagatorPtr = &propagator_;
-
 
   if( not _parameters_.overridePropagatorConfig.empty() ){
     LogWarning << "Reload the propagator config with override options" << std::endl;

--- a/src/DatasetManager/src/DatasetDefinition.cpp
+++ b/src/DatasetManager/src/DatasetDefinition.cpp
@@ -55,7 +55,7 @@ void DatasetDefinition::configureImpl() {
     _dataDispenserDict_.emplace(name, DataDispenser(this));
     _dataDispenserDict_.at(name).getParameters().isData = true;
 
-    if( dataEntry.fetchValue("fromMc", false) ){
+    if( dataEntry.fetchValue("fromModel", false) ){
       _dataDispenserDict_.at(name).setConfig( _modelDispenser_.getConfig() );
     }
 

--- a/src/Propagator/include/Propagator.h
+++ b/src/Propagator/include/Propagator.h
@@ -47,7 +47,7 @@ public:
   [[nodiscard]] auto& getEventDialCache() const { return _eventDialCache_; }
   [[nodiscard]] auto& getParametersManager() const { return _parManager_; }
   [[nodiscard]] auto& getDialCollectionList() const{ return _dialManager_.getDialCollectionList(); }
-  [[nodiscard]] auto& getParameterInjectorMc() const { return _parameterInjectorMc_;; }
+  [[nodiscard]] auto& getParameterInjectorMc() const { return _parameterInjectorMc_; }
 
   // mutable getters
   auto& getSampleSet(){ return _sampleSet_; }

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -409,9 +409,31 @@ void LikelihoodInterface::loadDataPropagator(){
 
       // otherwise load the dataset
       dataDispenser->getParameters().isData = true;
-      dataDispenser->load( _dataPropagator_ );
+
+      if( not dataDispenser->getParameters().evalModelAt.empty() ){
+        LogWarning << "Generating data histograms using model evaluated with a set of parameters" << std::endl;
+
+        LogInfo << "Injecting parameters to the model..." << std::endl;
+        _modelPropagator_.getParametersManager().injectParameterValues(dataDispenser->getParameters().evalModelAt);
+        _modelPropagator_.reweightEvents();
+
+        LogInfo << "Copying events to data histograms..." << std::endl;
+        _dataPropagator_.copyEventsFrom( _modelPropagator_ );
+
+        LogInfo << "Restoring model parameters..." << std::endl;
+        _modelPropagator_.getParametersManager().moveParametersToPrior();
+        _modelPropagator_.reweightEvents();
+
+        // histograms are filled afterward
+      }
+      else {
+        LogWarning << "Loading data propagator..." << std::endl;
+        dataDispenser->load( _dataPropagator_ );
+      }
+
     }
 
+    LogWarning << "Setting dial cache for data..." << std::endl;
     _dataPropagator_.getDialManager().shrinkDialContainers();
     _dataPropagator_.buildDialCache();
 


### PR DESCRIPTION
Related to issue: https://github.com/gundam-organization/gundam/issues/838

Example of usage:
```
fitterEngineConfig:
  propagatorConfig:
    dataSetList:
      - name: "ND280"
        selectedDataEntry: "fds-maqe-shift"

        data:
          - name: "fds-maqe-shift"
            evalModelAt:
              parameterSetList: [{ 
                name: "Cross-Section Systematics",  
                parameterValues: [{name: "MaCCQEGraph", value: 1.21 }]
              }]
```

This way the data entry `fds-maqe-shift` won't need to reload the full set of ROOT files to fill up the histograms.

The content of `evalModelAt` is the same as the parameter injector. 