### PR TITLE
Feature/cyclic parameters

### DIFF
--- a/resources/examples/mcmc/gundamPlotMCMC.C
+++ b/resources/examples/mcmc/gundamPlotMCMC.C
@@ -796,13 +796,13 @@ void gundamPlotMCMC() {
                               << std::endl;
                     continue;
                 }
-                if (std::isfinite(ess[iPar])) {
+                if (not std::isfinite(ess[iPar])) {
                     std::cout << "Parameter " << iPar
                               << " ESS is not finite:" << ess[iPar]
                               << std::endl;
                     continue;
                 }
-                if (ess[iPar] < 0.0) {
+                if (ess[iPar] <= 0.0) {
                     std::cout << "Parameter " << iPar
                               << " ESS is invalid: " << ess[iPar]
                               << std::endl;

--- a/resources/examples/mcmc/gundamPlotMCMC.C
+++ b/resources/examples/mcmc/gundamPlotMCMC.C
@@ -677,7 +677,10 @@ void gundamPlotMCMC() {
     for (std::size_t iAcc = 0; iAcc < posteriorParamPlots.size(); ++iAcc) {
         // Skip parameters that will not be in the summary plots.  These are
         // parameters that were fixed and have a zero autocorrelation.
-        if (!gPosteriorAutocorrelation[iAcc]) continue;
+        if (!gPosteriorAutocorrelation[iAcc]) {
+            std::cout << "Skip plot: " << iAcc << std::endl;
+            continue;
+        }
         for (int k = 1;
              k<=gPosteriorAutocorrelation[iAcc]->GetNbinsX(); ++k) {
             double a = gPosteriorAutocorrelation[iAcc]->GetBinContent(k);
@@ -715,7 +718,7 @@ void gundamPlotMCMC() {
         int b = gPosteriorAutocorrelationAvg->GetBin(x);
         double e = gPosteriorAutocorrelationAvg->GetBinError(x);
         double s = std::abs(r/e)/std::sqrt(2.0);
-        effectiveSampleSize += std::erf(s)*r;
+        effectiveSampleSize += std::erf(s)*std::abs(r);
     }
     effectiveSampleSize = steps/(1.0 + 2.0*std::abs(effectiveSampleSize));
     eventWeight = effectiveSampleSize/steps;
@@ -732,7 +735,7 @@ void gundamPlotMCMC() {
             int b = gPosteriorAutocorrelation[iPar]->GetBin(x);
             double e = gPosteriorAutocorrelation[iPar]->GetBinError(x);
             double s = std::abs(r/e)/std::sqrt(2.0);
-            ess.back() += std::erf(s)*r;
+            ess.back() += std::erf(s)*std::abs(r);
         }
         ess.back() = steps/(1.0 + 2.0*ess.back());
     }
@@ -789,9 +792,22 @@ void gundamPlotMCMC() {
             for (std::size_t iPar = 0; iPar < points->size(); ++iPar) {
                 double content = points->at(iPar);
                 if (!posteriorParamPlots[iPar]) {
+                    std::cout << "Missing parameter " << iPar
+                              << std::endl;
                     continue;
                 }
-                if (ess[iPar] < 0.1) continue;
+                if (std::isfinite(ess[iPar])) {
+                    std::cout << "Parameter " << iPar
+                              << " ESS is not finite:" << ess[iPar]
+                              << std::endl;
+                    continue;
+                }
+                if (ess[iPar] < 0.0) {
+                    std::cout << "Parameter " << iPar
+                              << " ESS is invalid: " << ess[iPar]
+                              << std::endl;
+                    continue;
+                }
                 double w = ess[iPar]/steps;
                 posteriorParamPlots[iPar]->Fill(content,w);
             }

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -1,7 +1,3 @@
-//
-// Created by Clark McGrew on 26/01/2023.
-//
-
 #include "SimpleMcmc.h"
 #include "LikelihoodInterface.h"
 #include "FitterEngine.h"
@@ -391,7 +387,7 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
   mcmc.GetProposeStep().ResetCorrelations();
 
   // Set up the correlations in the priors.
-  int count1 = 0;
+  int count1 = 0;             // The index in the parameter array
   for (const Parameter* par1 : getMinimizerFitParameterPtr() ) {
     ++count1;
     const ParameterSet* set1 = par1->getOwner();
@@ -401,11 +397,12 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
               << std::endl;
       continue;
     }
+
     if ( set1->isEnableEigenDecomp()) {
       continue;
     }
 
-    int count2 = 0;
+    int count2 = 0;             // The index in the parameter array
     for (const Parameter* par2 : getMinimizerFitParameterPtr()) {
       ++count2;
       const ParameterSet* set2 = par2->getOwner();
@@ -415,32 +412,47 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
                 << std::endl;
         continue;
       }
+
       if ( set2->isEnableEigenDecomp()) {
         continue;
       }
 
+      // Parameters have to be in the same set to have a prior correlation.
+      // If they are in different sets, then, by definition, they are not
+      // correlated.
       if (set1 != set2) continue;
+
+      // Only use the "lower half" to get the correlations.
       int in1 = par1->getParameterIndex();
       int in2 = par2->getParameterIndex();
       if (in2 <= in1) continue;
+
       const std::shared_ptr<TMatrixDSym>& corr
-          = GenericToolbox::toCorrelationMatrix(set1->getPriorCovarianceMatrix());
+          = GenericToolbox::toCorrelationMatrix(set1->getPriorFullCovarianceMatrix());
       if (!corr) continue;
+
       double correlation = (*corr)(in1,in2);
+      if (not std::isfinite(correlation)) {
+        LogError << "Invalid correlation" << std::endl;
+        corr->Print();
+        LogExit("Bad correlation");
+      }
       // Don't impose very small correlations, let them be discovered.
       if (std::abs(correlation) < 0.01) continue;
       // Complain about large correlations.  When a correlation is this
       // large, then the user should (but probably won't) rethink the
       // parameter definitions!
       if (std::abs(correlation) > 0.98) {
-        LogInfo << "VERY LARGE CORRELATION (" << correlation
-                << ") BETWEEN"
-                << " " << set1->getName() << "/" << par1->getName()
-                << " & " << set2->getName() << "/" << par2->getName()
-                << std::endl;
+        LogWarning << "Very large prior correlation (" << correlation
+                   << ") between"
+                   << " " << set1->getName() << "/" << par1->getName()
+                   << " & " << set2->getName() << "/" << par2->getName()
+                   << std::endl
+                   << "Consider using eigendecomposition for parameter set: "
+                   << set1->getName()
+                   << std::endl;
       }
-      mcmc.GetProposeStep().SetCorrelation(count1-1,count2-1,
-                                           (*corr)(in1,in2));
+      mcmc.GetProposeStep().SetCorrelation(count1-1,count2-1,correlation);
     }
   }
 

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -382,6 +382,19 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
       double step = par->getStdDevValue();
       mcmc.GetProposeStep().SetGaussian(count0-1,step);
     }
+    if (par->isCyclic()) {
+      double min = par->getCyclicRange().min;
+      double max = par->getCyclicRange().max;
+      LogInfo << "Cyclic parameter " << par->getFullTitle()
+              << " range regularizes to "
+              << " [" << min << ", " << max << "]"
+              << std::endl;
+      if (useNormalizedFitSpace()) {
+        min = ParameterSet::toNormalizedParValue(min, *par);
+        max = ParameterSet::toNormalizedParValue(max, *par);
+      }
+      mcmc.GetProposeStep().SetCyclic(count0-1,min,max);
+    }
   }
 
   mcmc.GetProposeStep().ResetCorrelations();
@@ -547,6 +560,20 @@ bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
         }
 #endif
         mcmc.GetProposeStep().SetGaussian(count1-1,step);
+        if (par1->isCyclic()) {
+          double min = par1->getCyclicRange().min;
+          double max = par1->getCyclicRange().max;
+          LogInfo << "Cyclic parameter " << par1->getFullTitle()
+                  << " range regularizes to "
+                  << " [" << min << ", " << max << "]"
+                  << std::endl;
+          if (useNormalizedFitSpace()) {
+            min = ParameterSet::toNormalizedParValue(min, *par1);
+            max = ParameterSet::toNormalizedParValue(max, *par1);
+          }
+          mcmc.GetProposeStep().SetCyclic(count1-1,min,max);
+        }
+
         continue;
       }
       double corr = proposalCov->GetBinContent(count1,count2)/sig1/sig2;

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -433,8 +433,8 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
 
       double correlation = (*corr)(in1,in2);
       if (not std::isfinite(correlation)) {
-        LogError << "Invalid correlation" << std::endl;
-        corr->Print();
+        LogError << "Invalid correlation for set " << set1->getName()
+                 << std::endl;
         LogExit("Bad correlation");
       }
       // Don't impose very small correlations, let them be discovered.
@@ -460,6 +460,10 @@ bool SimpleMcmc::adaptiveDefaultProposalCovariance( AdaptiveStepMCMC& mcmc,
 
   return true;
 }
+
+// Load the proposal covariance from an input file.  The input
+// file will usually contain the result of a MLL fit, and we load
+// the covariance calculated by HESSE.
 bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
                                                    sMCMC::Vector& prior,
                                                    const std::string& fileName,
@@ -509,7 +513,7 @@ bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
              << std::endl;
     LogError << "   Proposal Y Bins:     " << proposalCov->GetNbinsY()
              << std::endl;
-    LogThrow("Mismatched proposal covariance matrix");
+    LogExit("Mismatched proposal covariance matrix");
   }
 
   // Dump all of the previous correlations.
@@ -525,7 +529,7 @@ bool SimpleMcmc::adaptiveLoadProposalCovariance( AdaptiveStepMCMC& mcmc,
       LogError << "Mismatch of parameter and covariance names" << std::endl;
       LogError << "Parameter:  " << parName << std::endl;
       LogError << "Covariance: " << covName << std::endl;
-      LogThrow("Mismatched covariance histogram");
+      LogExit("Mismatched covariance histogram");
     }
     double sig1 = std::sqrt(proposalCov->GetBinContent(count1,count1));
     int count2 = 0;

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -72,6 +72,16 @@ public:
   /// while the input parameter value can continue outside of the bounds.
   void setMaxMirror(double maxMirror);
 
+  /// Record the minimum boundary for a cyclic parameter.  This is mostly
+  /// for documentation purposes, but the fitter might use it (e.g. the
+  /// MCMC) during the fit.
+  void setMinCyclic(double minCyclic);
+
+  /// Record the minimum boundary for a cyclic parameter.  This is mostly
+  /// for documentation purposes, but the fitter might use it (e.g. the
+  /// MCMC) during the fit.
+  void setMaxCyclic(double maxCyclic);
+
   /// Set the parameter value.  This always checks the parameter validity, but
   /// if force is true, then it will only print warnings, otherwise it stops
   /// with EXIT_FAILURE.
@@ -83,6 +93,7 @@ public:
   [[nodiscard]] auto isEigen() const{ return _isEigen_; }
   [[nodiscard]] auto isEnabled() const{ return _isEnabled_; }
   [[nodiscard]] auto isThrown() const{ return _isThrown_ and _isEnabled_ and not _isFixed_; }
+  [[nodiscard]] bool isCyclic() const;
   [[nodiscard]] auto gotUpdated() const { return _gotUpdated_; }
   [[nodiscard]] auto getParameterIndex() const{ return _parameterIndex_; }
   [[nodiscard]] auto getStepSize() const{ return _stepSize_; }
@@ -93,6 +104,7 @@ public:
   [[nodiscard]] auto getPriorType() const{ return _priorType_; }
   [[nodiscard]] auto& getParameterLimits() const{ return _parameterLimits_; }
   [[nodiscard]] auto& getMirrorRange() const{ return _mirrorRange_; }
+  [[nodiscard]] auto& getCyclicRange() const{ return _cyclicRange_; }
   [[nodiscard]] auto& getThrowLimits() const{ return _throwLimits_; }
   [[nodiscard]] auto& getPhysicalLimits() const{ return _physicalLimits_; }
   [[nodiscard]] auto& getName() const{ return _name_; }
@@ -100,6 +112,9 @@ public:
 
   [[nodiscard]] double getParameterValue() const;
 
+  /// The value of the parameter after applying any mirroring, and cyclic
+  /// corrections.
+  [[nodiscard]] double getRegularizedValue() const;
 
   /// Query if a value is in the domain of likelihood for this parameter.  Math
   /// remediation for those of us (including myself) who don't recall grammar
@@ -180,6 +195,7 @@ private:
   GenericToolbox::Range _throwLimits_;
   GenericToolbox::Range _physicalLimits_;
   GenericToolbox::Range _mirrorRange_;
+  GenericToolbox::Range _cyclicRange_;
 
   double _stepSize_{std::nan("unset")};
   std::string _name_{};

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -84,6 +84,7 @@ public:
   [[nodiscard]] auto& getDialSetDefinitions() const{ return _dialSetDefinitions_; }
   [[nodiscard]] auto& getCustomParThrow() const{ return _customParThrow_; }
   [[nodiscard]] auto& getPriorCovarianceMatrix() const { return _priorCovarianceMatrix_; }
+  [[nodiscard]] auto& getPriorFullCovarianceMatrix() const { return _priorFullCovarianceMatrix_; }
   [[nodiscard]] auto& getInverseCovarianceMatrix() const{ return _inverseCovarianceMatrix_; }
 
   /// Get the vector of parameters for this parameter set in the real

--- a/src/Utils/include/TSimpleMCMC.H
+++ b/src/Utils/include/TSimpleMCMC.H
@@ -672,7 +672,9 @@ public:
             if (fForcedStep.size() != proposal.size()) {
                 throw std::logic_error("Proposal and forced length mismatch");
             }
-            std::copy(fForcedStep.begin(), fForcedStep.end(), proposal.begin());
+            for (int i = 0; i<proposal.size(); ++i) {
+                proposal[i] = fProposalType[i].Regularize(fForcedStep[i]);
+            }
             fForcedStep.clear();
             return;
         }
@@ -690,6 +692,7 @@ public:
                 // Make a uniform proposal.
                 proposal[scan] = gRandom->Uniform(fProposalType[scan].param1,
                                                   fProposalType[scan].param2);
+                proposal[scan] = fProposalType[scan].Regularize(proposal[scan]);
                 return;
             }
             // Make a Gaussian proposal around the initial value.
@@ -698,7 +701,7 @@ public:
                 sigma = std::sqrt(fProposalType[scan].param1);
             }
             double r = gRandom->Gaus(fCentralPoint[scan],sigma);
-            proposal[scan] = r;
+            proposal[scan] = fProposalType[scan].Regularize(r);
             MCMC_DEBUG(0) << "propose " << r << " for " << scan << std::endl;
             return;
         }
@@ -721,6 +724,11 @@ public:
                 if (fProposalType[j].type == 1) continue;
                 proposal[j] += fSigma*r*fDecomposition(i,j);
             }
+        }
+
+        // Make sure the proposal is regularized
+        for (std::size_t i = 0; i < proposal.size(); ++i) {
+            proposal[i] = fProposalType[i].Regularize(proposal[i]);
         }
     }
 
@@ -864,6 +872,26 @@ public:
                       << std::endl;
         fProposalType[dim].type = 0;
         fProposalType[dim].param1 = sigma*sigma;
+    }
+
+    /// Set the domain for a cyclic parameter.  When this is used, the
+    /// parameter step will be limited to be between `lower <= value < upper`,
+    /// and the cyclic domain can be removed if upper and lower are equal.
+    /// When a cyclic domain is set, parameter value will be regularized after
+    /// each step, and the difference between two parameters is assumes a
+    /// periodic domain (this limits the maximum difference to range/2).
+    void SetCyclic(int dim, double lower, double upper) {
+        if (dim < 0 || (std::size_t) dim >= fProposalType.size()) {
+            MCMC_ERROR << "Dimension " << dim << " is out of range."
+                       << std::endl;
+            return;
+        }
+        MCMC_DEBUG(1) << "Cyclic domain for dimension " << dim
+                      << " is " << std::min(lower,upper)
+                      << " to " << std::max(lower,upper)
+                      << std::endl;
+        fProposalType[dim].lower = std::min(lower,upper);
+        fProposalType[dim].range = std::abs(upper-lower);
     }
 
     /// Reset the correlations (removes all prior correlations).  This should
@@ -1778,11 +1806,10 @@ private:
         // Update the estimate of the central value.  This is simply a running
         // average of the position of the points in the posterior.
         for (std::size_t i=0; i< current.size(); ++i) {
-            fCentralPointChange[i] = fCentralPoint[i];
-            fCentralPoint[i] *= fCentralPointTrials;
-            fCentralPoint[i] += current[i];
-            fCentralPoint[i] /= fCentralPointTrials + 1;
-            fCentralPointChange[i] = fCentralPoint[i] - fCentralPointChange[i];
+            double d = fProposalType[i].Difference(current[i],fCentralPoint[i]);
+            fCentralPointChange[i] = d/(fCentralPointTrials+1);
+            fCentralPoint[i] += fCentralPointChange[i];
+            fCentralPoint[i] = fProposalType[i].Regularize(fCentralPoint[i]);
         }
         fCentralPointTrials = std::min(fCovarianceWindow,
                                        fCentralPointTrials+1.0);
@@ -1804,8 +1831,11 @@ private:
                     v -= fCentralPointChange[i]*fCentralPointChange[j];
 #endif
                     // Calculate the "covariance" of the new point.
-                    double r = (current[i]-fCentralPoint[i])
-                        *(current[j]-fCentralPoint[j]);
+                    double r
+                        = (fProposalType[i].Difference(current[i],
+                                                      fCentralPoint[i])
+                           *fProposalType[i].Difference(current[j],
+                                                        fCentralPoint[j]));
                     // Update the running average of the covariance.
                     v *= fCovarianceTrials;
                     v += r;
@@ -1894,10 +1924,25 @@ private:
 
     // Record the type of proposal to use for each dimension
     struct ProposalType {
-        ProposalType(): type(0), param1(0), param2(0) {}
+        ProposalType(): type(0), param1(0), param2(0), lower(0), range(-1) {}
         int type;      // 0 for Gaussian, 1 for Uniform.
         double param1; // Sigma for Gaussian, Minimum for Uniform
         double param2; // Not used for Gaussian, Maximum for Uniform
+        double lower;  // The lower end  of a cyclic parameter range
+        double range;  // The total range of a cyclic parameter
+        double Regularize(double v) {
+            if (range < std::numeric_limits<float>::epsilon()) return v;
+            while (v < lower) v += range; // Brute force, but clear
+            while (v >= lower+range) v -= range;
+            return v;
+        }
+        double Difference(double u, double v) {
+            u = Regularize(u) - Regularize(v);
+            if (range <  std::numeric_limits<float>::epsilon()) return u;
+            while (u > 0.5*range) u -= range; // Brute force, but clear
+            while (u <= -0.5*range) u += range;
+            return u;
+        }
     };
 
     // The type of distribution to draw the proposal for a dimension from.
@@ -1978,7 +2023,7 @@ private:
 
 // MIT License
 
-// Copyright (c) 2017-2022 Clark McGrew
+// Copyright (c) 2017-2025 Clark McGrew
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Handle cyclic parameters.  This is contingent on #868.

Adds `cyclicRange` to the Parameter yaml which lets the user set a range for a cyclic parameter.  For minimization this is a NOP since it would break the continuity requirements, but is used by the MCMC to manage the proposed steps.   A good example of using a cyclic parameter is the PMNS_DELTA_CP used in neutrino oscillations.  This can be limited between -3.14 and 3.14 using

```yaml
cyclicRange: [-3.14, 3.14]
```
This won't change the way RootMinimizer handles the parameter, but does tell the SimpleMcmc to treat it as a cyclic parameter.  In other words, `-3.12 - 0.4` is `3.12`, and the difference between `-3.12 - 3.12` is `0.4`.