### PR TITLE
Disabling default prefit to postfix line scan

### DIFF
--- a/src/Fitter/Engine/include/FitterEngine.h
+++ b/src/Fitter/Engine/include/FitterEngine.h
@@ -91,7 +91,7 @@ private:
   bool _throwMcBeforeFit_{false};
   bool _enablePreFitScan_{false};
   bool _enablePostFitScan_{false};
-  bool _enablePreFitToPostFitLineScan_{true};
+  bool _enablePreFitToPostFitLineScan_{false};
   bool _generateSamplePlots_{true};
   bool _generateOneSigmaPlots_{false};
   bool _doAllParamVariations_{false};


### PR DESCRIPTION
By default `_enablePreFitToPostFitLineScan_` was set to true. However it takes quite a lot of space on disk.

As this is a user debug feature, this should be set to false.