### PR TITLE
Fix: SimpleMcmc correlations with a stripped covariance

### DIFF
--- a/resources/examples/mcmc/gundamPlotMCMC.C
+++ b/resources/examples/mcmc/gundamPlotMCMC.C
@@ -677,7 +677,10 @@ void gundamPlotMCMC() {
     for (std::size_t iAcc = 0; iAcc < posteriorParamPlots.size(); ++iAcc) {
         // Skip parameters that will not be in the summary plots.  These are
         // parameters that were fixed and have a zero autocorrelation.
-        if (!gPosteriorAutocorrelation[iAcc]) continue;
+        if (!gPosteriorAutocorrelation[iAcc]) {
+            std::cout << "Skip plot: " << iAcc << std::endl;
+            continue;
+        }
         for (int k = 1;
              k<=gPosteriorAutocorrelation[iAcc]->GetNbinsX(); ++k) {
             double a = gPosteriorAutocorrelation[iAcc]->GetBinContent(k);
@@ -715,7 +718,7 @@ void gundamPlotMCMC() {
         int b = gPosteriorAutocorrelationAvg->GetBin(x);
         double e = gPosteriorAutocorrelationAvg->GetBinError(x);
         double s = std::abs(r/e)/std::sqrt(2.0);
-        effectiveSampleSize += std::erf(s)*r;
+        effectiveSampleSize += std::erf(s)*std::abs(r);
     }
     effectiveSampleSize = steps/(1.0 + 2.0*std::abs(effectiveSampleSize));
     eventWeight = effectiveSampleSize/steps;
@@ -732,7 +735,7 @@ void gundamPlotMCMC() {
             int b = gPosteriorAutocorrelation[iPar]->GetBin(x);
             double e = gPosteriorAutocorrelation[iPar]->GetBinError(x);
             double s = std::abs(r/e)/std::sqrt(2.0);
-            ess.back() += std::erf(s)*r;
+            ess.back() += std::erf(s)*std::abs(r);
         }
         ess.back() = steps/(1.0 + 2.0*ess.back());
     }
@@ -789,9 +792,22 @@ void gundamPlotMCMC() {
             for (std::size_t iPar = 0; iPar < points->size(); ++iPar) {
                 double content = points->at(iPar);
                 if (!posteriorParamPlots[iPar]) {
+                    std::cout << "Missing parameter " << iPar
+                              << std::endl;
                     continue;
                 }
-                if (ess[iPar] < 0.1) continue;
+                if (std::isfinite(ess[iPar])) {
+                    std::cout << "Parameter " << iPar
+                              << " ESS is not finite:" << ess[iPar]
+                              << std::endl;
+                    continue;
+                }
+                if (ess[iPar] < 0.0) {
+                    std::cout << "Parameter " << iPar
+                              << " ESS is invalid: " << ess[iPar]
+                              << std::endl;
+                    continue;
+                }
                 double w = ess[iPar]/steps;
                 posteriorParamPlots[iPar]->Fill(content,w);
             }

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -1,7 +1,3 @@
-//
-// Created by Clark McGrew on 26/01/2023.
-//
-
 #include "SimpleMcmc.h"
 #include "LikelihoodInterface.h"
 #include "FitterEngine.h"
@@ -391,7 +387,7 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
   mcmc.GetProposeStep().ResetCorrelations();
 
   // Set up the correlations in the priors.
-  int count1 = 0;
+  int count1 = 0;             // The index in the parameter array
   for (const Parameter* par1 : getMinimizerFitParameterPtr() ) {
     ++count1;
     const ParameterSet* set1 = par1->getOwner();
@@ -401,11 +397,12 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
               << std::endl;
       continue;
     }
+
     if ( set1->isEnableEigenDecomp()) {
       continue;
     }
 
-    int count2 = 0;
+    int count2 = 0;             // The index in the parameter array
     for (const Parameter* par2 : getMinimizerFitParameterPtr()) {
       ++count2;
       const ParameterSet* set2 = par2->getOwner();
@@ -415,32 +412,47 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
                 << std::endl;
         continue;
       }
+
       if ( set2->isEnableEigenDecomp()) {
         continue;
       }
 
+      // Parameters have to be in the same set to have a prior correlation.
+      // If they are in different sets, then, by definition, they are not
+      // correlated.
       if (set1 != set2) continue;
+
+      // Only use the "lower half" to get the correlations.
       int in1 = par1->getParameterIndex();
       int in2 = par2->getParameterIndex();
       if (in2 <= in1) continue;
+
       const std::shared_ptr<TMatrixDSym>& corr
-          = GenericToolbox::toCorrelationMatrix(set1->getPriorCovarianceMatrix());
+          = GenericToolbox::toCorrelationMatrix(set1->getPriorFullCovarianceMatrix());
       if (!corr) continue;
+
       double correlation = (*corr)(in1,in2);
+      if (not std::isfinite(correlation)) {
+        LogError << "Invalid correlation" << std::endl;
+        corr->Print();
+        LogExit("Bad correlation");
+      }
       // Don't impose very small correlations, let them be discovered.
       if (std::abs(correlation) < 0.01) continue;
       // Complain about large correlations.  When a correlation is this
       // large, then the user should (but probably won't) rethink the
       // parameter definitions!
       if (std::abs(correlation) > 0.98) {
-        LogInfo << "VERY LARGE CORRELATION (" << correlation
-                << ") BETWEEN"
-                << " " << set1->getName() << "/" << par1->getName()
-                << " & " << set2->getName() << "/" << par2->getName()
-                << std::endl;
+        LogWarning << "Very large prior correlation (" << correlation
+                   << ") between"
+                   << " " << set1->getName() << "/" << par1->getName()
+                   << " & " << set2->getName() << "/" << par2->getName()
+                   << std::endl
+                   << "Consider using eigendecomposition for parameter set: "
+                   << set1->getName()
+                   << std::endl;
       }
-      mcmc.GetProposeStep().SetCorrelation(count1-1,count2-1,
-                                           (*corr)(in1,in2));
+      mcmc.GetProposeStep().SetCorrelation(count1-1,count2-1,correlation);
     }
   }
 

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -433,8 +433,8 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
 
       double correlation = (*corr)(in1,in2);
       if (not std::isfinite(correlation)) {
-        LogError << "Invalid correlation" << std::endl;
-        corr->Print();
+        LogError << "Invalid correlation for set " << set1->getName()
+                 << std::endl;
         LogExit("Bad correlation");
       }
       // Don't impose very small correlations, let them be discovered.
@@ -460,6 +460,10 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
 
   return true;
 }
+
+// Load the proposal covariance from an input file.  The input
+// file will usually contain the result of a MLL fit, and we load
+// the covariance calculated by HESSE.
 bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
                                                    sMCMC::Vector& prior,
                                                    const std::string& fileName,
@@ -509,7 +513,7 @@ bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
              << std::endl;
     LogError << "   Proposal Y Bins:     " << proposalCov->GetNbinsY()
              << std::endl;
-    LogThrow("Mismatched proposal covariance matrix");
+    LogExit("Mismatched proposal covariance matrix");
   }
 
   // Dump all of the previous correlations.
@@ -525,7 +529,7 @@ bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
       LogError << "Mismatch of parameter and covariance names" << std::endl;
       LogError << "Parameter:  " << parName << std::endl;
       LogError << "Covariance: " << covName << std::endl;
-      LogThrow("Mismatched covariance histogram");
+      LogExit("Mismatched covariance histogram");
     }
     double sig1 = std::sqrt(proposalCov->GetBinContent(count1,count1));
     int count2 = 0;

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -84,6 +84,7 @@ public:
   [[nodiscard]] auto& getDialSetDefinitions() const{ return _dialSetDefinitions_; }
   [[nodiscard]] auto& getCustomParThrow() const{ return _customParThrow_; }
   [[nodiscard]] auto& getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+  [[nodiscard]] auto& getPriorFullCovarianceMatrix() const { return _priorFullCovarianceMatrix_; }
   [[nodiscard]] auto& getInverseCovarianceMatrix() const{ return _inverseCovarianceMatrix_; }
 
   /// Get the vector of parameters for this parameter set in the real


### PR DESCRIPTION
The SimpleMcmc was not handling the new way of using covariances correctly.  It now uses
the full parameter set covariance so that it can refer to the raw parameter inside the set, independent of whether the parameters are free, fixed, or otherwise manipulated.  This works because TSimpleMCMC is effectively stripping the covariance as part of the proposal.  